### PR TITLE
[FIX] Sidebar Projects section scroll issue

### DIFF
--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -358,6 +358,8 @@ export function Sidebar() {
             </button>
           </div>
 
+          {/* Scrollable area: primary nav, workspace, favorites, projects */}
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           {/* 3. Primary nav: Home, Inbox, Your work */}
           <div className="flex flex-col gap-0.5 px-2 py-2">
             <NavLink
@@ -549,7 +551,7 @@ export function Sidebar() {
           </div>
 
           {/* 7. Projects section (collapsible) */}
-          <div className="flex-1 overflow-y-auto flex flex-col min-h-0">
+          <div className="flex flex-col flex-1 min-h-0">
             <div className="flex flex-col gap-0.5 px-2 pt-2 pb-1">
               <button
                 type="button"
@@ -614,6 +616,8 @@ export function Sidebar() {
               })}
             </div>
             )}
+          </div>
+
           </div>
 
           {/* 8. Footer: Community + Help + Settings */}


### PR DESCRIPTION
This pull request makes layout improvements to the `Sidebar` component, specifically to enhance scrolling behavior and structure. The main change is to ensure that the main navigation, workspace, favorites, and projects sections are all contained within a single scrollable area, providing a better user experience.

Layout and scrolling improvements:

* Wrapped the primary navigation, workspace, favorites, and projects sections in a single scrollable `div` to ensure these sections scroll together, improving usability and layout consistency. [[1]](diffhunk://#diff-669d16bb6beef8d1df0b0496917e06eaf9b4f639ef67b353cd8f6b63a3a20226R361-R362) [[2]](diffhunk://#diff-669d16bb6beef8d1df0b0496917e06eaf9b4f639ef67b353cd8f6b63a3a20226R621-R622)
* Adjusted the projects section to remove redundant scrolling behavior, relying on the new parent scrollable container instead.

Closes #7 