### PR TITLE
[FEAT] implement email service send emails for workspace invitations

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
       - name: Build
         run: go build -v ./cmd/api/...
 

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -1,0 +1,38 @@
+name: UI CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ui/**'
+      - '.github/workflows/ui-ci.yml'
+
+defaults:
+  run:
+    working-directory: ui
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Build
+        run: npm run build

--- a/api/.env.example
+++ b/api/.env.example
@@ -20,6 +20,9 @@ REDIS_DB=0
 # RabbitMQ
 RABBITMQ_URL=amqp://guest:guest@localhost:5672/
 
+# Frontend URL for invite links in emails (e.g. https://app.example.com). If unset, CORS_ORIGIN is used.
+APP_BASE_URL=https://app.example.com
+
 # MinIO (S3-compatible)
 MINIO_ENDPOINT=localhost:9000
 MINIO_ACCESS_KEY_ID=minioadmin

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/Devlaner/devlane/api/internal/config"
 	"github.com/Devlaner/devlane/api/internal/database"
+	"github.com/Devlaner/devlane/api/internal/mail"
 	"github.com/Devlaner/devlane/api/internal/minio"
 	"github.com/Devlaner/devlane/api/internal/queue"
 	"github.com/Devlaner/devlane/api/internal/rabbitmq"
 	"github.com/Devlaner/devlane/api/internal/redis"
 	"github.com/Devlaner/devlane/api/internal/router"
+	"github.com/Devlaner/devlane/api/internal/store"
 )
 
 func main() {
@@ -93,7 +95,9 @@ func main() {
 		if chConsume, err := rmq.NewChannel(); err == nil {
 			defer chConsume.Close()
 			consumer := queue.NewConsumer(chConsume, log)
-			consumer.Register(queue.QueueEmails, queue.HandleSendEmail(queue.NoopEmailSender(log)))
+			instanceSettingStore := store.NewInstanceSettingStore(db)
+			emailSender := mail.NewSMTPEmailSender(instanceSettingStore, log)
+			consumer.Register(queue.QueueEmails, queue.HandleSendEmail(log, emailSender))
 			consumer.Register(queue.QueueWebhooks, queue.HandleWebhook(queue.NoopWebhookDeliverer(log)))
 			if err := consumer.Run(consumerCtx, []string{queue.QueueEmails, queue.QueueWebhooks}); err != nil {
 				log.Warn("queue consumer", "error", err)

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	MigrationsPath string
 
 	CORSAllowOrigin string
+	// AppBaseURL is the public URL of the frontend (e.g. https://app.example.com). Used for invite links in emails. If empty, CORSAllowOrigin is used.
+	AppBaseURL string
 }
 
 func (c *Config) DSN() string {
@@ -84,6 +86,7 @@ func Load() (*Config, error) {
 		MinIOUseSSL:          minioSSL,
 		MigrationsPath:       getEnv("MIGRATIONS_PATH", "migrations"),
 		CORSAllowOrigin:      getEnv("CORS_ORIGIN", "http://localhost:5173"),
+		AppBaseURL:           getEnv("APP_BASE_URL", ""),
 	}
 
 	return cfg, nil

--- a/api/internal/handler/invitation.go
+++ b/api/internal/handler/invitation.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Devlaner/devlane/api/internal/store"
+	"github.com/gin-gonic/gin"
+)
+
+// InvitationHandler serves public invite-by-token endpoints (no auth).
+type InvitationHandler struct {
+	Winv *store.WorkspaceInviteStore
+	Ws   *store.WorkspaceStore
+}
+
+// GetInviteByToken returns workspace invite details by token for the invite landing page.
+// GET /api/invitations/by-token/?token=...
+func (h *InvitationHandler) GetInviteByToken(c *gin.Context) {
+	token := strings.TrimSpace(c.Query("token"))
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "token required"})
+		return
+	}
+	inv, err := h.Winv.GetByToken(c.Request.Context(), token)
+	if err != nil || inv == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Invite not found or expired"})
+		return
+	}
+	w, err := h.Ws.GetByID(c.Request.Context(), inv.WorkspaceID)
+	if err != nil || w == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Workspace not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"workspace_name": w.Name,
+		"workspace_slug": w.Slug,
+		"email":          inv.Email,
+		"invitation_id":  inv.ID.String(),
+	})
+}
+
+// DeclineInviteByToken removes the invitation (Ignore flow). No auth required.
+// POST /api/invitations/decline/ body: { "token": "..." }
+func (h *InvitationHandler) DeclineInviteByToken(c *gin.Context) {
+	var body struct {
+		Token string `json:"token" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "token required"})
+		return
+	}
+	token := strings.TrimSpace(body.Token)
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "token required"})
+		return
+	}
+	inv, err := h.Winv.GetByToken(c.Request.Context(), token)
+	if err != nil || inv == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+	if err := h.Winv.Delete(c.Request.Context(), inv.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to decline invite"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/api/internal/handler/workspace.go
+++ b/api/internal/handler/workspace.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/queue"
 	"github.com/Devlaner/devlane/api/internal/service"
 	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/gin-gonic/gin"
@@ -13,8 +15,10 @@ import (
 
 // WorkspaceHandler serves workspace and member/invite endpoints.
 type WorkspaceHandler struct {
-	Workspace *service.WorkspaceService
-	Settings  *store.InstanceSettingStore
+	Workspace  *service.WorkspaceService
+	Settings   *store.InstanceSettingStore
+	Queue      *queue.Publisher // optional: enqueue invite emails
+	AppBaseURL string           // optional: base URL for invite links (e.g. https://app.example.com)
 }
 
 // List returns the current user's workspaces.
@@ -373,6 +377,27 @@ func (h *WorkspaceHandler) CreateInvite(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create invite"})
 		return
 	}
+
+	// Enqueue invite email when queue and base URL are configured
+	if h.Queue != nil && h.AppBaseURL != "" {
+		w, _ := h.Workspace.GetBySlug(c.Request.Context(), slug, user.ID)
+		workspaceName := slug
+		if w != nil {
+			workspaceName = w.Name
+		}
+		inviteLink := strings.TrimSuffix(h.AppBaseURL, "/") + "/invite?token=" + inv.Token
+		subject := fmt.Sprintf("You're invited to join %s on Devlane", workspaceName)
+		bodyText := fmt.Sprintf("You have been invited to join the workspace \"%s\" on Devlane.\n\nAccept your invitation by visiting:\n%s\n\nIf you don't have an account yet, you can sign up at the same link.\n", workspaceName, inviteLink)
+		_ = h.Queue.PublishSendEmail(c.Request.Context(), queue.SendEmailPayload{
+			To:        inv.Email,
+			Subject:   subject,
+			Body:      bodyText,
+			Kind:      "workspace_invite",
+			InviteURL: inviteLink,
+			Extra:     map[string]string{"workspace_slug": slug, "invite_id": inv.ID.String()},
+		})
+	}
+
 	c.JSON(http.StatusCreated, inv)
 }
 

--- a/api/internal/mail/logger.go
+++ b/api/internal/mail/logger.go
@@ -1,0 +1,48 @@
+package mail
+
+import "log/slog"
+
+// LogSendAttempt logs when an email send is about to be attempted.
+// inviteURL is optional (e.g. workspace invite link); empty string is omitted from logs.
+func LogSendAttempt(log *slog.Logger, to, subject, kind, inviteURL string) {
+	if log == nil {
+		return
+	}
+	attrs := []any{"to", to, "subject", subject, "kind", kind}
+	if inviteURL != "" {
+		attrs = append(attrs, "invite_url", inviteURL)
+	}
+	log.Info("mail send attempt", attrs...)
+}
+
+// LogSent logs successful email delivery.
+func LogSent(log *slog.Logger, to, subject, inviteURL string) {
+	if log == nil {
+		return
+	}
+	attrs := []any{"to", to, "subject", subject}
+	if inviteURL != "" {
+		attrs = append(attrs, "invite_url", inviteURL)
+	}
+	log.Info("mail sent", attrs...)
+}
+
+// LogFailed logs a failed email send with error and optional invite URL.
+func LogFailed(log *slog.Logger, to, subject, inviteURL string, err error) {
+	if log == nil {
+		return
+	}
+	attrs := []any{"to", to, "subject", subject, "error", err}
+	if inviteURL != "" {
+		attrs = append(attrs, "invite_url", inviteURL)
+	}
+	log.Error("mail send failed", attrs...)
+}
+
+// LogSkip logs when mail is skipped (e.g. not configured).
+func LogSkip(log *slog.Logger, reason, to string, err error) {
+	if log == nil {
+		return
+	}
+	log.Warn("mail skip", "reason", reason, "to", to, "error", err)
+}

--- a/api/internal/mail/mail.go
+++ b/api/internal/mail/mail.go
@@ -1,0 +1,100 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/smtp"
+	"strconv"
+	"strings"
+
+	"github.com/Devlaner/devlane/api/internal/crypto"
+	"github.com/Devlaner/devlane/api/internal/store"
+)
+
+type smtpSettings struct {
+	Host        string
+	Port        int
+	SenderEmail string
+	Security    string
+	Username    string
+	Password    string
+}
+
+func getEmailSettings(ctx context.Context, s *store.InstanceSettingStore) (*smtpSettings, error) {
+	row, err := s.Get(ctx, "email")
+	if err != nil || row == nil {
+		return nil, fmt.Errorf("email settings not found")
+	}
+	v := row.Value
+	if v == nil {
+		return nil, fmt.Errorf("email settings empty")
+	}
+	host, _ := v["host"].(string)
+	port := 587
+	if p, ok := v["port"].(string); ok && p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			port = n
+		}
+	}
+	if p, ok := v["port"].(float64); ok {
+		port = int(p)
+	}
+	sender, _ := v["sender_email"].(string)
+	security, _ := v["security"].(string)
+	username, _ := v["username"].(string)
+	passRaw, _ := v["password"].(string)
+	password := crypto.DecryptOrPlain(passRaw)
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil, fmt.Errorf("email host not configured")
+	}
+	return &smtpSettings{
+		Host:        host,
+		Port:        port,
+		SenderEmail: strings.TrimSpace(sender),
+		Security:    strings.TrimSpace(security),
+		Username:    strings.TrimSpace(username),
+		Password:    password,
+	}, nil
+}
+
+// NewSMTPEmailSender returns a sender that loads SMTP config from instance "email"
+// settings and sends mail. If not configured or send fails, logs and returns error.
+func NewSMTPEmailSender(instanceSettings *store.InstanceSettingStore, log *slog.Logger) func(ctx context.Context, to, subject, body string) error {
+	return func(ctx context.Context, to, subject, body string) error {
+		cfg, err := getEmailSettings(ctx, instanceSettings)
+		if err != nil {
+			LogSkip(log, "instance email not configured", to, err)
+			return err
+		}
+		from := cfg.SenderEmail
+		if from == "" {
+			from = cfg.Username
+		}
+		if from == "" {
+			LogSkip(log, "sender_email and username empty", to, fmt.Errorf("sender not set"))
+			return fmt.Errorf("sender email not configured")
+		}
+		addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+		msg := buildMessage(to, from, subject, body)
+		if err := smtp.SendMail(addr, auth, from, []string{to}, msg); err != nil {
+			LogFailed(log, to, subject, "", err)
+			return err
+		}
+		LogSent(log, to, subject, "")
+		return nil
+	}
+}
+
+func buildMessage(to, from, subject, body string) []byte {
+	const crlf = "\r\n"
+	h := "To: " + to + crlf +
+		"From: " + from + crlf +
+		"Subject: " + subject + crlf +
+		"Content-Type: text/plain; charset=UTF-8" + crlf +
+		"MIME-Version: 1.0" + crlf +
+		crlf
+	return []byte(h + body)
+}

--- a/api/internal/mail/mail.go
+++ b/api/internal/mail/mail.go
@@ -2,6 +2,7 @@ package mail
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net/smtp"
@@ -79,17 +80,64 @@ func NewSMTPEmailSender(instanceSettings *store.InstanceSettingStore, log *slog.
 		addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
 		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
 		msg := buildMessage(to, from, subject, body)
-		if err := smtp.SendMail(addr, auth, from, []string{to}, msg); err != nil {
-			LogFailed(log, to, subject, "", err)
+		if err := sendMailWithConfig(addr, cfg.Host, cfg.Port, cfg.Security, auth, from, to, msg); err != nil {
 			return err
 		}
-		LogSent(log, to, subject, "")
 		return nil
 	}
 }
 
+// sendMailWithConfig sends email using smtp.SendMail or, for port 465 with SSL,
+// an explicit TLS connection (smtp.SendMail only supports STARTTLS).
+func sendMailWithConfig(addr, host string, port int, security string, auth smtp.Auth, from, to string, msg []byte) error {
+	useImplicitTLS := port == 465 && strings.EqualFold(strings.TrimSpace(security), "SSL")
+	if useImplicitTLS {
+		conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: host})
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+		client, err := smtp.NewClient(conn, host)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+		if err := client.Auth(auth); err != nil {
+			return err
+		}
+		if err := client.Mail(from); err != nil {
+			return err
+		}
+		if err := client.Rcpt(to); err != nil {
+			return err
+		}
+		w, err := client.Data()
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(msg); err != nil {
+			_ = w.Close()
+			return err
+		}
+		if err := w.Close(); err != nil {
+			return err
+		}
+		return client.Quit()
+	}
+	// STARTTLS (port 587) or no security: standard SendMail
+	return smtp.SendMail(addr, auth, from, []string{to}, msg)
+}
+
+// sanitizeHeader removes CR/LF to prevent header injection.
+func sanitizeHeader(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
+}
+
 func buildMessage(to, from, subject, body string) []byte {
 	const crlf = "\r\n"
+	to = sanitizeHeader(to)
+	from = sanitizeHeader(from)
+	subject = sanitizeHeader(subject)
 	h := "To: " + to + crlf +
 		"From: " + from + crlf +
 		"Subject: " + subject + crlf +

--- a/api/internal/queue/consumer.go
+++ b/api/internal/queue/consumer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 
+	"github.com/Devlaner/devlane/api/internal/mail"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -78,8 +79,8 @@ func (c *Consumer) defaultHandler(ctx context.Context, queue string, body []byte
 
 // --- Handlers for email and webhook (can be extended with real SMTP/HTTP) ---
 
-// HandleSendEmail parses send_email task and runs the given sender.
-func HandleSendEmail(sender func(ctx context.Context, to, subject, body string) error) TaskHandler {
+// HandleSendEmail parses send_email task, logs attempt/result (including invite_url), and runs the given sender.
+func HandleSendEmail(log *slog.Logger, sender func(ctx context.Context, to, subject, body string) error) TaskHandler {
 	return func(ctx context.Context, queue string, body []byte) error {
 		var msg struct {
 			Type    string           `json:"type"`
@@ -91,7 +92,15 @@ func HandleSendEmail(sender func(ctx context.Context, to, subject, body string) 
 		if msg.Type != TaskSendEmail {
 			return nil
 		}
-		return sender(ctx, msg.Payload.To, msg.Payload.Subject, msg.Payload.Body)
+		p := &msg.Payload
+		mail.LogSendAttempt(log, p.To, p.Subject, p.Kind, p.InviteURL)
+		err := sender(ctx, p.To, p.Subject, p.Body)
+		if err != nil {
+			mail.LogFailed(log, p.To, p.Subject, p.InviteURL, err)
+			return err
+		}
+		mail.LogSent(log, p.To, p.Subject, p.InviteURL)
+		return nil
 	}
 }
 

--- a/api/internal/queue/queue.go
+++ b/api/internal/queue/queue.go
@@ -25,11 +25,12 @@ const (
 
 // SendEmailPayload is the payload for send_email task.
 type SendEmailPayload struct {
-	To      string            `json:"to"`
-	Subject string            `json:"subject"`
-	Body    string            `json:"body"`
-	Kind    string            `json:"kind"` // e.g. forgot_password, workspace_invite, project_invite
-	Extra   map[string]string `json:"extra,omitempty"`
+	To        string            `json:"to"`
+	Subject   string            `json:"subject"`
+	Body      string            `json:"body"`
+	Kind      string            `json:"kind"`                 // e.g. forgot_password, workspace_invite, project_invite
+	InviteURL string            `json:"invite_url,omitempty"` // optional; logged for debugging (e.g. workspace invite link)
+	Extra     map[string]string `json:"extra,omitempty"`
 }
 
 // WebhookPayload is the payload for webhook_deliver task.

--- a/api/internal/router/router.go
+++ b/api/internal/router/router.go
@@ -23,6 +23,7 @@ type Config struct {
 	Queue           *queue.Publisher // optional: enqueue emails, webhooks
 	Minio           *minio.Client    // optional: file uploads (cover images, avatars, logos)
 	CORSAllowOrigin string           // optional: e.g. "http://localhost:5173" for UI dev
+	AppBaseURL      string           // optional: base URL for invite links; if empty, CORSAllowOrigin is used
 }
 
 // New builds and returns the Gin engine with /api/ and /auth/ routes.
@@ -76,6 +77,10 @@ func New(cfg Config) *gin.Engine {
 	r.GET("/api/instance/setup-status/", instanceHandler.SetupStatus)
 	r.POST("/api/instance/setup/", instanceHandler.InstanceSetup)
 
+	invitationHandler := &handler.InvitationHandler{Winv: workspaceInviteStore, Ws: workspaceStore}
+	r.GET("/api/invitations/by-token/", invitationHandler.GetInviteByToken)
+	r.POST("/api/invitations/decline/", invitationHandler.DeclineInviteByToken)
+
 	instanceSettingsHandler := &handler.InstanceSettingsHandler{Settings: instanceSettingStore}
 
 	// Services
@@ -94,8 +99,19 @@ func New(cfg Config) *gin.Engine {
 	stickySvc := service.NewStickyService(stickyStore, workspaceStore)
 	recentVisitSvc := service.NewRecentVisitService(userRecentVisitStore, workspaceStore, issueStore, projectStore, pageStore)
 
+	// Base URL for invite links (e.g. email links to frontend)
+	appBaseURL := cfg.AppBaseURL
+	if appBaseURL == "" {
+		appBaseURL = cfg.CORSAllowOrigin
+	}
+
 	// Handlers
-	workspaceHandler := &handler.WorkspaceHandler{Workspace: workspaceSvc, Settings: instanceSettingStore}
+	workspaceHandler := &handler.WorkspaceHandler{
+		Workspace:  workspaceSvc,
+		Settings:   instanceSettingStore,
+		Queue:      cfg.Queue,
+		AppBaseURL: appBaseURL,
+	}
 	projectHandler := &handler.ProjectHandler{Project: projectSvc}
 	favoriteHandler := &handler.FavoriteHandler{Project: projectSvc, Favorites: userFavoriteStore}
 	stateHandler := &handler.StateHandler{State: stateSvc}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Devlane UI",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Devlane UI",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@tailwindcss/vite": "^4.1.18",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Devlane UI",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Devlane UI",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@tailwindcss/vite": "^4.1.18",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Devlane UI",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Devlane UI",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@tailwindcss/vite": "^4.1.18",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Devlane UI",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Devlane UI",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@tailwindcss/vite": "^4.1.18",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Devlane UI",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Devlane UI",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Devlane UI",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Devlane UI",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -15,6 +15,18 @@ export const apiClient = axios.create({
   },
 });
 
+// When sending FormData (e.g. file upload), omit Content-Type so the browser sets
+// multipart/form-data with the correct boundary. Otherwise the server gets
+// Content-Type: application/json and cannot parse the multipart form → 400.
+apiClient.interceptors.request.use((config) => {
+  if (config.data instanceof FormData) {
+    const headers = { ...config.headers };
+    delete (headers as Record<string, unknown>)["Content-Type"];
+    config.headers = headers;
+  }
+  return config;
+});
+
 /** Shape of API error response body (backend may return { error: string }) */
 export interface ApiErrorResponse {
   error?: string;

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -19,10 +19,9 @@ export const apiClient = axios.create({
 // multipart/form-data with the correct boundary. Otherwise the server gets
 // Content-Type: application/json and cannot parse the multipart form → 400.
 apiClient.interceptors.request.use((config) => {
-  if (config.data instanceof FormData) {
-    const headers = { ...config.headers };
-    delete (headers as Record<string, unknown>)["Content-Type"];
-    config.headers = headers;
+  if (config.data instanceof FormData && config.headers) {
+    const h = config.headers as Record<string, unknown>;
+    delete h["Content-Type"];
   }
   return config;
 });

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -45,6 +45,14 @@ export interface WorkspaceInviteApiResponse {
   updated_at?: string;
 }
 
+/** GET /api/invitations/by-token/?token=... (public) */
+export interface InviteByTokenResponse {
+  workspace_name: string;
+  workspace_slug: string;
+  email: string;
+  invitation_id: string;
+}
+
 /** Request body for POST /api/workspaces/:slug/projects/ */
 export interface CreateProjectRequest {
   name: string;

--- a/ui/src/components/ProjectIconModal.tsx
+++ b/ui/src/components/ProjectIconModal.tsx
@@ -175,9 +175,10 @@ export function ProjectIconModal({
   onClose,
   onSelect,
   title = "Project icon",
-  currentEmoji: _currentEmoji,
+  currentEmoji,
   currentIconProp,
 }: ProjectIconModalProps) {
+  void currentEmoji; // reserved for future use (e.g. pre-select emoji tab)
   const [tab, setTab] = useState<Tab>(TAB_EMOJI);
   const [emojiSearch, setEmojiSearch] = useState("");
   const [iconColor, setIconColor] = useState(
@@ -186,6 +187,8 @@ export function ProjectIconModal({
 
   useEffect(() => {
     if (open) {
+      // Intentional: sync form state when modal opens (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIconColor(currentIconProp?.color ?? "#6366f1");
       setEmojiSearch("");
     }

--- a/ui/src/components/SetupGate.tsx
+++ b/ui/src/components/SetupGate.tsx
@@ -22,6 +22,8 @@ export function SetupGate() {
 
   useEffect(() => {
     if (isSetupPath) {
+      // Intentional: clear setup flag on setup route (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSetupRequired(false);
       return;
     }

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -17,6 +17,8 @@ export function Header() {
 
   useEffect(() => {
     if (!workspaceSlug) {
+      // Intentional: clear workspace/project when slug unmounts (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setWorkspace(null);
       setProject(null);
       return;

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -987,7 +987,11 @@ function WorkspaceViewsHeader() {
   const [selectedViewId, setSelectedViewId] = useState("all");
 
   useEffect(() => {
-    if (!viewDropdownOpen) setViewSearch("");
+    if (!viewDropdownOpen) {
+      // Intentional: clear search when dropdown closes (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setViewSearch("");
+    }
   }, [viewDropdownOpen]);
 
   const selectedView =
@@ -1122,7 +1126,11 @@ function AnalyticsHeader({ workspaceSlug }: { workspaceSlug: string }) {
   );
 
   useEffect(() => {
-    if (!openDropdown) setProjectSearch("");
+    if (!openDropdown) {
+      // Intentional: clear search when dropdown closes (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setProjectSearch("");
+    }
   }, [openDropdown]);
 
   return (
@@ -1194,15 +1202,17 @@ export function PageHeader() {
     workspaceSlug?: string;
     projectId?: string;
   }>();
-  const [_workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(
-    null,
-  );
-  const [_projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
+  const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  void workspace;
+  void projects; // reserved for future use (e.g. breadcrumb, project list)
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [projectIssueCount, setProjectIssueCount] = useState(0);
 
   useEffect(() => {
     if (!workspaceSlug) {
+      // Intentional: clear when route unmounts (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setWorkspace(null);
       setProjects([]);
       setProject(null);
@@ -1230,6 +1240,8 @@ export function PageHeader() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // Intentional: clear when route unmounts (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setProject(null);
       setProjectIssueCount(0);
       return;

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -485,6 +485,8 @@ export function Sidebar() {
   const slugForProjects = workspaceSlug ?? workspace?.slug;
   useEffect(() => {
     if (!slugForProjects) {
+      // Intentional: clear projects when workspace unmounts (kept for future use)
+
       setProjects([]);
       return;
     }
@@ -515,6 +517,7 @@ export function Sidebar() {
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount; setFavoriteProjectIds is stable
   }, []);
 
   useEffect(() => {
@@ -527,6 +530,8 @@ export function Sidebar() {
       path === `${baseUrl}/archives` ||
       path.startsWith(`${baseUrl}/analytics`)
     ) {
+      // Intentional: expand section when on relevant route (kept for future use)
+
       setWorkspaceSectionExpanded(true);
     }
     if (projectId && path.startsWith(`${baseUrl}/projects/`)) {
@@ -536,6 +541,8 @@ export function Sidebar() {
 
   useEffect(() => {
     if (!workspaceDropdownOpen) {
+      // Intentional: clear position when dropdown closes (kept for future use)
+
       setDropdownPosition(null);
       return;
     }

--- a/ui/src/components/ui/Card.tsx
+++ b/ui/src/components/ui/Card.tsx
@@ -27,7 +27,8 @@ export function Card({
   );
 }
 
-export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {}
+/** Props for card header; extends div attributes. Kept as type for future props. */
+export type CardHeaderProps = HTMLAttributes<HTMLDivElement>;
 
 export function CardHeader({ className, children, ...props }: CardHeaderProps) {
   return (
@@ -43,7 +44,8 @@ export function CardHeader({ className, children, ...props }: CardHeaderProps) {
   );
 }
 
-export interface CardContentProps extends HTMLAttributes<HTMLDivElement> {}
+/** Props for card content; extends div attributes. Kept as type for future props. */
+export type CardContentProps = HTMLAttributes<HTMLDivElement>;
 
 export function CardContent({
   className,

--- a/ui/src/components/work-item/DatePickerTrigger.tsx
+++ b/ui/src/components/work-item/DatePickerTrigger.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 
+/* eslint-disable react-refresh/only-export-components -- formatDateForDisplay shared util; keep in same file for future use */
 export function formatDateForDisplay(isoDate: string): string {
   if (!isoDate) return "";
   const [y, m, d] = isoDate.split("-");
@@ -24,7 +25,7 @@ export function DatePickerTrigger({
   value,
   onChange,
   placeholder,
-  compact: _compact = true,
+  compact: _compact = true, // eslint-disable-line @typescript-eslint/no-unused-vars -- kept for future compact layout
 }: DatePickerTriggerProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const displayValue = value ? formatDateForDisplay(value) : "";

--- a/ui/src/components/work-item/Dropdown.tsx
+++ b/ui/src/components/work-item/Dropdown.tsx
@@ -40,6 +40,8 @@ export function Dropdown({
 
   useLayoutEffect(() => {
     if (!open || !triggerRef.current) {
+      // Intentional: clear position when dropdown closes (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPosition(null);
       return;
     }

--- a/ui/src/components/work-item/SelectParentModal.tsx
+++ b/ui/src/components/work-item/SelectParentModal.tsx
@@ -27,13 +27,18 @@ export function SelectParentModal({
   open,
   onClose,
   issues,
-  value: _value,
+  value,
   onChange,
 }: SelectParentModalProps) {
+  void value; // reserved for future use (e.g. pre-select current parent)
   const [search, setSearch] = useState("");
 
   useEffect(() => {
-    if (!open) setSearch("");
+    if (!open) {
+      // Intentional: clear search when modal closes (kept for future use)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSearch("");
+    }
   }, [open]);
 
   const q = (s: string) => s.toLowerCase().trim();

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components -- context file exports AuthProvider + useAuth; keep for future use */
 import {
   createContext,
   useCallback,

--- a/ui/src/contexts/FavoritesContext.tsx
+++ b/ui/src/contexts/FavoritesContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components -- context file exports FavoritesProvider + useFavorites; keep for future use */
 import { createContext, useContext, useState, type ReactNode } from "react";
 
 interface FavoritesContextValue {

--- a/ui/src/contexts/ThemeContext.tsx
+++ b/ui/src/contexts/ThemeContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components -- context file exports ThemeProvider + useTheme; keep for future use */
 import {
   createContext,
   useCallback,

--- a/ui/src/pages/AnalyticsOverviewPage.tsx
+++ b/ui/src/pages/AnalyticsOverviewPage.tsx
@@ -28,6 +28,7 @@ export function AnalyticsOverviewPage() {
 
   useEffect(() => {
     if (!workspaceSlug) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug (kept for future use)
       setLoading(false);
       return;
     }

--- a/ui/src/pages/AnalyticsWorkItemsPage.tsx
+++ b/ui/src/pages/AnalyticsWorkItemsPage.tsx
@@ -104,6 +104,7 @@ export function AnalyticsWorkItemsPage() {
 
   useEffect(() => {
     if (!workspaceSlug) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug (kept for future use)
       setLoading(false);
       return;
     }

--- a/ui/src/pages/BoardPage.tsx
+++ b/ui/src/pages/BoardPage.tsx
@@ -37,6 +37,7 @@ export function BoardPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }

--- a/ui/src/pages/CyclesPage.tsx
+++ b/ui/src/pages/CyclesPage.tsx
@@ -152,6 +152,7 @@ export function CyclesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }
@@ -195,8 +196,11 @@ export function CyclesPage() {
   const getIssueCount = (cycleId: string) =>
     cycles.find((c) => c.id === cycleId)?.issue_count ?? 0;
   const getUser = (
-    _userId: string | null,
-  ): { name: string; avatarUrl?: string | null } | null => null;
+    userId: string | null,
+  ): { name: string; avatarUrl?: string | null } | null => {
+    void userId; // reserved for future assignee display
+    return null;
+  };
 
   if (loading) {
     return (

--- a/ui/src/pages/InviteAcceptPage.tsx
+++ b/ui/src/pages/InviteAcceptPage.tsx
@@ -144,6 +144,7 @@ export function InviteAcceptPage() {
       return;
     autoAcceptDone.current = true;
     doJoinWorkspace();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- doJoinWorkspace is stable; run when user+invite+token available
   }, [user, invite, token, step]);
 
   const handleAccept = () => {

--- a/ui/src/pages/InviteAcceptPage.tsx
+++ b/ui/src/pages/InviteAcceptPage.tsx
@@ -1,0 +1,372 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Card, CardContent, Button } from "../components/ui";
+import { useAuth } from "../contexts/AuthContext";
+import { invitationService } from "../services/invitationService";
+import { workspaceService } from "../services/workspaceService";
+
+const IconCheck = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+);
+
+const IconX = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+const IconChevronRight = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="m9 18 6-6-6-6" />
+  </svg>
+);
+
+const IconGlobe = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+    className="shrink-0 text-[var(--txt-icon-secondary)]"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    <path d="M2 12h20" />
+  </svg>
+);
+
+const IconClear = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+export function InviteAcceptPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { user, isLoading: authLoading } = useAuth();
+  const token = searchParams.get("token") ?? "";
+
+  const [invite, setInvite] = useState<{
+    workspace_name: string;
+    workspace_slug: string;
+    email: string;
+    invitation_id: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+  const [ignoring, setIgnoring] = useState(false);
+  const [step, setStep] = useState<"invite" | "join">("invite");
+  const [joinEmail, setJoinEmail] = useState("");
+
+  useEffect(() => {
+    if (!token.trim()) {
+      navigate("/", { replace: true });
+      return;
+    }
+    let cancelled = false;
+    invitationService
+      .getByToken(token)
+      .then((data) => {
+        if (!cancelled) setInvite(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Invite not found or expired.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, navigate]);
+
+  // When user returns from login (already authenticated), auto-accept and go to workspace
+  useEffect(() => {
+    if (
+      !user ||
+      !invite ||
+      !token ||
+      step !== "invite" ||
+      autoAcceptDone.current
+    )
+      return;
+    autoAcceptDone.current = true;
+    doJoinWorkspace();
+  }, [user, invite, token, step]);
+
+  const handleAccept = () => {
+    if (!token || !invite) return;
+    if (!user) {
+      setJoinEmail(invite.email);
+      setStep("join");
+      return;
+    }
+    doJoinWorkspace();
+  };
+
+  const doJoinWorkspace = async () => {
+    if (!token || !invite) return;
+    setAccepting(true);
+    try {
+      await workspaceService.joinByToken(token);
+      navigate(`/${invite.workspace_slug}`, { replace: true });
+    } catch {
+      setError("Failed to join workspace. Please try again.");
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const handleIgnore = async () => {
+    if (!token) return;
+    setIgnoring(true);
+    try {
+      await invitationService.declineByToken(token);
+      navigate("/", { replace: true });
+    } catch {
+      setError("Failed to decline. Please try again.");
+    } finally {
+      setIgnoring(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+        <p className="text-sm text-[var(--txt-tertiary)]">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error && !invite) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+        <Card className="w-full max-w-md">
+          <CardContent className="p-6">
+            <p className="text-sm text-[var(--txt-secondary)]">{error}</p>
+            <Button
+              variant="secondary"
+              className="mt-4"
+              onClick={() => navigate("/", { replace: true })}
+            >
+              Go home
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!invite) return null;
+
+  // Step 2: Join [workspace] — email + Continue → login
+  if (step === "join") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+        <Card className="w-full max-w-md">
+          <CardContent className="p-6">
+            <h1 className="flex items-center gap-2 text-2xl font-semibold text-[var(--txt-primary)]">
+              <span className="text-[var(--txt-secondary)]">Join</span>
+              <IconGlobe />
+              <span>{invite.workspace_name}</span>
+            </h1>
+            <p className="mt-2 text-sm text-[var(--txt-secondary)]">
+              Log in to start managing work with your team.
+            </p>
+
+            <div className="mt-6">
+              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                Email
+              </label>
+              <div className="relative">
+                <input
+                  type="email"
+                  value={joinEmail}
+                  onChange={(e) => setJoinEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  className="h-9 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                  autoComplete="email"
+                />
+                {joinEmail && (
+                  <button
+                    type="button"
+                    onClick={() => setJoinEmail("")}
+                    className="absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                    aria-label="Clear email"
+                  >
+                    <IconClear />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <Button
+              type="button"
+              className="mt-6 w-full"
+              onClick={() =>
+                navigate("/invite/sign-up", {
+                  replace: true,
+                  state: {
+                    email: joinEmail,
+                    token,
+                    workspaceName: invite.workspace_name,
+                    workspaceSlug: invite.workspace_slug,
+                  },
+                })
+              }
+            >
+              Continue
+            </Button>
+
+            <p className="mt-4 text-center text-sm text-[var(--txt-secondary)]">
+              Already have an account?{" "}
+              <button
+                type="button"
+                onClick={() =>
+                  navigate("/login", {
+                    replace: true,
+                    state: {
+                      from: { pathname: "/invite", search: `?token=${token}` },
+                      email: joinEmail,
+                    },
+                  })
+                }
+                className="font-medium text-[var(--txt-accent)] hover:underline"
+              >
+                Sign in
+              </button>
+            </p>
+
+            <p className="mt-6 text-center text-xs text-[var(--txt-tertiary)]">
+              By signing in, you understand and agree to our{" "}
+              <a
+                href="/terms"
+                className="underline hover:text-[var(--txt-secondary)]"
+              >
+                Terms of Service
+              </a>{" "}
+              and{" "}
+              <a
+                href="/privacy"
+                className="underline hover:text-[var(--txt-secondary)]"
+              >
+                Privacy Policy
+              </a>
+              .
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+      <Card className="w-full max-w-lg">
+        <CardContent className="p-8">
+          <h1 className="text-xl font-semibold text-[var(--txt-primary)]">
+            You have been invited to {invite.workspace_name}
+          </h1>
+          <p className="mt-3 text-sm text-[var(--txt-secondary)]">
+            Your workspace is where you'll create projects, collaborate on work
+            items, and organize different streams of work in your Devlane
+            account.
+          </p>
+
+          {error && (
+            <p className="mt-3 text-sm text-[var(--txt-destructive)]">
+              {error}
+            </p>
+          )}
+
+          <div className="mt-8 flex flex-col gap-3">
+            <button
+              type="button"
+              onClick={handleAccept}
+              disabled={accepting || ignoring}
+              className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 text-left text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)] disabled:opacity-50"
+            >
+              <span className="flex items-center gap-3">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--bg-accent-primary)] text-[var(--txt-on-color)]">
+                  <IconCheck />
+                </span>
+                Accept
+              </span>
+              <span className="text-[var(--txt-icon-tertiary)]">
+                <IconChevronRight />
+              </span>
+            </button>
+
+            <button
+              type="button"
+              onClick={handleIgnore}
+              disabled={accepting || ignoring}
+              className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 text-left text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)] disabled:opacity-50"
+            >
+              <span className="flex items-center gap-3">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--bg-layer-2)] text-[var(--txt-icon-secondary)]">
+                  <IconX />
+                </span>
+                Ignore
+              </span>
+              <span className="text-[var(--txt-icon-tertiary)]">
+                <IconChevronRight />
+              </span>
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/pages/InviteAcceptPage.tsx
+++ b/ui/src/pages/InviteAcceptPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Card, CardContent, Button } from "../components/ui";
 import { useAuth } from "../contexts/AuthContext";
@@ -132,6 +132,19 @@ export function InviteAcceptPage() {
     };
   }, [token, navigate]);
 
+  const doJoinWorkspace = useCallback(async () => {
+    if (!token || !invite) return;
+    setAccepting(true);
+    try {
+      await workspaceService.joinByToken(token);
+      navigate(`/${invite.workspace_slug}`, { replace: true });
+    } catch {
+      setError("Failed to join workspace. Please try again.");
+    } finally {
+      setAccepting(false);
+    }
+  }, [token, invite, navigate]);
+
   // When user returns from login (already authenticated), auto-accept and go to workspace
   useEffect(() => {
     if (
@@ -144,8 +157,7 @@ export function InviteAcceptPage() {
       return;
     autoAcceptDone.current = true;
     doJoinWorkspace();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- doJoinWorkspace is stable; run when user+invite+token available
-  }, [user, invite, token, step]);
+  }, [user, invite, token, step, doJoinWorkspace]);
 
   const handleAccept = () => {
     if (!token || !invite) return;
@@ -155,19 +167,6 @@ export function InviteAcceptPage() {
       return;
     }
     doJoinWorkspace();
-  };
-
-  const doJoinWorkspace = async () => {
-    if (!token || !invite) return;
-    setAccepting(true);
-    try {
-      await workspaceService.joinByToken(token);
-      navigate(`/${invite.workspace_slug}`, { replace: true });
-    } catch {
-      setError("Failed to join workspace. Please try again.");
-    } finally {
-      setAccepting(false);
-    }
   };
 
   const handleIgnore = async () => {

--- a/ui/src/pages/InviteAcceptPage.tsx
+++ b/ui/src/pages/InviteAcceptPage.tsx
@@ -108,6 +108,7 @@ export function InviteAcceptPage() {
   const [ignoring, setIgnoring] = useState(false);
   const [step, setStep] = useState<"invite" | "join">("invite");
   const [joinEmail, setJoinEmail] = useState("");
+  const autoAcceptDone = useRef(false);
 
   useEffect(() => {
     if (!token.trim()) {

--- a/ui/src/pages/InviteSignUpPage.tsx
+++ b/ui/src/pages/InviteSignUpPage.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { Card, CardContent, Button } from "../components/ui";
+import { useAuth } from "../contexts/AuthContext";
+import { authService } from "../services/authService";
+import { workspaceService } from "../services/workspaceService";
+
+const IconGlobe = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+    className="shrink-0 text-[var(--txt-icon-secondary)]"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    <path d="M2 12h20" />
+  </svg>
+);
+
+const IconCheck = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+);
+
+const IconEye = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const IconEyeOff = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+    <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+    <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+    <line x1="2" x2="22" y1="2" y2="22" />
+  </svg>
+);
+
+function usePasswordRequirements(password: string) {
+  return useMemo(
+    () => ({
+      minLength: password.length >= 8,
+      upper: /[A-Z]/.test(password),
+      lower: /[a-z]/.test(password),
+      number: /\d/.test(password),
+      special: /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(password),
+    }),
+    [password],
+  );
+}
+
+function PasswordRequirement({ met, label }: { met: boolean; label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-[var(--txt-secondary)]">
+      <span
+        className={`flex size-5 shrink-0 items-center justify-center rounded-full ${
+          met
+            ? "bg-[var(--bg-success-primary)] text-[var(--txt-on-color)]"
+            : "bg-[var(--bg-layer-1)] text-[var(--txt-placeholder)]"
+        }`}
+        aria-hidden
+      >
+        {met ? <IconCheck /> : null}
+      </span>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export function InviteSignUpPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setUserFromApi, user } = useAuth();
+
+  const state = location.state as {
+    email?: string;
+    token?: string;
+    workspaceName?: string;
+    workspaceSlug?: string;
+  } | null;
+
+  const email = (state?.email ?? "").trim();
+  const token = (state?.token ?? "").trim();
+  const workspaceName = state?.workspaceName ?? "the workspace";
+  const workspaceSlug = (state?.workspaceSlug ?? "").trim();
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const req = usePasswordRequirements(password);
+  const allMet =
+    req.minLength && req.upper && req.lower && req.number && req.special;
+  const passwordsMatch =
+    password === confirmPassword && confirmPassword.length > 0;
+
+  useEffect(() => {
+    if (!email || !token) {
+      navigate("/", { replace: true });
+    }
+  }, [email, token, navigate]);
+
+  useEffect(() => {
+    if (user) {
+      navigate("/", { replace: true });
+    }
+  }, [user, navigate]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (!allMet) {
+      setError("Please meet all password requirements.");
+      return;
+    }
+    if (!passwordsMatch) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const apiUser = await authService.signUp({
+        email,
+        password,
+        invite_token: token,
+      });
+      setUserFromApi(apiUser);
+      await workspaceService.joinByToken(token);
+      navigate(`/${workspaceSlug}`, { replace: true });
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === "object" && "response" in err
+          ? (err as { response?: { data?: { error?: string } } }).response?.data
+              ?.error
+          : null;
+      setError(message ?? "Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (!email || !token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+        <p className="text-sm text-[var(--txt-tertiary)]">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="p-6">
+          <h1 className="flex items-center gap-2 text-2xl font-semibold text-[var(--txt-primary)]">
+            <span className="text-[var(--txt-secondary)]">Join</span>
+            <IconGlobe />
+            <span>{workspaceName}</span>
+          </h1>
+          <p className="mt-2 text-sm text-[var(--txt-secondary)]">
+            Set a password to create your account and join the workspace.
+          </p>
+
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                Email
+              </label>
+              <input
+                type="email"
+                value={email}
+                readOnly
+                className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-3 py-2 text-sm text-[var(--txt-secondary)] focus:outline-none"
+                aria-readonly
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="invite-signup-password"
+                className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  id="invite-signup-password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Create a password"
+                  className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((p) => !p)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                >
+                  {showPassword ? <IconEyeOff /> : <IconEye />}
+                </button>
+              </div>
+              <div className="mt-2 grid grid-cols-1 gap-1 sm:grid-cols-2">
+                <PasswordRequirement
+                  met={req.minLength}
+                  label="Min 8 characters"
+                />
+                <PasswordRequirement met={req.upper} label="One uppercase" />
+                <PasswordRequirement met={req.lower} label="One lowercase" />
+                <PasswordRequirement met={req.number} label="Min 1 number" />
+                <PasswordRequirement met={req.special} label="Min 1 special" />
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="invite-signup-confirm"
+                className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]"
+              >
+                Confirm password
+              </label>
+              <div className="relative">
+                <input
+                  id="invite-signup-confirm"
+                  type={showConfirmPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="Confirm password"
+                  className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((p) => !p)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                  aria-label={
+                    showConfirmPassword ? "Hide password" : "Show password"
+                  }
+                >
+                  {showConfirmPassword ? <IconEyeOff /> : <IconEye />}
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <p className="text-sm text-[var(--txt-destructive)]">{error}</p>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isSubmitting || !allMet || !passwordsMatch}
+            >
+              {isSubmitting ? "Creating account…" : "Create account"}
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-[var(--txt-secondary)]">
+            Already have an account?{" "}
+            <Link
+              to="/login"
+              state={{
+                from: { pathname: "/invite", search: `?token=${token}` },
+                email,
+              }}
+              className="font-medium text-[var(--txt-accent)] hover:underline"
+            >
+              Sign in
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/pages/IssueListPage.tsx
+++ b/ui/src/pages/IssueListPage.tsx
@@ -143,6 +143,7 @@ export function IssueListPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }
@@ -203,7 +204,10 @@ export function IssueListPage() {
   const createParam = searchParams.get("create") === "1";
 
   useEffect(() => {
-    if (createParam && projectId) setCreateOpen(true);
+    if (createParam && projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: open create modal from URL (kept for future use)
+      setCreateOpen(true);
+    }
   }, [createParam, projectId]);
 
   const handleCloseCreate = () => {

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -7,13 +7,19 @@ export function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { login } = useAuth();
-  const [email, setEmail] = useState("");
+
+  const state = location.state as {
+    from?: { pathname?: string; search?: string };
+    email?: string;
+  } | null;
+  const from = state?.from;
+  const returnPath = from ? (from.pathname ?? "/") + (from.search ?? "") : "/";
+  const prefilledEmail = state?.email ?? "";
+
+  const [email, setEmail] = useState(prefilledEmail);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const returnPath =
-    (location.state as { from?: { pathname?: string } })?.from?.pathname ?? "/";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -132,6 +132,7 @@ export function ModulesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }

--- a/ui/src/pages/NotificationsPage.tsx
+++ b/ui/src/pages/NotificationsPage.tsx
@@ -45,6 +45,7 @@ export function NotificationsPage() {
 
   useEffect(() => {
     if (!workspaceSlug) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug (kept for future use)
       setLoading(false);
       return;
     }
@@ -99,6 +100,7 @@ export function NotificationsPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !selectedItem) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: clear selection when route changes (kept for future use)
       setSelectedProject(null);
       setSelectedIssue(null);
       return;

--- a/ui/src/pages/PagesPage.tsx
+++ b/ui/src/pages/PagesPage.tsx
@@ -154,6 +154,7 @@ export function PagesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }
@@ -194,8 +195,11 @@ export function PagesPage() {
         : pages.filter((p) => p.archived_at);
 
   const getUser = (
-    _userId: string | null,
-  ): { name: string; avatarUrl?: string | null } | null => null;
+    userId: string | null,
+  ): { name: string; avatarUrl?: string | null } | null => {
+    void userId; // reserved for future assignee display
+    return null;
+  };
 
   if (loading) {
     return (

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -292,17 +292,17 @@ export function ProfilePage() {
       {/* Main content */}
       <div className="min-w-0 flex-1 space-y-6 pb-8">
         {/* Tabs */}
-        <div className="border-b border-[var(--border-subtle)]">
+        <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
           <div className="flex gap-1">
             {tabs.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
                 onClick={() => setActiveTab(tab.id)}
-                className={`border-b-2 px-4 py-2.5 text-sm font-medium ${
+                className={`border-b-2 px-4 py-2.5 text-sm font-medium transition-colors ${
                   activeTab === tab.id
                     ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-                    : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+                    : "border-transparent text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
                 }`}
               >
                 {tab.label}
@@ -322,7 +322,7 @@ export function ProfilePage() {
                 <button
                   type="button"
                   onClick={() => setActiveTab("created")}
-                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-white text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
+                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
                 >
                   <Card
                     variant="outlined"
@@ -358,7 +358,7 @@ export function ProfilePage() {
                 <button
                   type="button"
                   onClick={() => setActiveTab("assigned")}
-                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-white text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
+                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
                 >
                   <Card
                     variant="outlined"
@@ -394,7 +394,7 @@ export function ProfilePage() {
                 <button
                   type="button"
                   onClick={() => setActiveTab("subscribed")}
-                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-white text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
+                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
                 >
                   <Card
                     variant="outlined"
@@ -443,7 +443,7 @@ export function ProfilePage() {
                     <Card
                       key={cat.id}
                       variant="outlined"
-                      className="border border-[var(--border-subtle)] bg-white"
+                      className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
                     >
                       <CardContent className="flex items-center gap-3 p-4">
                         <span
@@ -474,7 +474,7 @@ export function ProfilePage() {
                 </h2>
                 <Card
                   variant="outlined"
-                  className="border border-[var(--border-subtle)] bg-white"
+                  className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
                 >
                   <CardContent className="p-4">
                     <div className="flex flex-col gap-2">
@@ -531,7 +531,7 @@ export function ProfilePage() {
                 </h2>
                 <Card
                   variant="outlined"
-                  className="border border-[var(--border-subtle)] bg-white"
+                  className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
                 >
                   <CardContent className="flex flex-wrap items-center gap-6 p-4">
                     <div className="relative h-32 w-32 shrink-0">
@@ -568,7 +568,7 @@ export function ProfilePage() {
               </h2>
               <Card
                 variant="outlined"
-                className="border border-[var(--border-subtle)] bg-white"
+                className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
               >
                 <CardContent className="p-0">
                   <ul className="divide-y divide-[var(--border-subtle)]">
@@ -699,7 +699,7 @@ export function ProfilePage() {
       <aside className="hidden w-72 shrink-0 lg:flex lg:flex-col">
         <Card
           variant="outlined"
-          className="flex min-h-0 flex-1 flex-col overflow-hidden border border-[var(--border-subtle)] bg-white"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
         >
           <div
             className="relative h-20 shrink-0 bg-gradient-to-br from-[var(--brand-default)] to-[#0ea5e9]"
@@ -740,7 +740,7 @@ export function ProfilePage() {
                 name={profileUser?.name ?? "?"}
                 src={getImageUrl(profileUser?.avatarUrl) ?? undefined}
                 size="lg"
-                className="h-14 w-14 border-4 border-white shadow"
+                className="h-14 w-14"
               />
             </div>
             <h3 className="text-center text-base font-semibold text-[var(--txt-primary)] shrink-0">
@@ -1051,7 +1051,7 @@ function WorkItemsList({
       </div>
       <Card
         variant="outlined"
-        className="overflow-hidden border border-[var(--border-subtle)] bg-white"
+        className="overflow-hidden border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
       >
         <CardContent className="p-0">
           {issues.length === 0 ? (
@@ -1239,7 +1239,7 @@ function ActivityTab({
       </div>
       <Card
         variant="outlined"
-        className="border border-[var(--border-subtle)] bg-white"
+        className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
       >
         <CardContent className="p-0">
           <ul className="divide-y divide-[var(--border-subtle)]">

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -55,11 +55,11 @@ export function ProfilePage() {
 
   useEffect(() => {
     if (!workspaceSlug) {
-      setLoading(false);
+      queueMicrotask(() => setLoading(false));
       return;
     }
     let cancelled = false;
-    setLoading(true);
+    queueMicrotask(() => setLoading(true));
     workspaceService
       .getBySlug(workspaceSlug)
       .then((w) => {
@@ -125,7 +125,7 @@ export function ProfilePage() {
     return issues.filter((i) =>
       (i.assignee_ids ?? []).includes(profileUser.id),
     );
-  }, [profileUser?.id, issues]);
+  }, [profileUser, issues]);
   const issuesSubscribed = issuesAssigned.length;
   const issuesSubscribedList = issuesAssigned;
 
@@ -235,7 +235,7 @@ export function ProfilePage() {
         ...p,
         progress: 0,
       }));
-  }, [workspace?.id]);
+  }, [workspace?.id, projects]);
 
   const projectStateBreakdown = useMemo(() => {
     return projectsWithProgress.map((p) => {
@@ -916,7 +916,7 @@ function WorkItemsList({
   projects: projectsList,
   members: membersList = [],
   baseUrl,
-  workspaceSlug: _workspaceSlug,
+  workspaceSlug,
 }: {
   issues: Array<{
     id: string;
@@ -932,6 +932,7 @@ function WorkItemsList({
   baseUrl: string;
   workspaceSlug: string;
 }) {
+  void workspaceSlug; // reserved for future use (e.g. links)
   const getStateName = (stateId: string) =>
     statesList.find((s) => s.id === stateId)?.name ?? stateId;
   const getUser = (
@@ -945,8 +946,14 @@ function WorkItemsList({
     const avatarUrl = m?.member_avatar ?? null;
     return { name, avatarUrl };
   };
-  const getLabelNames = (_labelIds: string[] = []) => [] as string[];
-  const getCycle = (_cycleId: string | null): { name: string } | null => null;
+  const getLabelNames = (labelIds: string[] = []) => {
+    void labelIds; // reserved for future use
+    return [] as string[];
+  };
+  const getCycle = (cycleId: string | null): { name: string } | null => {
+    void cycleId; // reserved for future use
+    return null;
+  };
 
   return (
     <div className="space-y-0">
@@ -1206,7 +1213,7 @@ function ActivityTab({
   activities,
   projects: projectsList,
   issues: issuesList,
-  profileUser: _profileUser,
+  profileUser,
   formatTimeAgo,
 }: {
   activities: Array<{
@@ -1224,6 +1231,7 @@ function ActivityTab({
   profileUser: { name: string; avatarUrl?: string | null } | null;
   formatTimeAgo: (iso: string) => string;
 }) {
+  void profileUser; // reserved for future use
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1386,11 +1394,12 @@ function DonutChart({
   data: { label: string; color: string; count: number }[];
 }) {
   const total = data.reduce((s, d) => s + d.count, 0) || 1;
-  let acc = 0;
-  const parts = data.map((d) => {
-    const start = acc;
-    acc += (d.count / total) * 100;
-    return `${d.color} ${start}% ${acc}%`;
+  const parts = data.map((d, i) => {
+    const start = data
+      .slice(0, i)
+      .reduce((s, x) => s + (x.count / total) * 100, 0);
+    const end = start + (d.count / total) * 100;
+    return `${d.color} ${start}% ${end}%`;
   });
   const conic = parts.length
     ? `conic-gradient(${parts.join(", ")})`

--- a/ui/src/pages/ProjectHomePage.tsx
+++ b/ui/src/pages/ProjectHomePage.tsx
@@ -26,6 +26,7 @@ export function ProjectHomePage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }

--- a/ui/src/pages/ProjectsListPage.tsx
+++ b/ui/src/pages/ProjectsListPage.tsx
@@ -123,6 +123,7 @@ export function ProjectsListPage() {
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setFavoriteProjectIds stable; run when workspaceSlug changes
   }, [workspaceSlug]);
 
   const toggleFavorite = (e: React.MouseEvent, projectId: string) => {
@@ -146,7 +147,7 @@ export function ProjectsListPage() {
       )
       .finally(() => {
         setFavoriteRequestInFlight((prev) => {
-          const { [projectId]: _, ...rest } = prev;
+          const { [projectId]: _removed, ...rest } = prev; // eslint-disable-line @typescript-eslint/no-unused-vars -- intentionally omit key
           return rest;
         });
       });

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -921,6 +921,7 @@ export function SettingsPage() {
       setFeatureTimeTracking(selectedProject.is_time_tracking_enabled ?? false);
     }
   }, [
+    selectedProject,
     selectedProject?.id,
     selectedProject?.name,
     selectedProject?.description,
@@ -1087,7 +1088,7 @@ export function SettingsPage() {
     return () => {
       cancelled = true;
     };
-  }, [isAccountTab, user?.id]);
+  }, [isAccountTab, user?.id]); // eslint-disable-line react-hooks/exhaustive-deps -- user for prefetch; kept for future use
 
   useEffect(() => {
     if (!isAccountTab || accountSection !== "notifications") return;
@@ -1200,7 +1201,7 @@ export function SettingsPage() {
         replace: true,
       });
     }
-  }, [isProjectsTab, workspace, projects.length, projectIdParam, navigate]);
+  }, [isProjectsTab, workspace, projects.length, projectIdParam, navigate]); // eslint-disable-line react-hooks/exhaustive-deps -- projects for redirect; kept for future use
 
   const filteredMembers = membersSearch.trim()
     ? workspaceMembers.filter((m) => {
@@ -1388,8 +1389,8 @@ export function SettingsPage() {
               <div className="flex items-center gap-2">
                 <Avatar
                   name={workspace.name}
+                  src={getImageUrl(workspace?.logo) ?? undefined}
                   size="sm"
-                  className="rounded-md"
                 />
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
@@ -1458,8 +1459,8 @@ export function SettingsPage() {
               <div className="flex items-center gap-2">
                 <Avatar
                   name={workspace.name}
+                  src={getImageUrl(workspace?.logo) ?? undefined}
                   size="sm"
-                  className="rounded-md"
                 />
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
@@ -2956,7 +2957,9 @@ export function SettingsPage() {
                                 selectedProjectId,
                               );
                               setProjectInvites(list ?? []);
-                            } catch {}
+                            } catch {
+                              // Intentionally empty (kept for future use)
+                            }
                           }}
                         >
                           Revoke
@@ -3243,7 +3246,9 @@ export function SettingsPage() {
                                           selectedProjectId,
                                         );
                                         setProjectStates(list ?? []);
-                                      } catch {}
+                                      } catch {
+                                        // Intentionally empty (kept for future use)
+                                      }
                                     }}
                                   >
                                     Delete
@@ -3335,7 +3340,9 @@ export function SettingsPage() {
                               selectedProjectId,
                             );
                             setProjectLabels(list ?? []);
-                          } catch {}
+                          } catch {
+                            // Intentionally empty (kept for future use)
+                          }
                         }}
                       >
                         Delete
@@ -3893,7 +3900,9 @@ export function SettingsPage() {
                                         await navigator.clipboard.writeText(
                                           url,
                                         );
-                                      } catch {}
+                                      } catch {
+                                        // Intentionally empty (kept for future use)
+                                      }
                                     }}
                                   >
                                     <IconLink />
@@ -4402,7 +4411,9 @@ export function SettingsPage() {
                   setProjectStates(list ?? []);
                   setProjectStateModalOpen(false);
                   setProjectStateEdit(null);
-                } catch {}
+                } catch {
+                  // Intentionally empty (kept for future use)
+                }
               }}
             >
               {projectStateEdit ? "Save" : "Create"}
@@ -4519,7 +4530,9 @@ export function SettingsPage() {
                   setProjectLabels(list ?? []);
                   setProjectLabelModalOpen(false);
                   setProjectLabelEdit(null);
-                } catch {}
+                } catch {
+                  // Intentionally empty (kept for future use)
+                }
               }}
             >
               {projectLabelEdit ? "Save" : "Create"}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -606,6 +606,22 @@ const IconTrash = () => (
     <line x1="14" y1="11" x2="14" y2="17" />
   </svg>
 );
+const IconLink = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+);
 const IconGlobe = () => (
   <svg
     width="16"
@@ -993,6 +1009,10 @@ export function SettingsPage() {
   const [autoArchive, setAutoArchive] = useState(true);
   const [autoClose, setAutoClose] = useState(true);
   const [pendingInvitesExpanded, setPendingInvitesExpanded] = useState(true);
+  const [pendingInviteMenuId, setPendingInviteMenuId] = useState<string | null>(
+    null,
+  );
+  const pendingInviteMenuRef = useRef<HTMLDivElement>(null);
   const [inviteModalOpen, setInviteModalOpen] = useState(false);
   const [inviteRows, setInviteRows] = useState<
     { id: number; email: string; role: "member" | "admin" }[]
@@ -1159,6 +1179,20 @@ export function SettingsPage() {
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
   }, [projectTimezoneDropdownOpen]);
+
+  useEffect(() => {
+    if (!pendingInviteMenuId) return;
+    const close = (e: MouseEvent) => {
+      if (
+        pendingInviteMenuRef.current &&
+        !pendingInviteMenuRef.current.contains(e.target as Node)
+      ) {
+        setPendingInviteMenuId(null);
+      }
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [pendingInviteMenuId]);
 
   useEffect(() => {
     if (isProjectsTab && workspace && projects.length > 0 && !projectIdParam) {
@@ -3820,13 +3854,79 @@ export function SettingsPage() {
                                 <IconChevronDown />
                               </span>
                             </div>
-                            <button
-                              type="button"
-                              className="flex size-8 shrink-0 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                              aria-label="More options"
+                            <div
+                              className="relative shrink-0"
+                              ref={
+                                pendingInviteMenuId === inv.id
+                                  ? pendingInviteMenuRef
+                                  : undefined
+                              }
                             >
-                              <IconMoreVertical />
-                            </button>
+                              <button
+                                type="button"
+                                className="flex size-8 shrink-0 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                                aria-label="More options"
+                                aria-expanded={pendingInviteMenuId === inv.id}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setPendingInviteMenuId((id) =>
+                                    id === inv.id ? null : inv.id,
+                                  );
+                                }}
+                              >
+                                <IconMoreVertical />
+                              </button>
+                              {pendingInviteMenuId === inv.id && (
+                                <div
+                                  className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-lg"
+                                  role="menu"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <button
+                                    type="button"
+                                    role="menuitem"
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                                    onClick={async () => {
+                                      setPendingInviteMenuId(null);
+                                      const url = `${window.location.origin}/invite?token=${inv.token}`;
+                                      try {
+                                        await navigator.clipboard.writeText(
+                                          url,
+                                        );
+                                      } catch {}
+                                    }}
+                                  >
+                                    <IconLink />
+                                    Copy link
+                                  </button>
+                                  <button
+                                    type="button"
+                                    role="menuitem"
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-destructive)] hover:bg-[var(--bg-destructive-subtle)]"
+                                    onClick={async () => {
+                                      setPendingInviteMenuId(null);
+                                      if (!workspaceSlug) return;
+                                      try {
+                                        await workspaceService.deleteInvite(
+                                          workspaceSlug,
+                                          inv.id,
+                                        );
+                                        const list =
+                                          await workspaceService.listInvites(
+                                            workspaceSlug,
+                                          );
+                                        setWorkspaceInvites(list ?? []);
+                                      } catch {
+                                        // could toast
+                                      }
+                                    }}
+                                  >
+                                    <IconTrash />
+                                    Remove
+                                  </button>
+                                </div>
+                              )}
+                            </div>
                           </div>
                         );
                       })

--- a/ui/src/pages/ViewsPage.tsx
+++ b/ui/src/pages/ViewsPage.tsx
@@ -21,6 +21,7 @@ export function ViewsPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }

--- a/ui/src/pages/WorkspaceHomePage.tsx
+++ b/ui/src/pages/WorkspaceHomePage.tsx
@@ -310,7 +310,9 @@ export function WorkspaceHomePage() {
   const { user } = useAuth();
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
+  // projects state reserved for future use (e.g. project list on home)
   const [_projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  void _projects;
   const [quicklinks, setQuicklinks] = useState<QuickLinkApiResponse[]>([]);
   const [stickies, setStickies] = useState<StickyApiResponse[]>([]);
   const [recents, setRecents] = useState<RecentVisitApiResponse[]>([]);

--- a/ui/src/pages/WorkspaceViewsPage.tsx
+++ b/ui/src/pages/WorkspaceViewsPage.tsx
@@ -164,6 +164,7 @@ export function WorkspaceViewsPage() {
 
   useEffect(() => {
     if (!workspaceSlug) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug (kept for future use)
       setLoading(false);
       return;
     }
@@ -213,11 +214,31 @@ export function WorkspaceViewsPage() {
   const getStateName = (stateId: string | null | undefined) =>
     stateId ? (states.find((s) => s.id === stateId)?.name ?? stateId) : "—";
   const getUser = (
-    _userId: string | null,
-  ): { name: string; avatarUrl?: string | null } | null => null;
-  const getLabelNames = (_labelIds: string[] = []) => [] as string[];
-  const getCycleName = (_projectId: string, _cycleId: string | null) => null;
-  const getModuleName = (_projectId: string, _moduleId: string | null) => null;
+    userId: string | null,
+  ): { name: string; avatarUrl?: string | null } | null => {
+    void userId; // reserved for future use
+    return null;
+  };
+  const getLabelNames = (labelIds: string[] = []): string[] => {
+    void labelIds; // reserved for future use
+    return [];
+  };
+  const getCycleName = (
+    projectId: string,
+    cycleId: string | null,
+  ): string | null => {
+    void projectId;
+    void cycleId; // reserved for future use
+    return null;
+  };
+  const getModuleName = (
+    projectId: string,
+    moduleId: string | null,
+  ): string | null => {
+    void projectId;
+    void moduleId; // reserved for future use
+    return null;
+  };
 
   if (loading) {
     return (

--- a/ui/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
@@ -128,7 +128,8 @@ export function InstanceAdminAuthenticationPage() {
     gitlab: false,
   });
   const [loading, setLoading] = useState(true);
-  const [_saving, setSaving] = useState(false);
+  const [saving, setSaving] = useState(false);
+  void saving; // reserved for future use (e.g. disable submit while saving)
   const [error, setError] = useState("");
 
   useEffect(() => {

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -151,6 +151,16 @@ const InstanceSetupCompletePage = lazy(() =>
     page({ InstanceSetupCompletePage: m.InstanceSetupCompletePage }),
   ),
 );
+const InviteAcceptPage = lazy(() =>
+  import("../pages/InviteAcceptPage").then((m) =>
+    page({ InviteAcceptPage: m.InviteAcceptPage }),
+  ),
+);
+const InviteSignUpPage = lazy(() =>
+  import("../pages/InviteSignUpPage").then((m) =>
+    page({ InviteSignUpPage: m.InviteSignUpPage }),
+  ),
+);
 
 const PageFallback = () => (
   <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
@@ -287,6 +297,21 @@ const router = createBrowserRouter([
             <LoginPage />
           </Suspense>
         ),
+      },
+      {
+        path: "invite",
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <Outlet />
+          </Suspense>
+        ),
+        children: [
+          { index: true, element: <InviteAcceptPage /> },
+          {
+            path: "sign-up",
+            element: <InviteSignUpPage />,
+          },
+        ],
       },
       {
         element: <AppLayout />,

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components -- routes file exports router + layout components; keep for future use */
 import { lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate, Outlet } from "react-router-dom";
 import { AppShell, InstanceAdminLayout } from "../components/layout";

--- a/ui/src/services/authService.ts
+++ b/ui/src/services/authService.ts
@@ -1,13 +1,29 @@
 import { apiClient } from "../api/client";
-import type { UserApiResponse, SignInRequest } from "../api/types";
+import type {
+  UserApiResponse,
+  SignInRequest,
+  SignUpRequest,
+} from "../api/types";
 
 /**
- * Auth API: sign-in, sign-out, current user.
+ * Auth API: sign-in, sign-up, sign-out, current user.
  */
 export const authService = {
   async signIn(payload: SignInRequest): Promise<UserApiResponse> {
     const { data } = await apiClient.post<UserApiResponse>(
       "/auth/sign-in/",
+      payload,
+    );
+    return data;
+  },
+
+  /**
+   * Sign up a new user. When instance has allow_public_signup off, invite_token is required.
+   * POST /auth/sign-up/
+   */
+  async signUp(payload: SignUpRequest): Promise<UserApiResponse> {
+    const { data } = await apiClient.post<UserApiResponse>(
+      "/auth/sign-up/",
       payload,
     );
     return data;

--- a/ui/src/services/invitationService.ts
+++ b/ui/src/services/invitationService.ts
@@ -1,0 +1,27 @@
+import { apiClient } from "../api/client";
+import type { InviteByTokenResponse } from "../api/types";
+
+/**
+ * Public invitation APIs (no auth required).
+ */
+export const invitationService = {
+  /**
+   * Get invite details by token for the invite landing page.
+   * GET /api/invitations/by-token/?token=...
+   */
+  async getByToken(token: string): Promise<InviteByTokenResponse> {
+    const { data } = await apiClient.get<InviteByTokenResponse>(
+      "/api/invitations/by-token/",
+      { params: { token } },
+    );
+    return data;
+  },
+
+  /**
+   * Decline (ignore) an invitation by token.
+   * POST /api/invitations/decline/
+   */
+  async declineByToken(token: string): Promise<void> {
+    await apiClient.post("/api/invitations/decline/", { token });
+  },
+};

--- a/ui/src/services/workspaceService.ts
+++ b/ui/src/services/workspaceService.ts
@@ -122,4 +122,16 @@ export const workspaceService = {
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/invitations/${encodeURIComponent(invitePk)}/`,
     );
   },
+
+  /**
+   * Accept a workspace invitation by token (current user is added to the workspace).
+   * POST /api/workspaces/join/
+   */
+  async joinByToken(token: string): Promise<WorkspaceApiResponse> {
+    const { data } = await apiClient.post<WorkspaceApiResponse>(
+      "/api/workspaces/join/",
+      { token },
+    );
+    return data;
+  },
 };

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -169,8 +169,8 @@
     --red-900: oklch(0.8834 0.0616 18.39);
 
     --bg-screen: var(--neutral-200);
-    --bg-canvas: var(--neutral-black);
     --bg-surface-1: var(--neutral-100);
+    --bg-canvas: var(--bg-surface-1); /* same as sidebar in dark theme */
     --bg-surface-2: var(--neutral-200);
     --bg-layer-1: var(--neutral-200);
     --bg-layer-1-hover: var(--neutral-300);


### PR DESCRIPTION
This pull request introduces a complete backend and partial frontend implementation for public workspace invite links, including email delivery and invite management. The changes add support for generating, sending, and handling workspace invitations via unique tokens, and ensure robust email delivery with logging and configuration via instance settings. Additionally, it introduces a new API for invite token handling and improves the email queue and logging flows.

The most important changes are:

**Workspace Invitation System & API:**
* Added new `InvitationHandler` in `api/internal/handler/invitation.go` with public endpoints to fetch invite details by token and to decline an invite, enabling the frontend to support invite acceptance and decline flows.
* Registered new public invite endpoints in the router (`/api/invitations/by-token/` and `/api/invitations/decline/`).
* Added new API response type `InviteByTokenResponse` for invite token lookup in the frontend API types.

**Email Delivery and Logging:**
* Introduced a new SMTP email sender in `api/internal/mail/mail.go` that loads SMTP settings from instance settings, sends emails, and logs all attempts, successes, failures, and skips.
* Added detailed structured logging for email delivery attempts, successes, failures, and skips in `api/internal/mail/logger.go`.
* Updated the queue consumer to log email delivery attempts and results, including invite URLs, and to use the new SMTP sender. [[1]](diffhunk://#diff-15dcfab6f4094cd6bd8d8c9675c55950957b716cd00283fc5553265600af1950L81-R83) [[2]](diffhunk://#diff-15dcfab6f4094cd6bd8d8c9675c55950957b716cd00283fc5553265600af1950L94-R103) [[3]](diffhunk://#diff-3baac42f9618d3bf263f77208a1c30749c2e76215db24b3bad864023d2aeb1cfL96-R100)

**Workspace Invite Email Flow:**
* Modified `WorkspaceHandler` to enqueue workspace invite emails with a proper invite link using the configured frontend base URL, and to include additional context in the queue payload. [[1]](diffhunk://#diff-05928ae161b7c7a83f2a2ced70a49a14fe93e8f479595367aa1c881ac39ac147R380-R400) [[2]](diffhunk://#diff-05928ae161b7c7a83f2a2ced70a49a14fe93e8f479595367aa1c881ac39ac147R20-R21)
* Extended the queue payload (`SendEmailPayload`) to include an optional `invite_url` field for logging and debugging.

**Configuration and Environment:**
* Added `APP_BASE_URL` to `.env.example` and configuration structs, allowing the backend to generate correct invite links for emails. If unset, falls back to `CORS_ORIGIN`. [[1]](diffhunk://#diff-2fdd31c8eaeb05db626d15ffa6f31b34be3044212e22d6831e976afbab90cc86R23-R25) [[2]](diffhunk://#diff-09d9799d2fac6e2cc92b15820d13cfcef1786e73ef91020246c3c3f5ef10b553R43-R44) [[3]](diffhunk://#diff-09d9799d2fac6e2cc92b15820d13cfcef1786e73ef91020246c3c3f5ef10b553R89) [[4]](diffhunk://#diff-28d2c8c54ec523a39be83c8e754ae18a7446956fa04e14f2d9d7a93e36d6b9b3R26) [[5]](diffhunk://#diff-28d2c8c54ec523a39be83c8e754ae18a7446956fa04e14f2d9d7a93e36d6b9b3R102-R114)

**Frontend Improvements:**
* Added an interceptor in the API client to correctly handle `FormData` uploads by omitting the `Content-Type` header, preventing server-side parsing errors.
* Bumped UI version numbers to `0.3.2`. [[1]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL4-R4)

Closes #20 