### PR TITLE
25 adjust project create modal to be consistent with project settings page

### DIFF
--- a/api/internal/handler/project.go
+++ b/api/internal/handler/project.go
@@ -84,8 +84,22 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 	}
 	slug := c.Param("slug")
 	var body struct {
-		Name       string `json:"name" binding:"required"`
-		Identifier string `json:"identifier"`
+		Name                  string                 `json:"name" binding:"required"`
+		Identifier            string                 `json:"identifier"`
+		Description           *string                `json:"description"`
+		Timezone              *string                `json:"timezone"`
+		CoverImage            *string                `json:"cover_image"`
+		Emoji                 *string                `json:"emoji"`
+		IconProp              map[string]interface{} `json:"icon_prop"`
+		ProjectLeadID         *string                `json:"project_lead_id"`
+		DefaultAssigneeID     *string                `json:"default_assignee_id"`
+		GuestViewAllFeatures  *bool                  `json:"guest_view_all_features"`
+		ModuleView            *bool                  `json:"module_view"`
+		CycleView             *bool                  `json:"cycle_view"`
+		IssueViewsView        *bool                  `json:"issue_views_view"`
+		PageView              *bool                  `json:"page_view"`
+		IntakeView            *bool                  `json:"intake_view"`
+		IsTimeTrackingEnabled *bool                  `json:"is_time_tracking_enabled"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
@@ -100,6 +114,106 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create project"})
 		return
 	}
+
+	// If additional fields were provided, immediately apply them using the same logic as Update.
+	if body.Description != nil ||
+		body.Timezone != nil ||
+		body.CoverImage != nil ||
+		body.Emoji != nil ||
+		len(body.IconProp) > 0 ||
+		body.ProjectLeadID != nil ||
+		body.DefaultAssigneeID != nil ||
+		body.GuestViewAllFeatures != nil ||
+		body.ModuleView != nil ||
+		body.CycleView != nil ||
+		body.IssueViewsView != nil ||
+		body.PageView != nil ||
+		body.IntakeView != nil ||
+		body.IsTimeTrackingEnabled != nil {
+
+		// Reuse Update's field handling by calling the service directly.
+		var (
+			description, timezone *string
+			coverImage            *string
+			iconProp              *model.JSONMap
+			projectLeadIDPtr      *uuid.UUID
+			defaultAssigneeIDPtr  *uuid.UUID
+		)
+
+		if body.Description != nil {
+			description = body.Description
+		}
+		if body.Timezone != nil {
+			timezone = body.Timezone
+		}
+		if body.CoverImage != nil {
+			coverImage = body.CoverImage
+		}
+		if body.Emoji != nil && *body.Emoji != "" {
+			empty := model.JSONMap{}
+			iconProp = &empty
+		} else if len(body.IconProp) > 0 {
+			ip := model.JSONMap(body.IconProp)
+			iconProp = &ip
+		}
+		projectLeadSet := false
+		if body.ProjectLeadID != nil {
+			projectLeadSet = true
+			if *body.ProjectLeadID != "" {
+				id, parseErr := uuid.Parse(*body.ProjectLeadID)
+				if parseErr != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project_lead_id", "detail": "must be a valid UUID"})
+					return
+				}
+				projectLeadIDPtr = &id
+			}
+		}
+		defaultAssigneeSet := false
+		if body.DefaultAssigneeID != nil {
+			defaultAssigneeSet = true
+			if *body.DefaultAssigneeID != "" {
+				id, parseErr := uuid.Parse(*body.DefaultAssigneeID)
+				if parseErr != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid default_assignee_id", "detail": "must be a valid UUID"})
+					return
+				}
+				defaultAssigneeIDPtr = &id
+			}
+		}
+
+		updated, err := h.Project.Update(
+			c.Request.Context(),
+			slug,
+			p.ID,
+			user.ID,
+			nil, // name
+			nil, // identifier
+			description,
+			timezone,
+			coverImage,
+			body.Emoji,
+			iconProp,
+			projectLeadSet,
+			projectLeadIDPtr,
+			defaultAssigneeSet,
+			defaultAssigneeIDPtr,
+			body.GuestViewAllFeatures,
+			body.ModuleView,
+			body.CycleView,
+			body.IssueViewsView,
+			body.PageView,
+			body.IntakeView,
+			body.IsTimeTrackingEnabled,
+		)
+		if err != nil {
+			// If the follow-up update fails, still return the base project creation result.
+			c.JSON(http.StatusCreated, p)
+			return
+		}
+		c.JSON(http.StatusCreated, updated)
+		return
+	}
+
 	c.JSON(http.StatusCreated, p)
 }
 

--- a/api/migrations/000001_init_schema.up.sql
+++ b/api/migrations/000001_init_schema.up.sql
@@ -1424,6 +1424,8 @@ CREATE TABLE user_favorites (
     updated_by_id UUID REFERENCES users (id) ON DELETE SET NULL,
     parent_id UUID REFERENCES user_favorites (id) ON DELETE CASCADE
 );
+CREATE UNIQUE INDEX idx_user_fav_entity
+    ON user_favorites (user_id, entity_type, entity_identifier);
 CREATE TABLE user_recent_visits (
     id UUID PRIMARY KEY ,
     workspace_id UUID NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -57,6 +57,20 @@ export interface InviteByTokenResponse {
 export interface CreateProjectRequest {
   name: string;
   identifier?: string;
+  description?: string;
+  timezone?: string;
+  cover_image?: string;
+  emoji?: string;
+  icon_prop?: ProjectIconProp | null;
+  project_lead_id?: string;
+  default_assignee_id?: string;
+  guest_view_all_features?: boolean;
+  module_view?: boolean;
+  cycle_view?: boolean;
+  issue_views_view?: boolean;
+  page_view?: boolean;
+  intake_view?: boolean;
+  is_time_tracking_enabled?: boolean;
 }
 
 /** Project icon_prop from API (name + optional color) */

--- a/ui/src/components/CreateProjectModal.tsx
+++ b/ui/src/components/CreateProjectModal.tsx
@@ -1,8 +1,21 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button, Input } from "./ui";
+import { CoverImageModal } from "./CoverImageModal";
+import {
+  ProjectIconDisplay,
+  ProjectIconModal,
+  type ProjectIconSelection,
+} from "./ProjectIconModal";
 import { projectService } from "../services/projectService";
-import type { ProjectApiResponse } from "../api/types";
+import type {
+  ProjectApiResponse,
+  WorkspaceMemberApiResponse,
+} from "../api/types";
+import { useAuth } from "../contexts/AuthContext";
+import { workspaceService } from "../services/workspaceService";
+import { ProjectNetworkSelect } from "./ProjectNetworkSelect";
+import { ProjectLeadSelect } from "./ProjectLeadSelect";
 
 export interface CreateProjectModalProps {
   open: boolean;
@@ -97,17 +110,33 @@ export function CreateProjectModal({
   workspaceSlug,
   onSuccess,
 }: CreateProjectModalProps) {
+  const { user } = useAuth();
   const [name, setName] = useState("");
   const [identifier, setIdentifier] = useState("");
   const [description, setDescription] = useState("");
+  const [emoji, setEmoji] = useState<string | null>(null);
+  const [iconProp, setIconProp] =
+    useState<ProjectIconSelection["icon_prop"]>(null);
+  const [coverImage, setCoverImage] = useState<string | null>(null);
+  const [network, setNetwork] = useState<"public" | "private">("public");
+  const [projectLeadId, setProjectLeadId] = useState<string | null>(null);
+  const [workspaceMembers, setWorkspaceMembers] = useState<
+    WorkspaceMemberApiResponse[]
+  >([]);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [coverIndex, setCoverIndex] = useState(0);
+  const [coverModalOpen, setCoverModalOpen] = useState(false);
+  const [iconModalOpen, setIconModalOpen] = useState(false);
 
   const handleClose = () => {
     setName("");
     setIdentifier("");
     setDescription("");
+    setEmoji(null);
+    setIconProp(null);
+    setCoverImage(null);
+    setNetwork("public");
+    setProjectLeadId(null);
     setError("");
     onClose();
   };
@@ -121,10 +150,18 @@ export function CreateProjectModal({
     }
     setSubmitting(true);
     try {
-      const project = await projectService.create(workspaceSlug, {
+      const payload: Parameters<typeof projectService.create>[1] = {
         name: name.trim(),
         identifier: identifier.trim() || undefined,
-      });
+        description: description.trim() || undefined,
+        cover_image: coverImage || undefined,
+        emoji: emoji ?? undefined,
+        icon_prop: iconProp ?? undefined,
+        guest_view_all_features: network === "public" ? true : undefined,
+        project_lead_id: projectLeadId ?? undefined,
+      };
+
+      const project = await projectService.create(workspaceSlug, payload);
       onSuccess?.(project);
       handleClose();
     } catch (err) {
@@ -138,22 +175,39 @@ export function CreateProjectModal({
 
   useEffect(() => {
     if (!open) return;
+
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleEscape);
     document.body.style.overflow = "hidden";
+
+    // Load workspace members for project lead dropdown
+    workspaceService
+      .listMembers(workspaceSlug)
+      .then((members) => setWorkspaceMembers(members))
+      .catch(() => {
+        // ignore for create modal; dropdown will just be empty
+      });
+
     return () => {
       document.removeEventListener("keydown", handleEscape);
       document.body.style.overflow = "";
     };
-  }, [open, onClose]);
+  }, [open, onClose, workspaceSlug]);
 
   if (!open) return null;
 
-  const coverStyle = {
-    background: COVER_GRADIENTS[coverIndex % COVER_GRADIENTS.length],
-  };
+  const coverStyle =
+    coverImage != null
+      ? {
+          backgroundImage: `url(${coverImage})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }
+      : {
+          background: COVER_GRADIENTS[0],
+        };
 
   return createPortal(
     <div
@@ -171,11 +225,11 @@ export function CreateProjectModal({
         aria-hidden
       />
       <div
-        className="relative z-10 w-full max-w-lg overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-overlay)]"
+        className="relative z-10 w-full max-w-2xl overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-overlay)]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Cover + Close */}
-        <div className="relative h-28 w-full shrink-0" style={coverStyle}>
+        <div className="relative h-36 w-full shrink-0" style={coverStyle}>
           <button
             type="button"
             onClick={handleClose}
@@ -186,26 +240,34 @@ export function CreateProjectModal({
           </button>
           <button
             type="button"
-            onClick={() => setCoverIndex((i) => i + 1)}
+            onClick={() => setCoverModalOpen(true)}
             className="absolute bottom-3 right-3 rounded-md bg-white/20 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm hover:bg-white/30"
           >
-            Change cover
+            Choose image
           </button>
         </div>
 
-        {/* Icon placeholder overlapping cover */}
+        {/* Icon overlapping cover */}
         <div className="px-5 -mt-6 relative z-10">
-          <div className="flex size-12 items-center justify-center rounded-lg border-2 border-[var(--bg-surface-1)] bg-[var(--bg-layer-2)] text-2xl shadow-sm">
-            📁
-          </div>
+          <button
+            type="button"
+            onClick={() => setIconModalOpen(true)}
+            className="flex size-12 items-center justify-center rounded-lg border-2 border-[var(--bg-surface-1)] bg-[var(--bg-layer-2)] text-2xl shadow-sm hover:bg-[var(--bg-layer-transparent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--border-strong)]"
+            aria-label="Change project icon"
+          >
+            <ProjectIconDisplay
+              emoji={emoji ?? undefined}
+              icon_prop={iconProp ?? undefined}
+              size={24}
+            />
+          </button>
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="px-5 pb-5 pt-2">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div className="sm:col-span-2 sm:grid-cols-1">
+        <form onSubmit={handleSubmit} className="px-5 pb-5 pt-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="sm:col-span-2">
               <Input
-                label="Project name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Project name"
@@ -215,9 +277,8 @@ export function CreateProjectModal({
                 className="w-full"
               />
             </div>
-            <div className="relative sm:col-span-2">
+            <div className="relative">
               <Input
-                label="Project ID"
                 value={identifier}
                 onChange={(e) =>
                   setIdentifier(
@@ -237,9 +298,6 @@ export function CreateProjectModal({
             </div>
           </div>
           <div className="mt-4">
-            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
-              Description
-            </label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -250,16 +308,19 @@ export function CreateProjectModal({
             />
           </div>
 
-          {/* Visibility / type tags (Plane-style) */}
-          <div className="mt-4 flex flex-wrap gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-xs font-medium text-[var(--txt-secondary)]">
-              <IconGlobe />
-              Public
-            </span>
-            <span className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-xs font-medium text-[var(--txt-secondary)]">
-              <IconUsers />
-              Lead
-            </span>
+          {/* Network + Project Lead (under description, side by side) */}
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <ProjectNetworkSelect
+              value={network}
+              onChange={setNetwork}
+              disabled={submitting}
+            />
+            <ProjectLeadSelect
+              value={projectLeadId}
+              members={workspaceMembers}
+              onChange={setProjectLeadId}
+              disabled={submitting || !user}
+            />
           </div>
 
           {error && (
@@ -283,6 +344,32 @@ export function CreateProjectModal({
             </Button>
           </div>
         </form>
+
+        {/* Cover and icon selection modals (reused from settings) */}
+        <CoverImageModal
+          open={coverModalOpen}
+          onClose={() => setCoverModalOpen(false)}
+          onSelect={(url) => {
+            setCoverImage(url);
+            setCoverModalOpen(false);
+          }}
+          title="Select project cover"
+        />
+        <ProjectIconModal
+          open={iconModalOpen}
+          onClose={() => setIconModalOpen(false)}
+          onSelect={(selection) => {
+            if (selection.emoji != null) {
+              setEmoji(selection.emoji);
+              setIconProp(null);
+            } else {
+              setEmoji(null);
+              setIconProp(selection.icon_prop ?? null);
+            }
+            setIconModalOpen(false);
+          }}
+          title="Project icon"
+        />
       </div>
     </div>,
     document.body,

--- a/ui/src/components/CreateProjectModal.tsx
+++ b/ui/src/components/CreateProjectModal.tsx
@@ -32,43 +32,6 @@ const COVER_GRADIENTS = [
   "linear-gradient(135deg, #ec4899 0%, #f472b6 50%, #f9a8d4 100%)",
 ];
 
-const IconGlobe = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden
-  >
-    <circle cx="12" cy="12" r="10" />
-    <line x1="2" y1="12" x2="22" y2="12" />
-    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-  </svg>
-);
-
-const IconUsers = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden
-  >
-    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-    <circle cx="9" cy="7" r="4" />
-    <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-  </svg>
-);
-
 const IconInfo = () => (
   <svg
     width="14"

--- a/ui/src/components/ProjectLeadSelect.tsx
+++ b/ui/src/components/ProjectLeadSelect.tsx
@@ -8,7 +8,10 @@ interface ProjectLeadSelectProps {
   disabled?: boolean;
 }
 
-const memberLabel = (members: WorkspaceMemberApiResponse[], memberId: string | null | undefined) => {
+const memberLabel = (
+  members: WorkspaceMemberApiResponse[],
+  memberId: string | null | undefined,
+) => {
   if (!memberId) return "—";
   const m = members.find((wm) => wm.member_id === memberId);
   const display = m?.member_display_name?.trim();
@@ -52,4 +55,3 @@ export function ProjectLeadSelect({
     </div>
   );
 }
-

--- a/ui/src/components/ProjectLeadSelect.tsx
+++ b/ui/src/components/ProjectLeadSelect.tsx
@@ -1,0 +1,55 @@
+import type { ChangeEvent } from "react";
+import type { WorkspaceMemberApiResponse } from "../api/types";
+
+interface ProjectLeadSelectProps {
+  value: string | null;
+  members: WorkspaceMemberApiResponse[];
+  onChange: (value: string | null) => void;
+  disabled?: boolean;
+}
+
+const memberLabel = (members: WorkspaceMemberApiResponse[], memberId: string | null | undefined) => {
+  if (!memberId) return "—";
+  const m = members.find((wm) => wm.member_id === memberId);
+  const display = m?.member_display_name?.trim();
+  if (display) return display;
+  const emailUser = m?.member_email?.split("@")[0]?.trim();
+  if (emailUser) return emailUser;
+  return "Member";
+};
+
+export function ProjectLeadSelect({
+  value,
+  members,
+  onChange,
+  disabled,
+}: ProjectLeadSelectProps) {
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value || null;
+    onChange(v);
+  };
+
+  return (
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-[var(--txt-primary)]">
+        Project Lead
+      </p>
+      <div className="relative min-w-[180px]">
+        <select
+          value={value ?? ""}
+          onChange={handleChange}
+          disabled={disabled}
+          className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+        >
+          <option value="">Select</option>
+          {members.map((m) => (
+            <option key={m.member_id} value={m.member_id ?? ""}>
+              {memberLabel(members, m.member_id)}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+

--- a/ui/src/components/ProjectNetworkSelect.tsx
+++ b/ui/src/components/ProjectNetworkSelect.tsx
@@ -35,4 +35,3 @@ export function ProjectNetworkSelect({
     </div>
   );
 }
-

--- a/ui/src/components/ProjectNetworkSelect.tsx
+++ b/ui/src/components/ProjectNetworkSelect.tsx
@@ -1,0 +1,38 @@
+import type { ChangeEvent } from "react";
+
+interface ProjectNetworkSelectProps {
+  value: string;
+  onChange: (value: "public" | "private") => void;
+  disabled?: boolean;
+}
+
+export function ProjectNetworkSelect({
+  value,
+  onChange,
+  disabled,
+}: ProjectNetworkSelectProps) {
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value === "private" ? "private" : "public";
+    onChange(v);
+  };
+
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+        Network
+      </label>
+      <div className="relative">
+        <select
+          value={value}
+          onChange={handleChange}
+          disabled={disabled}
+          className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+        >
+          <option value="public">Public</option>
+          <option value="private">Private</option>
+        </select>
+      </div>
+    </div>
+  );
+}
+

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -17,6 +17,8 @@ import { getImageUrl } from "../lib/utils";
 import { useAuth } from "../contexts/AuthContext";
 import { useTheme } from "../contexts/ThemeContext";
 import { workspaceService } from "../services/workspaceService";
+import { ProjectNetworkSelect } from "../components/ProjectNetworkSelect";
+import { ProjectLeadSelect } from "../components/ProjectLeadSelect";
 import { projectService } from "../services/projectService";
 import { issueService } from "../services/issueService";
 import { labelService } from "../services/labelService";
@@ -910,6 +912,10 @@ export function SettingsPage() {
       setProjectDescription(selectedProject.description ?? "");
       if (selectedProject.timezone != null)
         setProjectTimezone(selectedProject.timezone);
+      // Derive Network dropdown value from guest_view_all_features so it reflects persisted visibility
+      setProjectNetwork(
+        selectedProject.guest_view_all_features ? "public" : "private",
+      );
       setProjectLeadId(selectedProject.project_lead_id ?? null);
       setDefaultAssigneeId(selectedProject.default_assignee_id ?? null);
       setGuestAccess(selectedProject.guest_view_all_features ?? false);
@@ -2477,24 +2483,34 @@ export function SettingsPage() {
                     </span>
                   </div>
                 </div>
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
-                    Network
-                  </label>
-                  <div className="relative">
-                    <select
-                      value={projectNetwork}
-                      onChange={(e) => setProjectNetwork(e.target.value)}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
-                    >
-                      <option value="public">Public</option>
-                      <option value="private">Private</option>
-                    </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
-                      <IconGlobe />
-                    </span>
-                  </div>
-                </div>
+                <ProjectNetworkSelect
+                  value={projectNetwork}
+                  onChange={async (v) => {
+                    // Map network dropdown to the same guest_view_all_features flag used elsewhere
+                    const nextGuestAccess = v === "public";
+                    setProjectNetwork(v);
+                    setGuestAccess(nextGuestAccess);
+                    if (!workspaceSlug || !selectedProjectId) return;
+                    try {
+                      const updated = await projectService.update(
+                        workspaceSlug,
+                        selectedProjectId,
+                        { guest_view_all_features: nextGuestAccess },
+                      );
+                      setProjects((prev) =>
+                        prev.map((p) =>
+                          p.id === updated.id ? updated : p,
+                        ),
+                      );
+                    } catch {
+                      // revert local state on failure
+                      setProjectNetwork(
+                        nextGuestAccess ? "private" : "public",
+                      );
+                      setGuestAccess(!nextGuestAccess);
+                    }
+                  }}
+                />
                 <div className="sm:col-span-2">
                   <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
                     Project Timezone
@@ -2703,7 +2719,7 @@ export function SettingsPage() {
                     >
                       <option value="">Select</option>
                       {workspaceMembers.map((m) => (
-                        <option key={m.member_id} value={m.member_id}>
+                        <option key={m.member_id} value={m.member_id ?? ""}>
                           {memberLabel(m.member_id)}
                         </option>
                       ))}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -2498,15 +2498,11 @@ export function SettingsPage() {
                         { guest_view_all_features: nextGuestAccess },
                       );
                       setProjects((prev) =>
-                        prev.map((p) =>
-                          p.id === updated.id ? updated : p,
-                        ),
+                        prev.map((p) => (p.id === updated.id ? updated : p)),
                       );
                     } catch {
                       // revert local state on failure
-                      setProjectNetwork(
-                        nextGuestAccess ? "private" : "public",
-                      );
+                      setProjectNetwork(nextGuestAccess ? "private" : "public");
                       setGuestAccess(!nextGuestAccess);
                     }
                   }}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -18,7 +18,6 @@ import { useAuth } from "../contexts/AuthContext";
 import { useTheme } from "../contexts/ThemeContext";
 import { workspaceService } from "../services/workspaceService";
 import { ProjectNetworkSelect } from "../components/ProjectNetworkSelect";
-import { ProjectLeadSelect } from "../components/ProjectLeadSelect";
 import { projectService } from "../services/projectService";
 import { issueService } from "../services/issueService";
 import { labelService } from "../services/labelService";
@@ -622,23 +621,6 @@ const IconLink = () => (
   >
     <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
     <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-  </svg>
-);
-const IconGlobe = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden
-  >
-    <circle cx="12" cy="12" r="10" />
-    <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
-    <path d="M2 12h20" />
   </svg>
 );
 const IconTag = () => (


### PR DESCRIPTION
This pull request introduces significant enhancements to project creation and configuration, both in the backend and frontend. The main updates expand the project creation API and UI to support additional metadata and settings, such as description, cover image, emoji, icon, project lead, and network visibility. The UI now provides a more flexible and feature-rich modal for creating projects, and the backend ensures these new fields are handled consistently. Additionally, a unique database index is added to prevent duplicate user favorites.

**Backend enhancements to project creation and metadata:**

- The `CreateProjectRequest` API and the `ProjectHandler.Create` handler now accept and process new optional fields: `description`, `timezone`, `cover_image`, `emoji`, `icon_prop`, `project_lead_id`, `default_assignee_id`, and several feature toggles (such as guest access and module/cycle/page views). These fields are immediately applied during project creation using the same logic as the update flow, ensuring consistency. [[1]](diffhunk://#diff-6490ab7c1c1f75875e96460ac6523884d858a9a32e432432e45417c42d8e19acR89-R102) [[2]](diffhunk://#diff-6490ab7c1c1f75875e96460ac6523884d858a9a32e432432e45417c42d8e19acR117-R216) [[3]](diffhunk://#diff-a75e1abf9627f72124f13ee5a5c4287c880e281a2547c3822346c1ce818144dbR60-R73)

- A unique index (`idx_user_fav_entity`) is added to the `user_favorites` table to prevent users from favoriting the same entity multiple times.

**Frontend improvements to project creation UI:**

- The `CreateProjectModal` now supports selecting a cover image, project icon (emoji or custom icon), project lead, and network visibility (public/private). The modal has been redesigned for better usability, including new components for selecting project lead and network. [[1]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57R4-R18) [[2]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57R113-R139) [[3]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L124-R164) [[4]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57R178-R209) [[5]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L174-R232) [[6]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L189-L208) [[7]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L218-L220) [[8]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L240-L242) [[9]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L253-R323) [[10]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57R347-R372)

- Two new reusable components, `ProjectLeadSelect` and `ProjectNetworkSelect`, are introduced for selecting the project lead from workspace members and toggling project visibility, respectively. [[1]](diffhunk://#diff-2bc3148c38a6da2b1815787052ff67e6b0ad0ca888fed6cc0a72b32192fd4472R1-R57) [[2]](diffhunk://#diff-499b9bcf6f8f97bbd4c7f851984c5a5e1984aae52f5e4eb53e15e6c75bae404dR1-R37)

**Settings page updates:**

- The Settings page now correctly reflects the persisted network visibility of a project by deriving the dropdown value from the backend field. [[1]](diffhunk://#diff-ca237f40fdb5fa909440ca5aa5319745f0c17312074cc883115e953243417bd4R20-R21) [[2]](diffhunk://#diff-ca237f40fdb5fa909440ca5aa5319745f0c17312074cc883115e953243417bd4R915-R918)

Closes #25 