### PR TITLE
[FEAT] implement modules page projects modules

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -375,6 +375,7 @@ export interface ModuleApiResponse {
   status: string;
   project_id: string;
   workspace_id: string;
+  lead_id?: string | null;
   sort_order?: number;
   issue_count?: number;
   created_at: string;

--- a/ui/src/components/AddExistingWorkItemModal.tsx
+++ b/ui/src/components/AddExistingWorkItemModal.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { Button } from "./ui";
+import { issueService } from "../services/issueService";
+import { moduleService } from "../services/moduleService";
+import type { IssueApiResponse } from "../api/types";
+
+const IconSearch = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.35-4.35" />
+  </svg>
+);
+
+function displayId(issue: IssueApiResponse, projectIdentifier: string): string {
+  return `${projectIdentifier}-${issue.sequence_id ?? issue.id.slice(-4)}`;
+}
+
+export interface AddExistingWorkItemModalProps {
+  open: boolean;
+  onClose: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  moduleId: string;
+  projectIdentifier: string;
+  onAdded?: () => void;
+}
+
+export function AddExistingWorkItemModal({
+  open,
+  onClose,
+  workspaceSlug,
+  projectId,
+  moduleId,
+  projectIdentifier,
+  onAdded,
+}: AddExistingWorkItemModalProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [projectIssues, setProjectIssues] = useState<IssueApiResponse[]>([]);
+  const [moduleIssueIds, setModuleIssueIds] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !workspaceSlug || !projectId || !moduleId) return;
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      issueService.list(workspaceSlug, projectId, { limit: 2000 }),
+      moduleService.listIssueIds(workspaceSlug, projectId, moduleId),
+    ])
+      .then(([issues, ids]) => {
+        setProjectIssues(issues ?? []);
+        setModuleIssueIds(new Set(ids ?? []));
+        setSelectedIds(new Set());
+      })
+      .catch(() => setError("Failed to load work items"))
+      .finally(() => setLoading(false));
+  }, [open, workspaceSlug, projectId, moduleId]);
+
+  useEffect(() => {
+    if (!open) {
+      setSearchQuery("");
+      setSelectedIds(new Set());
+    }
+  }, [open]);
+
+  const availableIssues = useMemo(() => {
+    return projectIssues.filter((i) => !moduleIssueIds.has(i.id));
+  }, [projectIssues, moduleIssueIds]);
+
+  const filteredIssues = useMemo(() => {
+    if (!searchQuery.trim()) return availableIssues;
+    const q = searchQuery.trim().toLowerCase();
+    return availableIssues.filter((issue) => {
+      const id = displayId(issue, projectIdentifier);
+      const name = (issue.name ?? "").toLowerCase();
+      return id.toLowerCase().includes(q) || name.includes(q);
+    });
+  }, [availableIssues, searchQuery, projectIdentifier]);
+
+  const selectAll = () => {
+    if (filteredIssues.length === 0) return;
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      filteredIssues.forEach((i) => next.add(i.id));
+      return next;
+    });
+  };
+
+  const toggleOne = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleAdd = async () => {
+    if (selectedIds.size === 0) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await Promise.all(
+        Array.from(selectedIds).map((issueId) =>
+          moduleService.addIssue(workspaceSlug, projectId, moduleId, issueId),
+        ),
+      );
+      onAdded?.();
+      onClose();
+    } catch {
+      setError("Failed to add work items");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const selectedCount = selectedIds.size;
+  const selectionLabel =
+    selectedCount === 0
+      ? "No work items selected"
+      : `${selectedCount} work item${selectedCount === 1 ? "" : "s"} selected`;
+
+  const footer = (
+    <div className="flex w-full items-center justify-between">
+      <button
+        type="button"
+        onClick={selectAll}
+        className="text-sm font-medium text-(--brand-default) hover:underline"
+      >
+        Select all
+      </button>
+      <div className="flex gap-2">
+        <Button variant="secondary" onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleAdd}
+          disabled={selectedCount === 0 || submitting}
+          className="gap-1.5"
+        >
+          Add selected work items
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-existing-work-item-title"
+    >
+      <div
+        className="absolute inset-0 bg-(--bg-backdrop)"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        className="relative z-10 flex w-full max-w-md flex-col rounded-lg border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay)"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-col gap-3 border-b border-(--border-subtle) px-5 py-4">
+          <div className="relative">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
+              <IconSearch />
+            </span>
+            <input
+              type="text"
+              placeholder="Type to search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-9 w-full rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-9 pr-3 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
+              aria-label="Search work items"
+            />
+          </div>
+          <span
+            id="add-existing-work-item-title"
+            className="inline-flex w-fit rounded-full bg-(--bg-layer-2) px-3 py-1 text-sm text-(--txt-secondary)"
+          >
+            {selectionLabel}
+          </span>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-5 py-4">
+          {error && (
+            <p className="mb-2 text-sm text-(--txt-danger-primary)">{error}</p>
+          )}
+          {loading ? (
+            <p className="py-8 text-center text-sm text-(--txt-tertiary)">
+              Loading work items…
+            </p>
+          ) : filteredIssues.length === 0 ? (
+            <p className="py-8 text-center text-sm text-(--txt-tertiary)">
+              {availableIssues.length === 0
+                ? "No other work items in this project."
+                : "No matching work items."}
+            </p>
+          ) : (
+            <ul className="max-h-64 overflow-y-auto divide-y divide-(--border-subtle)">
+              {filteredIssues.map((issue) => {
+                const id = displayId(issue, projectIdentifier);
+                const checked = selectedIds.has(issue.id);
+                return (
+                  <li key={issue.id}>
+                    <label className="flex cursor-pointer items-center gap-3 py-2.5 hover:bg-(--bg-layer-1-hover)">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleOne(issue.id)}
+                        className="size-4 shrink-0 rounded border-(--border-subtle)"
+                      />
+                      <span
+                        className="size-2 shrink-0 rounded-full bg-(--txt-primary)"
+                        aria-hidden
+                      />
+                      <span className="min-w-0 flex-1 truncate text-sm">
+                        <span className="font-medium text-(--txt-primary)">
+                          {id}
+                        </span>
+                        <span className="ml-2 text-(--txt-secondary)">
+                          {issue.name || "—"}
+                        </span>
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex w-full border-t border-(--border-subtle) px-5 py-4">
+          {footer}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/components/CoverImageModal.tsx
+++ b/ui/src/components/CoverImageModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+﻿import { useCallback, useEffect, useState } from "react";
 import { Button, Modal } from "./ui";
 import {
   instanceSettingsService,
@@ -164,14 +164,14 @@ export function CoverImageModal({
       footer={footer}
       className="max-w-2xl"
     >
-      <div className="flex gap-2 border-b border-[var(--border-subtle)] pb-3 mb-3">
+      <div className="flex gap-2 border-b border-(--border-subtle) pb-3 mb-3">
         <button
           type="button"
           onClick={() => setTab(TAB_UNSPLASH)}
-          className={`rounded-[var(--radius-md)] px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`rounded-(--radius-md) px-3 py-1.5 text-sm font-medium transition-colors ${
             tab === TAB_UNSPLASH
-              ? "bg-[var(--brand-default)] text-white"
-              : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+              ? "bg-(--brand-default) text-white"
+              : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover)"
           }`}
         >
           Unsplash
@@ -179,10 +179,10 @@ export function CoverImageModal({
         <button
           type="button"
           onClick={() => setTab(TAB_UPLOAD)}
-          className={`rounded-[var(--radius-md)] px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`rounded-(--radius-md) px-3 py-1.5 text-sm font-medium transition-colors ${
             tab === TAB_UPLOAD
-              ? "bg-[var(--brand-default)] text-white"
-              : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+              ? "bg-(--brand-default) text-white"
+              : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover)"
           }`}
         >
           Upload
@@ -198,7 +198,7 @@ export function CoverImageModal({
               onChange={(e) => setUnsplashQuery(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSearch()}
               placeholder="Search for images"
-              className="min-w-0 flex-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+              className="min-w-0 flex-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
             />
             <Button
               variant="secondary"
@@ -209,7 +209,7 @@ export function CoverImageModal({
             </Button>
           </div>
           {unsplashError && (
-            <p className="text-sm text-[var(--txt-danger-primary)]">
+            <p className="text-sm text-(--txt-danger-primary)">
               {unsplashError}
             </p>
           )}
@@ -219,10 +219,10 @@ export function CoverImageModal({
                 type="button"
                 key={r.id}
                 onClick={() => setSelectedUrl(r.url)}
-                className={`relative aspect-video rounded-[var(--radius-md)] overflow-hidden border-2 transition-colors ${
+                className={`relative aspect-video rounded-(--radius-md) overflow-hidden border-2 transition-colors ${
                   selectedUrl === r.url
-                    ? "border-[var(--brand-default)] ring-2 ring-[var(--brand-200)]"
-                    : "border-transparent hover:border-[var(--border-strong)]"
+                    ? "border-(--brand-default) ring-2 ring-(--brand-200)"
+                    : "border-transparent hover:border-(--border-strong)"
                 }`}
               >
                 <img
@@ -242,13 +242,13 @@ export function CoverImageModal({
             <div
               onDrop={handleDrop}
               onDragOver={handleDragOver}
-              className="flex flex-col items-center justify-center rounded-[var(--radius-md)] border-2 border-dashed border-[var(--border-subtle)] bg-[var(--bg-layer-2)] py-12 px-4"
+              className="flex flex-col items-center justify-center rounded-(--radius-md) border-2 border-dashed border-(--border-subtle) bg-(--bg-layer-2) py-12 px-4"
             >
-              <p className="text-sm text-[var(--txt-secondary)] mb-2">
+              <p className="text-sm text-(--txt-secondary) mb-2">
                 Drag & drop image here
               </p>
               <label className="cursor-pointer">
-                <span className="text-sm font-medium text-[var(--txt-accent-primary)] hover:underline">
+                <span className="text-sm font-medium text-(--txt-accent-primary) hover:underline">
                   Browse
                 </span>
                 <input
@@ -260,7 +260,7 @@ export function CoverImageModal({
               </label>
             </div>
           ) : (
-            <div className="relative rounded-[var(--radius-md)] border border-[var(--border-subtle)] overflow-hidden bg-[var(--bg-layer-2)]">
+            <div className="relative rounded-(--radius-md) border border-(--border-subtle) overflow-hidden bg-(--bg-layer-2)">
               <img
                 src={uploadPreview}
                 alt="Preview"
@@ -270,18 +270,18 @@ export function CoverImageModal({
                 <button
                   type="button"
                   onClick={handleRemoveUpload}
-                  className="text-xs font-medium text-[var(--txt-accent-primary)] hover:underline"
+                  className="text-xs font-medium text-(--txt-accent-primary) hover:underline"
                 >
                   Edit
                 </button>
               </div>
             </div>
           )}
-          <p className="text-xs text-[var(--txt-tertiary)]">
+          <p className="text-xs text-(--txt-tertiary)">
             File formats supported: .jpeg, .jpg, .png, .webp
           </p>
           {uploadError && (
-            <p className="text-sm text-[var(--txt-danger-primary)]">
+            <p className="text-sm text-(--txt-danger-primary)">
               {uploadError}
             </p>
           )}

--- a/ui/src/components/CoverImageModal.tsx
+++ b/ui/src/components/CoverImageModal.tsx
@@ -281,9 +281,7 @@ export function CoverImageModal({
             File formats supported: .jpeg, .jpg, .png, .webp
           </p>
           {uploadError && (
-            <p className="text-sm text-(--txt-danger-primary)">
-              {uploadError}
-            </p>
+            <p className="text-sm text-(--txt-danger-primary)">{uploadError}</p>
           )}
         </div>
       )}

--- a/ui/src/components/CreateModuleModal.tsx
+++ b/ui/src/components/CreateModuleModal.tsx
@@ -1,0 +1,456 @@
+import { useState, useEffect, useRef } from "react";
+import { Modal, Button, Input, Avatar } from "./ui";
+import { DateRangeModal } from "./workspace-views/DateRangeModal";
+import { getImageUrl } from "../lib/utils";
+import { moduleService } from "../services/moduleService";
+import { workspaceService } from "../services/workspaceService";
+import type { ModuleApiResponse } from "../api/types";
+import type { WorkspaceMemberApiResponse } from "../api/types";
+
+const MODULE_STATUSES = [
+  { id: "backlog", label: "Backlog" },
+  { id: "planned", label: "Planned" },
+  { id: "in_progress", label: "In Progress" },
+  { id: "paused", label: "Paused" },
+  { id: "completed", label: "Completed" },
+  { id: "cancelled", label: "Cancelled" },
+] as const;
+
+function formatDateRangeDisplay(start: string | null, end: string | null): string {
+  if (!start && !end) return "Start date → End date";
+  const fmt = (s: string) =>
+    new Date(s).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  if (start && end) return `${fmt(start)} → ${fmt(end)}`;
+  return start ? fmt(start) : end ? fmt(end) : "Start date → End date";
+}
+
+export interface CreateModuleModalProps {
+  open: boolean;
+  onClose: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  projectName: string;
+  onCreated?: (module: ModuleApiResponse) => void;
+}
+
+export function CreateModuleModal({
+  open,
+  onClose,
+  workspaceSlug,
+  projectId,
+  projectName,
+  onCreated,
+}: CreateModuleModalProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState<string | null>(null);
+  const [endDate, setEndDate] = useState<string | null>(null);
+  const [status, setStatus] = useState<string>("backlog");
+  const [leadId, setLeadId] = useState<string | null>(null);
+  const [memberIds, setMemberIds] = useState<string[]>([]);
+  const [dateModalOpen, setDateModalOpen] = useState(false);
+  const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
+  const [leadDropdownOpen, setLeadDropdownOpen] = useState(false);
+  const [membersDropdownOpen, setMembersDropdownOpen] = useState(false);
+  const [leadSearch, setLeadSearch] = useState("");
+  const [membersSearch, setMembersSearch] = useState("");
+  const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const leadRef = useRef<HTMLDivElement>(null);
+  const membersRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open || !workspaceSlug) return;
+    workspaceService
+      .listMembers(workspaceSlug)
+      .then((list) => setMembers(list ?? []))
+      .catch(() => setMembers([]));
+  }, [open, workspaceSlug]);
+
+  useEffect(() => {
+    if (!open) {
+      setTitle("");
+      setDescription("");
+      setStartDate(null);
+      setEndDate(null);
+      setStatus("backlog");
+      setLeadId(null);
+      setMemberIds([]);
+      setError(null);
+      setLeadSearch("");
+      setMembersSearch("");
+      setStatusDropdownOpen(false);
+      setLeadDropdownOpen(false);
+      setMembersDropdownOpen(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (statusRef.current?.contains(target)) return;
+      if (leadRef.current?.contains(target)) return;
+      if (membersRef.current?.contains(target)) return;
+      setStatusDropdownOpen(false);
+      setLeadDropdownOpen(false);
+      setMembersDropdownOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const q = (s: string) => s.trim().toLowerCase();
+  const filteredLead = members.filter((m) =>
+    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(q(leadSearch)),
+  );
+  const filteredMembers = members.filter((m) =>
+    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(q(membersSearch)),
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const created = await moduleService.create(workspaceSlug, projectId, {
+        name: title.trim(),
+        description: description.trim() || undefined,
+        status: status || "backlog",
+        start_date: startDate || undefined,
+        target_date: endDate || undefined,
+      });
+      onClose();
+      onCreated?.(created);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create module.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const statusLabel = MODULE_STATUSES.find((s) => s.id === status)?.label ?? status;
+  const leadMember = leadId ? members.find((m) => m.member_id === leadId) : null;
+  const selectedMembers = memberIds
+    .map((id) => members.find((m) => m.member_id === id))
+    .filter(Boolean) as WorkspaceMemberApiResponse[];
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onClose={onClose}
+        title="Create module"
+        className="max-w-lg"
+        footer={
+          <>
+            <Button type="button" variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              form="create-module-form"
+              disabled={submitting || !title.trim()}
+            >
+              Create Module
+            </Button>
+          </>
+        }
+      >
+        <div className="mb-3 text-sm text-[var(--txt-secondary)]">
+          {projectName}
+        </div>
+        <form
+          id="create-module-form"
+          onSubmit={handleSubmit}
+          className="space-y-4"
+        >
+          <Input
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+            autoFocus
+          />
+          <div>
+            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Description"
+              rows={3}
+              className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setDateModalOpen(true)}
+              className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            >
+              <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+                <CalendarIcon />
+              </span>
+              {formatDateRangeDisplay(startDate, endDate)}
+            </button>
+
+            <div className="relative" ref={statusRef}>
+              <button
+                type="button"
+                onClick={() =>
+                  setStatusDropdownOpen((o) => !o)
+                }
+                className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+              >
+                <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+                  <BacklogIcon />
+                </span>
+                {statusLabel}
+                <ChevronDownIcon />
+              </button>
+              {statusDropdownOpen && (
+                <div className="absolute left-0 top-full z-10 mt-1 min-w-[180px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]">
+                  {MODULE_STATUSES.map((opt) => (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      onClick={() => {
+                        setStatus(opt.id);
+                        setStatusDropdownOpen(false);
+                      }}
+                      className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                    >
+                      {opt.label}
+                      {status === opt.id && (
+                        <span className="text-[var(--txt-primary)]">
+                          <CheckIcon />
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="relative" ref={leadRef}>
+              <button
+                type="button"
+                onClick={() => setLeadDropdownOpen((o) => !o)}
+                className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+              >
+                {leadMember ? (
+                  <Avatar
+                    name={leadMember.member_display_name ?? leadMember.member_email ?? leadMember.member_id}
+                    src={getImageUrl(leadMember.member_avatar) ?? undefined}
+                    size="sm"
+                    className="h-6 w-6 text-xs"
+                  />
+                ) : (
+                  <LeadIcon />
+                )}
+                Lead
+                <ChevronDownIcon />
+              </button>
+              {leadDropdownOpen && (
+                <div className="absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5 shadow-[var(--shadow-raised)]">
+                  <div className="mb-1.5 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
+                    <SearchIcon />
+                    <input
+                      type="text"
+                      placeholder="Search"
+                      value={leadSearch}
+                      onChange={(e) => setLeadSearch(e.target.value)}
+                      className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                    />
+                  </div>
+                  <div className="max-h-48 overflow-y-auto">
+                    {filteredLead.map((m) => (
+                      <button
+                        key={m.member_id}
+                        type="button"
+                        onClick={() => {
+                          setLeadId(leadId === m.member_id ? null : m.member_id);
+                          setLeadDropdownOpen(false);
+                        }}
+                        className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      >
+                        <span className="flex items-center gap-2 truncate">
+                          <Avatar
+                            name={m.member_display_name ?? m.member_email ?? m.member_id}
+                            src={getImageUrl(m.member_avatar) ?? undefined}
+                            size="sm"
+                            className="h-6 w-6 text-xs"
+                          />
+                          {m.member_display_name?.trim() ?? m.member_email ?? m.member_id.slice(0, 8)}
+                        </span>
+                        {leadId === m.member_id && <CheckIcon />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="relative" ref={membersRef}>
+              <button
+                type="button"
+                onClick={() => setMembersDropdownOpen((o) => !o)}
+                className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+              >
+                <MembersIcon />
+                Members
+                {selectedMembers.length > 0 && (
+                  <span className="flex -space-x-1.5">
+                    {selectedMembers.map((m) => (
+                      <Avatar
+                        key={m.member_id}
+                        name={m.member_display_name ?? m.member_email ?? m.member_id}
+                        src={getImageUrl(m.member_avatar) ?? undefined}
+                        size="sm"
+                        className="h-6 w-6 border-2 border-[var(--bg-layer-2)] text-xs"
+                      />
+                    ))}
+                  </span>
+                )}
+                <ChevronDownIcon />
+              </button>
+              {membersDropdownOpen && (
+                <div className="absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5 shadow-[var(--shadow-raised)]">
+                  <div className="mb-1.5 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
+                    <SearchIcon />
+                    <input
+                      type="text"
+                      placeholder="Search"
+                      value={membersSearch}
+                      onChange={(e) => setMembersSearch(e.target.value)}
+                      className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                    />
+                  </div>
+                  <div className="max-h-48 overflow-y-auto">
+                    {filteredMembers.map((m) => {
+                      const selected = memberIds.includes(m.member_id);
+                      return (
+                        <button
+                          key={m.member_id}
+                          type="button"
+                          onClick={() => {
+                            setMemberIds(
+                              selected
+                                ? memberIds.filter((id) => id !== m.member_id)
+                                : [...memberIds, m.member_id],
+                            );
+                          }}
+                          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                        >
+                          <span className="flex items-center gap-2 truncate">
+                            <Avatar
+                              name={m.member_display_name ?? m.member_email ?? m.member_id}
+                              src={getImageUrl(m.member_avatar) ?? undefined}
+                              size="sm"
+                              className="h-6 w-6 text-xs"
+                            />
+                            {m.member_display_name?.trim() ?? m.member_email ?? m.member_id.slice(0, 8)}
+                          </span>
+                          {selected && <CheckIcon />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+          )}
+        </form>
+      </Modal>
+
+      <DateRangeModal
+        open={dateModalOpen}
+        onClose={() => setDateModalOpen(false)}
+        title="Start date → End date"
+        after={startDate}
+        before={endDate}
+        onApply={(after, before) => {
+          setStartDate(after);
+          setEndDate(before);
+          setDateModalOpen(false);
+        }}
+      />
+    </>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+function BacklogIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeDasharray="2 2" aria-hidden>
+      <rect width="18" height="18" x="3" y="3" rx="2" />
+    </svg>
+  );
+}
+function ChevronDownIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0 text-[var(--txt-icon-tertiary)]" aria-hidden>
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.35-4.35" />
+    </svg>
+  );
+}
+function LeadIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+      <circle cx="9" cy="7" r="4" />
+      <path d="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2" />
+      <line x1="16" y1="11" x2="22" y2="11" />
+      <line x1="19" y1="8" x2="19" y2="14" />
+    </svg>
+  );
+}
+function MembersIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}

--- a/ui/src/components/CreateModuleModal.tsx
+++ b/ui/src/components/CreateModuleModal.tsx
@@ -16,7 +16,10 @@ const MODULE_STATUSES = [
   { id: "cancelled", label: "Cancelled" },
 ] as const;
 
-function formatDateRangeDisplay(start: string | null, end: string | null): string {
+function formatDateRangeDisplay(
+  start: string | null,
+  end: string | null,
+): string {
   if (!start && !end) return "Start date → End date";
   const fmt = (s: string) =>
     new Date(s).toLocaleDateString("en-US", {
@@ -107,10 +110,14 @@ export function CreateModuleModal({
 
   const q = (s: string) => s.trim().toLowerCase();
   const filteredLead = members.filter((m) =>
-    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(q(leadSearch)),
+    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(
+      q(leadSearch),
+    ),
   );
   const filteredMembers = members.filter((m) =>
-    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(q(membersSearch)),
+    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(
+      q(membersSearch),
+    ),
   );
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -138,8 +145,11 @@ export function CreateModuleModal({
     }
   };
 
-  const statusLabel = MODULE_STATUSES.find((s) => s.id === status)?.label ?? status;
-  const leadMember = leadId ? members.find((m) => m.member_id === leadId) : null;
+  const statusLabel =
+    MODULE_STATUSES.find((s) => s.id === status)?.label ?? status;
+  const leadMember = leadId
+    ? members.find((m) => m.member_id === leadId)
+    : null;
   const selectedMembers = memberIds
     .map((id) => members.find((m) => m.member_id === id))
     .filter(Boolean) as WorkspaceMemberApiResponse[];
@@ -209,9 +219,7 @@ export function CreateModuleModal({
             <div className="relative" ref={statusRef}>
               <button
                 type="button"
-                onClick={() =>
-                  setStatusDropdownOpen((o) => !o)
-                }
+                onClick={() => setStatusDropdownOpen((o) => !o)}
                 className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
               >
                 <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
@@ -252,7 +260,11 @@ export function CreateModuleModal({
               >
                 {leadMember ? (
                   <Avatar
-                    name={leadMember.member_display_name ?? leadMember.member_email ?? leadMember.member_id}
+                    name={
+                      leadMember.member_display_name ??
+                      leadMember.member_email ??
+                      leadMember.member_id
+                    }
                     src={getImageUrl(leadMember.member_avatar) ?? undefined}
                     size="sm"
                     className="h-6 w-6 text-xs"
@@ -281,19 +293,27 @@ export function CreateModuleModal({
                         key={m.member_id}
                         type="button"
                         onClick={() => {
-                          setLeadId(leadId === m.member_id ? null : m.member_id);
+                          setLeadId(
+                            leadId === m.member_id ? null : m.member_id,
+                          );
                           setLeadDropdownOpen(false);
                         }}
                         className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
                       >
                         <span className="flex items-center gap-2 truncate">
                           <Avatar
-                            name={m.member_display_name ?? m.member_email ?? m.member_id}
+                            name={
+                              m.member_display_name ??
+                              m.member_email ??
+                              m.member_id
+                            }
                             src={getImageUrl(m.member_avatar) ?? undefined}
                             size="sm"
                             className="h-6 w-6 text-xs"
                           />
-                          {m.member_display_name?.trim() ?? m.member_email ?? m.member_id.slice(0, 8)}
+                          {m.member_display_name?.trim() ??
+                            m.member_email ??
+                            m.member_id.slice(0, 8)}
                         </span>
                         {leadId === m.member_id && <CheckIcon />}
                       </button>
@@ -316,7 +336,9 @@ export function CreateModuleModal({
                     {selectedMembers.map((m) => (
                       <Avatar
                         key={m.member_id}
-                        name={m.member_display_name ?? m.member_email ?? m.member_id}
+                        name={
+                          m.member_display_name ?? m.member_email ?? m.member_id
+                        }
                         src={getImageUrl(m.member_avatar) ?? undefined}
                         size="sm"
                         className="h-6 w-6 border-2 border-[var(--bg-layer-2)] text-xs"
@@ -356,12 +378,18 @@ export function CreateModuleModal({
                         >
                           <span className="flex items-center gap-2 truncate">
                             <Avatar
-                              name={m.member_display_name ?? m.member_email ?? m.member_id}
+                              name={
+                                m.member_display_name ??
+                                m.member_email ??
+                                m.member_id
+                              }
                               src={getImageUrl(m.member_avatar) ?? undefined}
                               size="sm"
                               className="h-6 w-6 text-xs"
                             />
-                            {m.member_display_name?.trim() ?? m.member_email ?? m.member_id.slice(0, 8)}
+                            {m.member_display_name?.trim() ??
+                              m.member_email ??
+                              m.member_id.slice(0, 8)}
                           </span>
                           {selected && <CheckIcon />}
                         </button>
@@ -397,7 +425,15 @@ export function CreateModuleModal({
 
 function CalendarIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden
+    >
       <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
       <line x1="16" y1="2" x2="16" y2="6" />
       <line x1="8" y1="2" x2="8" y2="6" />
@@ -407,28 +443,62 @@ function CalendarIcon() {
 }
 function BacklogIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeDasharray="2 2" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeDasharray="2 2"
+      aria-hidden
+    >
       <rect width="18" height="18" x="3" y="3" rx="2" />
     </svg>
   );
 }
 function ChevronDownIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden
+    >
       <path d="m6 9 6 6 6-6" />
     </svg>
   );
 }
 function CheckIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden
+    >
       <polyline points="20 6 9 17 4 12" />
     </svg>
   );
 }
 function SearchIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0 text-[var(--txt-icon-tertiary)]" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="shrink-0 text-[var(--txt-icon-tertiary)]"
+      aria-hidden
+    >
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.35-4.35" />
     </svg>
@@ -436,7 +506,16 @@ function SearchIcon() {
 }
 function LeadIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="text-[var(--txt-icon-tertiary)]"
+      aria-hidden
+    >
       <circle cx="9" cy="7" r="4" />
       <path d="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2" />
       <line x1="16" y1="11" x2="22" y2="11" />
@@ -446,7 +525,16 @@ function LeadIcon() {
 }
 function MembersIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="text-[var(--txt-icon-tertiary)]"
+      aria-hidden
+    >
       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="9" cy="7" r="4" />
       <path d="M23 21v-2a4 4 0 0 0-3-3.87" />

--- a/ui/src/components/CreateModuleModal.tsx
+++ b/ui/src/components/CreateModuleModal.tsx
@@ -176,9 +176,7 @@ export function CreateModuleModal({
           </>
         }
       >
-        <div className="mb-3 text-sm text-(--txt-secondary)">
-          {projectName}
-        </div>
+        <div className="mb-3 text-sm text-(--txt-secondary)">{projectName}</div>
         <form
           id="create-module-form"
           onSubmit={handleSubmit}

--- a/ui/src/components/CreateModuleModal.tsx
+++ b/ui/src/components/CreateModuleModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+﻿import { useState, useEffect, useRef } from "react";
 import { Modal, Button, Input, Avatar } from "./ui";
 import { DateRangeModal } from "./workspace-views/DateRangeModal";
 import { getImageUrl } from "../lib/utils";
@@ -176,7 +176,7 @@ export function CreateModuleModal({
           </>
         }
       >
-        <div className="mb-3 text-sm text-[var(--txt-secondary)]">
+        <div className="mb-3 text-sm text-(--txt-secondary)">
           {projectName}
         </div>
         <form
@@ -192,7 +192,7 @@ export function CreateModuleModal({
             autoFocus
           />
           <div>
-            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+            <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
               Description
             </label>
             <textarea
@@ -200,7 +200,7 @@ export function CreateModuleModal({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Description"
               rows={3}
-              className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
             />
           </div>
 
@@ -208,9 +208,9 @@ export function CreateModuleModal({
             <button
               type="button"
               onClick={() => setDateModalOpen(true)}
-              className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+              className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
             >
-              <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+              <span className="text-(--txt-icon-tertiary)" aria-hidden>
                 <CalendarIcon />
               </span>
               {formatDateRangeDisplay(startDate, endDate)}
@@ -220,16 +220,16 @@ export function CreateModuleModal({
               <button
                 type="button"
                 onClick={() => setStatusDropdownOpen((o) => !o)}
-                className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+                className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
               >
-                <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+                <span className="text-(--txt-icon-tertiary)" aria-hidden>
                   <BacklogIcon />
                 </span>
                 {statusLabel}
                 <ChevronDownIcon />
               </button>
               {statusDropdownOpen && (
-                <div className="absolute left-0 top-full z-10 mt-1 min-w-[180px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]">
+                <div className="absolute left-0 top-full z-10 mt-1 min-w-[180px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
                   {MODULE_STATUSES.map((opt) => (
                     <button
                       key={opt.id}
@@ -238,11 +238,11 @@ export function CreateModuleModal({
                         setStatus(opt.id);
                         setStatusDropdownOpen(false);
                       }}
-                      className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {opt.label}
                       {status === opt.id && (
-                        <span className="text-[var(--txt-primary)]">
+                        <span className="text-(--txt-primary)">
                           <CheckIcon />
                         </span>
                       )}
@@ -256,7 +256,7 @@ export function CreateModuleModal({
               <button
                 type="button"
                 onClick={() => setLeadDropdownOpen((o) => !o)}
-                className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+                className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
               >
                 {leadMember ? (
                   <Avatar
@@ -276,15 +276,15 @@ export function CreateModuleModal({
                 <ChevronDownIcon />
               </button>
               {leadDropdownOpen && (
-                <div className="absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5 shadow-[var(--shadow-raised)]">
-                  <div className="mb-1.5 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
+                <div className="absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-1.5 shadow-(--shadow-raised)">
+                  <div className="mb-1.5 flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
                     <SearchIcon />
                     <input
                       type="text"
                       placeholder="Search"
                       value={leadSearch}
                       onChange={(e) => setLeadSearch(e.target.value)}
-                      className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                      className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                     />
                   </div>
                   <div className="max-h-48 overflow-y-auto">
@@ -298,7 +298,7 @@ export function CreateModuleModal({
                           );
                           setLeadDropdownOpen(false);
                         }}
-                        className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                        className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                       >
                         <span className="flex items-center gap-2 truncate">
                           <Avatar
@@ -327,7 +327,7 @@ export function CreateModuleModal({
               <button
                 type="button"
                 onClick={() => setMembersDropdownOpen((o) => !o)}
-                className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+                className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
               >
                 <MembersIcon />
                 Members
@@ -341,7 +341,7 @@ export function CreateModuleModal({
                         }
                         src={getImageUrl(m.member_avatar) ?? undefined}
                         size="sm"
-                        className="h-6 w-6 border-2 border-[var(--bg-layer-2)] text-xs"
+                        className="h-6 w-6 border-2 border-(--bg-layer-2) text-xs"
                       />
                     ))}
                   </span>
@@ -349,15 +349,15 @@ export function CreateModuleModal({
                 <ChevronDownIcon />
               </button>
               {membersDropdownOpen && (
-                <div className="absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5 shadow-[var(--shadow-raised)]">
-                  <div className="mb-1.5 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
+                <div className="absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-1.5 shadow-(--shadow-raised)">
+                  <div className="mb-1.5 flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
                     <SearchIcon />
                     <input
                       type="text"
                       placeholder="Search"
                       value={membersSearch}
                       onChange={(e) => setMembersSearch(e.target.value)}
-                      className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                      className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                     />
                   </div>
                   <div className="max-h-48 overflow-y-auto">
@@ -374,7 +374,7 @@ export function CreateModuleModal({
                                 : [...memberIds, m.member_id],
                             );
                           }}
-                          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                         >
                           <span className="flex items-center gap-2 truncate">
                             <Avatar
@@ -402,7 +402,7 @@ export function CreateModuleModal({
           </div>
 
           {error && (
-            <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+            <p className="text-sm text-(--txt-danger-primary)">{error}</p>
           )}
         </form>
       </Modal>
@@ -496,7 +496,7 @@ function SearchIcon() {
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
-      className="shrink-0 text-[var(--txt-icon-tertiary)]"
+      className="shrink-0 text-(--txt-icon-tertiary)"
       aria-hidden
     >
       <circle cx="11" cy="11" r="8" />
@@ -513,7 +513,7 @@ function LeadIcon() {
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
-      className="text-[var(--txt-icon-tertiary)]"
+      className="text-(--txt-icon-tertiary)"
       aria-hidden
     >
       <circle cx="9" cy="7" r="4" />
@@ -532,7 +532,7 @@ function MembersIcon() {
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
-      className="text-[var(--txt-icon-tertiary)]"
+      className="text-(--txt-icon-tertiary)"
       aria-hidden
     >
       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />

--- a/ui/src/components/CreateProjectModal.tsx
+++ b/ui/src/components/CreateProjectModal.tsx
@@ -287,9 +287,7 @@ export function CreateProjectModal({
           </div>
 
           {error && (
-            <p className="mt-3 text-sm text-(--txt-danger-primary)">
-              {error}
-            </p>
+            <p className="mt-3 text-sm text-(--txt-danger-primary)">{error}</p>
           )}
 
           {/* Actions */}

--- a/ui/src/components/CreateProjectModal.tsx
+++ b/ui/src/components/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button, Input } from "./ui";
 import { CoverImageModal } from "./CoverImageModal";
@@ -183,12 +183,12 @@ export function CreateProjectModal({
         Create project
       </h2>
       <div
-        className="absolute inset-0 bg-[var(--bg-backdrop)]"
+        className="absolute inset-0 bg-(--bg-backdrop)"
         onClick={handleClose}
         aria-hidden
       />
       <div
-        className="relative z-10 w-full max-w-2xl overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-overlay)]"
+        className="relative z-10 w-full max-w-2xl overflow-hidden rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay)"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Cover + Close */}
@@ -215,7 +215,7 @@ export function CreateProjectModal({
           <button
             type="button"
             onClick={() => setIconModalOpen(true)}
-            className="flex size-12 items-center justify-center rounded-lg border-2 border-[var(--bg-surface-1)] bg-[var(--bg-layer-2)] text-2xl shadow-sm hover:bg-[var(--bg-layer-transparent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--border-strong)]"
+            className="flex size-12 items-center justify-center rounded-lg border-2 border-(--bg-surface-1) bg-(--bg-layer-2) text-2xl shadow-sm hover:bg-(--bg-layer-transparent-hover) focus:outline-none focus:ring-2 focus:ring-(--border-strong)"
             aria-label="Change project icon"
           >
             <ProjectIconDisplay
@@ -253,7 +253,7 @@ export function CreateProjectModal({
                 className="w-full pr-9"
               />
               <span
-                className="absolute right-3 top-9 text-[var(--txt-icon-tertiary)]"
+                className="absolute right-3 top-9 text-(--txt-icon-tertiary)"
                 title="Short identifier used in issue IDs (e.g. PROJ-123)"
               >
                 <IconInfo />
@@ -267,7 +267,7 @@ export function CreateProjectModal({
               placeholder="Description"
               rows={3}
               disabled={submitting}
-              className="min-h-[72px] w-full resize-y rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:ring-2 focus:ring-[var(--border-strong)]"
+              className="min-h-[72px] w-full resize-y rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:ring-2 focus:ring-(--border-strong)"
             />
           </div>
 
@@ -287,13 +287,13 @@ export function CreateProjectModal({
           </div>
 
           {error && (
-            <p className="mt-3 text-sm text-[var(--txt-danger-primary)]">
+            <p className="mt-3 text-sm text-(--txt-danger-primary)">
               {error}
             </p>
           )}
 
           {/* Actions */}
-          <div className="mt-6 flex justify-end gap-2 border-t border-[var(--border-subtle)] pt-4">
+          <div className="mt-6 flex justify-end gap-2 border-t border-(--border-subtle) pt-4">
             <Button
               type="button"
               variant="secondary"

--- a/ui/src/components/CreateWorkItemModal.tsx
+++ b/ui/src/components/CreateWorkItemModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button, Input } from "./ui";
 import { Dropdown, DatePickerTrigger, SelectParentModal } from "./work-item";
@@ -496,18 +496,18 @@ export function CreateWorkItemModal({
         aria-labelledby="create-work-item-title"
       >
         <div
-          className="absolute inset-0 bg-[var(--bg-backdrop)]"
+          className="absolute inset-0 bg-(--bg-backdrop)"
           onClick={onClose}
           aria-hidden
         />
         <div
-          className="relative z-10 w-full max-w-4xl rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-overlay)]"
+          className="relative z-10 w-full max-w-4xl rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay)"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="px-5 pt-5 pb-2">
             <h2
               id="create-work-item-title"
-              className="text-xl font-bold text-[var(--txt-primary)]"
+              className="text-xl font-bold text-(--txt-primary)"
             >
               Create new work item
             </h2>
@@ -525,15 +525,15 @@ export function CreateWorkItemModal({
                   )
                 }
                 displayValue={selectedProject?.name ?? ""}
-                panelClassName="flex min-w-[160px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+                panelClassName="flex min-w-[160px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
-                <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
                   <input
                     type="text"
                     placeholder="Search..."
                     value={projectSearch}
                     onChange={(e) => setProjectSearch(e.target.value)}
-                    className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -545,7 +545,7 @@ export function CreateWorkItemModal({
                         setProjectId(p.id);
                         setOpenDropdown(null);
                       }}
-                      className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {p.name}
                     </button>
@@ -560,14 +560,14 @@ export function CreateWorkItemModal({
               placeholder="Title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="mb-3 border-[var(--border-subtle)]"
+              className="mb-3 border-(--border-subtle)"
             />
             <textarea
               placeholder="Click to add description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={5}
-              className="mb-4 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+              className="mb-4 w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
             />
             <div className="flex flex-nowrap items-center gap-1.5 overflow-x-auto pb-1">
               <Dropdown
@@ -578,15 +578,15 @@ export function CreateWorkItemModal({
                 icon={<IconCog />}
                 displayValue={stateName || "Backlog"}
                 compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
-                <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
                   <input
                     type="text"
                     placeholder="Search..."
                     value={stateSearch}
                     onChange={(e) => setStateSearch(e.target.value)}
-                    className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -598,7 +598,7 @@ export function CreateWorkItemModal({
                         setStateId(s.id);
                         setOpenDropdown(null);
                       }}
-                      className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {s.name}
                     </button>
@@ -617,7 +617,7 @@ export function CreateWorkItemModal({
                     : priority.charAt(0).toUpperCase() + priority.slice(1)
                 }
                 compact
-                panelClassName="max-h-52 min-w-[110px] overflow-auto rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-0.5 shadow-[var(--shadow-raised)] [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs"
+                panelClassName="max-h-52 min-w-[110px] overflow-auto rounded border border-(--border-subtle) bg-(--bg-surface-1) py-0.5 shadow-(--shadow-raised) [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs"
               >
                 {PRIORITIES.map((p) => (
                   <button
@@ -627,7 +627,7 @@ export function CreateWorkItemModal({
                       setPriority(p);
                       setOpenDropdown(null);
                     }}
-                    className="w-full text-left capitalize text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                    className="w-full text-left capitalize text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                   >
                     {p}
                   </button>
@@ -641,15 +641,15 @@ export function CreateWorkItemModal({
                 icon={<IconUsers />}
                 displayValue={assigneeNames || "Add assignees"}
                 compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
-                <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
                   <input
                     type="text"
                     placeholder="Search..."
                     value={assigneeSearch}
                     onChange={(e) => setAssigneeSearch(e.target.value)}
-                    className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -659,7 +659,7 @@ export function CreateWorkItemModal({
                       setAssigneeIds([]);
                       setOpenDropdown(null);
                     }}
-                    className="w-full text-left text-[var(--txt-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+                    className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
                   >
                     No assignee
                   </button>
@@ -674,7 +674,7 @@ export function CreateWorkItemModal({
                             : [...prev, u.id],
                         )
                       }
-                      className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {u.name} {assigneeIds.includes(u.id) ? "✓" : ""}
                     </button>
@@ -689,15 +689,15 @@ export function CreateWorkItemModal({
                 icon={<IconTag />}
                 displayValue={labelNames}
                 compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
-                <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
                   <input
                     type="text"
                     placeholder="Search..."
                     value={labelSearch}
                     onChange={(e) => setLabelSearch(e.target.value)}
-                    className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -708,7 +708,7 @@ export function CreateWorkItemModal({
                       onClick={() => {
                         toggleLabel(l.id);
                       }}
-                      className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {l.name}
                     </button>
@@ -720,12 +720,12 @@ export function CreateWorkItemModal({
                         labelSearch.trim().toLowerCase(),
                     ) && (
                       <>
-                        <div className="my-1 border-t border-[var(--border-subtle)]" />
+                        <div className="my-1 border-t border-(--border-subtle)" />
                         <button
                           type="button"
                           onClick={handleCreateLabel}
                           disabled={createLabelLoading}
-                          className="w-full text-left text-[var(--brand-default)] hover:bg-[var(--bg-layer-1-hover)] disabled:opacity-50"
+                          className="w-full text-left text-(--brand-default) hover:bg-(--bg-layer-1-hover) disabled:opacity-50"
                         >
                           {createLabelLoading
                             ? "Creating…"
@@ -762,15 +762,15 @@ export function CreateWorkItemModal({
                 icon={<IconCycle />}
                 displayValue={cycleName || "No cycle"}
                 compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
-                <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
                   <input
                     type="text"
                     placeholder="Search..."
                     value={cycleSearch}
                     onChange={(e) => setCycleSearch(e.target.value)}
-                    className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -780,7 +780,7 @@ export function CreateWorkItemModal({
                       setCycleId(null);
                       setOpenDropdown(null);
                     }}
-                    className="w-full text-left text-[var(--txt-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+                    className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
                   >
                     No cycle
                   </button>
@@ -792,7 +792,7 @@ export function CreateWorkItemModal({
                         setCycleId(c.id);
                         setOpenDropdown(null);
                       }}
-                      className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {c.name}
                     </button>
@@ -807,15 +807,15 @@ export function CreateWorkItemModal({
                 icon={<IconGrid />}
                 displayValue={moduleName ?? ""}
                 compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
-                <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
                   <input
                     type="text"
                     placeholder="Search..."
                     value={moduleSearch}
                     onChange={(e) => setModuleSearch(e.target.value)}
-                    className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -825,7 +825,7 @@ export function CreateWorkItemModal({
                       setModuleId(null);
                       setOpenDropdown(null);
                     }}
-                    className="w-full text-left text-[var(--txt-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+                    className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
                   >
                     No module
                   </button>
@@ -837,7 +837,7 @@ export function CreateWorkItemModal({
                         setModuleId(m.id);
                         setOpenDropdown(null);
                       }}
-                      className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                     >
                       {m.name}
                     </button>
@@ -847,9 +847,9 @@ export function CreateWorkItemModal({
               <button
                 type="button"
                 onClick={() => setParentModalOpen(true)}
-                className="inline-flex min-w-0 items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-1.5 py-1 text-xs text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)] [&_svg]:size-3"
+                className="inline-flex min-w-0 items-center gap-1 rounded border border-(--border-subtle) bg-(--bg-layer-2) px-1.5 py-1 text-xs text-(--txt-secondary) hover:bg-(--bg-layer-2-hover) [&_svg]:size-3"
               >
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconLink2 />
                 </span>
                 <span className="truncate">{parentTitle || "Add parent"}</span>
@@ -857,10 +857,10 @@ export function CreateWorkItemModal({
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border-subtle)] px-5 py-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-(--border-subtle) px-5 py-4">
             <div className="flex flex-col gap-1">
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-[var(--txt-secondary)]">
-                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform after:content-[''] has-[:checked]:border-[var(--brand-default)] has-[:checked]:bg-[var(--brand-default)] has-[:checked]:after:translate-x-4">
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-(--txt-secondary)">
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full border border-(--border-subtle) bg-(--bg-layer-2) transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform after:content-[''] has-[:checked]:border-(--brand-default) has-[:checked]:bg-(--brand-default) has-[:checked]:after:translate-x-4">
                   <input
                     type="checkbox"
                     checked={createMore}
@@ -871,7 +871,7 @@ export function CreateWorkItemModal({
                 Create more
               </label>
               {createError && (
-                <p className="text-sm text-[var(--txt-danger-primary)]">
+                <p className="text-sm text-(--txt-danger-primary)">
                   {createError}
                 </p>
               )}

--- a/ui/src/components/CreateWorkItemModal.tsx
+++ b/ui/src/components/CreateWorkItemModal.tsx
@@ -215,7 +215,9 @@ export function CreateWorkItemModal({
   const [startDate, setStartDate] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [cycleId, setCycleId] = useState<string | null>(null);
-  const [moduleId, setModuleId] = useState<string | null>(defaultModuleId ?? null);
+  const [moduleId, setModuleId] = useState<string | null>(
+    defaultModuleId ?? null,
+  );
   const [parentId, setParentId] = useState<string | null>(null);
   const [parentModalOpen, setParentModalOpen] = useState(false);
 

--- a/ui/src/components/CreateWorkItemModal.tsx
+++ b/ui/src/components/CreateWorkItemModal.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button, Input } from "./ui";
 import { Dropdown, DatePickerTrigger, SelectParentModal } from "./work-item";
@@ -170,6 +170,7 @@ export interface CreateWorkItemModalProps {
   workspaceSlug: string;
   projects: ProjectApiResponse[];
   defaultProjectId?: string;
+  defaultModuleId?: string | null;
   createError?: string | null;
   onSave?: (data: {
     title: string;
@@ -194,6 +195,7 @@ export function CreateWorkItemModal({
   workspaceSlug,
   projects,
   defaultProjectId,
+  defaultModuleId,
   createError,
   onSave,
 }: CreateWorkItemModalProps) {
@@ -213,7 +215,7 @@ export function CreateWorkItemModal({
   const [startDate, setStartDate] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [cycleId, setCycleId] = useState<string | null>(null);
-  const [moduleId, setModuleId] = useState<string | null>(null);
+  const [moduleId, setModuleId] = useState<string | null>(defaultModuleId ?? null);
   const [parentId, setParentId] = useState<string | null>(null);
   const [parentModalOpen, setParentModalOpen] = useState(false);
 
@@ -374,12 +376,12 @@ export function CreateWorkItemModal({
       setStartDate("");
       setDueDate("");
       setCycleId(null);
-      setModuleId(null);
+      setModuleId(defaultModuleId ?? null);
       setParentId(null);
       setOpenDropdown(null);
       setParentModalOpen(false);
     }
-  }, [open, defaultProjectId, projects]);
+  }, [open, defaultProjectId, defaultModuleId, projects]);
 
   useEffect(() => {
     if (!open) return;

--- a/ui/src/components/ProjectIconModal.tsx
+++ b/ui/src/components/ProjectIconModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+﻿import { useState, useMemo, useEffect } from "react";
 import { Modal } from "./ui";
 
 const EMOJI_LIST = [
@@ -218,7 +218,7 @@ export function ProjectIconModal({
     <button
       type="button"
       onClick={onClose}
-      className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-1.5 text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2-hover)]"
+      className="rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-1.5 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover)"
     >
       Cancel
     </button>
@@ -232,14 +232,14 @@ export function ProjectIconModal({
       footer={footer}
       className="max-w-md"
     >
-      <div className="flex gap-2 border-b border-[var(--border-subtle)] pb-3 mb-3">
+      <div className="flex gap-2 border-b border-(--border-subtle) pb-3 mb-3">
         <button
           type="button"
           onClick={() => setTab(TAB_EMOJI)}
-          className={`rounded-[var(--radius-md)] px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`rounded-(--radius-md) px-3 py-1.5 text-sm font-medium transition-colors ${
             tab === TAB_EMOJI
-              ? "bg-[var(--brand-default)] text-white"
-              : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+              ? "bg-(--brand-default) text-white"
+              : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover)"
           }`}
         >
           Emoji
@@ -247,10 +247,10 @@ export function ProjectIconModal({
         <button
           type="button"
           onClick={() => setTab(TAB_ICON)}
-          className={`rounded-[var(--radius-md)] px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`rounded-(--radius-md) px-3 py-1.5 text-sm font-medium transition-colors ${
             tab === TAB_ICON
-              ? "bg-[var(--brand-default)] text-white"
-              : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+              ? "bg-(--brand-default) text-white"
+              : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover)"
           }`}
         >
           Icon
@@ -264,7 +264,7 @@ export function ProjectIconModal({
             value={emojiSearch}
             onChange={(e) => setEmojiSearch(e.target.value)}
             placeholder="Search"
-            className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+            className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
           />
           <div className="grid grid-cols-8 gap-1.5 max-h-48 overflow-y-auto">
             {filteredEmojis.map((emoji) => (
@@ -272,7 +272,7 @@ export function ProjectIconModal({
                 type="button"
                 key={emoji}
                 onClick={() => handleEmojiSelect(emoji)}
-                className="flex size-9 items-center justify-center rounded-[var(--radius-md)] text-xl hover:bg-[var(--bg-layer-transparent-hover)]"
+                className="flex size-9 items-center justify-center rounded-(--radius-md) text-xl hover:bg-(--bg-layer-transparent-hover)"
                 title={emoji}
               >
                 {emoji}
@@ -284,7 +284,7 @@ export function ProjectIconModal({
 
       {tab === TAB_ICON && (
         <div className="space-y-3">
-          <p className="text-xs text-[var(--txt-tertiary)]">Color</p>
+          <p className="text-xs text-(--txt-tertiary)">Color</p>
           <div className="flex flex-wrap gap-2">
             {ICON_COLORS.map((c) => (
               <button
@@ -305,14 +305,14 @@ export function ProjectIconModal({
               />
             ))}
           </div>
-          <p className="text-xs text-[var(--txt-tertiary)]">Choose an icon</p>
+          <p className="text-xs text-(--txt-tertiary)">Choose an icon</p>
           <div className="grid grid-cols-6 gap-2 max-h-48 overflow-y-auto">
             {ICON_NAMES.map((name) => (
               <button
                 type="button"
                 key={name}
                 onClick={() => handleIconSelect(name)}
-                className="flex size-10 items-center justify-center rounded-[var(--radius-md)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                className="flex size-10 items-center justify-center rounded-(--radius-md) hover:bg-(--bg-layer-transparent-hover)"
                 title={name}
               >
                 <IconSvg name={name} color={iconColor} size={20} />

--- a/ui/src/components/ProjectLeadSelect.tsx
+++ b/ui/src/components/ProjectLeadSelect.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react";
+﻿import type { ChangeEvent } from "react";
 import type { WorkspaceMemberApiResponse } from "../api/types";
 
 interface ProjectLeadSelectProps {
@@ -34,7 +34,7 @@ export function ProjectLeadSelect({
 
   return (
     <div className="space-y-1">
-      <p className="text-sm font-medium text-[var(--txt-primary)]">
+      <p className="text-sm font-medium text-(--txt-primary)">
         Project Lead
       </p>
       <div className="relative min-w-[180px]">
@@ -42,7 +42,7 @@ export function ProjectLeadSelect({
           value={value ?? ""}
           onChange={handleChange}
           disabled={disabled}
-          className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+          className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
         >
           <option value="">Select</option>
           {members.map((m) => (

--- a/ui/src/components/ProjectLeadSelect.tsx
+++ b/ui/src/components/ProjectLeadSelect.tsx
@@ -34,9 +34,7 @@ export function ProjectLeadSelect({
 
   return (
     <div className="space-y-1">
-      <p className="text-sm font-medium text-(--txt-primary)">
-        Project Lead
-      </p>
+      <p className="text-sm font-medium text-(--txt-primary)">Project Lead</p>
       <div className="relative min-w-[180px]">
         <select
           value={value ?? ""}

--- a/ui/src/components/ProjectNetworkSelect.tsx
+++ b/ui/src/components/ProjectNetworkSelect.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react";
+﻿import type { ChangeEvent } from "react";
 
 interface ProjectNetworkSelectProps {
   value: string;
@@ -18,7 +18,7 @@ export function ProjectNetworkSelect({
 
   return (
     <div>
-      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+      <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
         Network
       </label>
       <div className="relative">
@@ -26,7 +26,7 @@ export function ProjectNetworkSelect({
           value={value}
           onChange={handleChange}
           disabled={disabled}
-          className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+          className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
         >
           <option value="public">Public</option>
           <option value="private">Private</option>

--- a/ui/src/components/RootRedirect.tsx
+++ b/ui/src/components/RootRedirect.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { instanceService } from "../services/instanceService";
 import { workspaceService } from "../services/workspaceService";
 
 const PageFallback = () => (
-  <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+  <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
     Loading...
   </div>
 );
@@ -56,10 +56,10 @@ export function RootRedirect() {
   if (noWorkspaces) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-[var(--txt-secondary)]">
+        <p className="text-(--txt-secondary)">
           You don’t have any workspaces yet.
         </p>
-        <p className="text-sm text-[var(--txt-tertiary)]">
+        <p className="text-sm text-(--txt-tertiary)">
           Create one from instance admin or use the API to get started.
         </p>
       </div>

--- a/ui/src/components/SetupGate.tsx
+++ b/ui/src/components/SetupGate.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { instanceService } from "../services/instanceService";
 
 const PageFallback = () => (
-  <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+  <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
     Loading...
   </div>
 );

--- a/ui/src/components/UploadImageModal.tsx
+++ b/ui/src/components/UploadImageModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+﻿import { useCallback, useEffect, useState } from "react";
 import { Button, Modal } from "./ui";
 import { uploadImage } from "../services/uploadService";
 
@@ -93,7 +93,7 @@ export function UploadImageModal({
       {preview && (
         <Button
           variant="secondary"
-          className="text-[var(--txt-danger-primary)]"
+          className="text-(--txt-danger-primary)"
           onClick={handleRemove}
         >
           Remove
@@ -121,13 +121,13 @@ export function UploadImageModal({
           <div
             onDrop={handleDrop}
             onDragOver={handleDragOver}
-            className="flex flex-col items-center justify-center rounded-[var(--radius-md)] border-2 border-dashed border-[var(--border-subtle)] bg-[var(--bg-layer-2)] py-12 px-4"
+            className="flex flex-col items-center justify-center rounded-(--radius-md) border-2 border-dashed border-(--border-subtle) bg-(--bg-layer-2) py-12 px-4"
           >
-            <p className="text-sm text-[var(--txt-secondary)] mb-2">
+            <p className="text-sm text-(--txt-secondary) mb-2">
               Drag & drop image here
             </p>
             <label className="cursor-pointer">
-              <span className="text-sm font-medium text-[var(--txt-accent-primary)] hover:underline">
+              <span className="text-sm font-medium text-(--txt-accent-primary) hover:underline">
                 Browse
               </span>
               <input
@@ -139,7 +139,7 @@ export function UploadImageModal({
             </label>
           </div>
         ) : (
-          <div className="relative rounded-[var(--radius-md)] border border-[var(--border-subtle)] overflow-hidden bg-[var(--bg-layer-2)]">
+          <div className="relative rounded-(--radius-md) border border-(--border-subtle) overflow-hidden bg-(--bg-layer-2)">
             <img
               src={preview}
               alt="Preview"
@@ -149,18 +149,18 @@ export function UploadImageModal({
               <button
                 type="button"
                 onClick={handleRemove}
-                className="text-xs font-medium text-[var(--txt-accent-primary)] hover:underline"
+                className="text-xs font-medium text-(--txt-accent-primary) hover:underline"
               >
                 Edit
               </button>
             </div>
           </div>
         )}
-        <p className="text-xs text-[var(--txt-tertiary)]">
+        <p className="text-xs text-(--txt-tertiary)">
           File formats supported: .jpeg, .jpg, .png, .webp
         </p>
         {error && (
-          <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+          <p className="text-sm text-(--txt-danger-primary)">{error}</p>
         )}
       </div>
     </Modal>

--- a/ui/src/components/instance-admin/CreateWorkspaceSetupHint.tsx
+++ b/ui/src/components/instance-admin/CreateWorkspaceSetupHint.tsx
@@ -1,4 +1,4 @@
-import { Button } from "../ui";
+﻿import { Button } from "../ui";
 
 const IconWorkspace = () => (
   <svg
@@ -27,16 +27,16 @@ export function CreateWorkspaceSetupHint({
 }: CreateWorkspaceSetupHintProps) {
   return (
     <div
-      className="fixed bottom-6 right-6 z-50 w-full max-w-sm rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4 shadow-[var(--shadow-overlay)]"
+      className="fixed bottom-6 right-6 z-50 w-full max-w-sm rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) p-4 shadow-(--shadow-overlay)"
       role="dialog"
       aria-label="Create workspace"
     >
       <div className="flex gap-3">
         <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-semibold text-[var(--txt-primary)]">
+          <h3 className="text-sm font-semibold text-(--txt-primary)">
             Create workspace
           </h3>
-          <p className="mt-1 text-xs text-[var(--txt-secondary)]">
+          <p className="mt-1 text-xs text-(--txt-secondary)">
             Instance setup is complete. Welcome to your Devlane instance. Start
             your journey by creating your first workspace.
           </p>
@@ -54,7 +54,7 @@ export function CreateWorkspaceSetupHint({
             </Button>
           </div>
         </div>
-        <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-(--bg-accent-subtle) text-(--txt-accent-primary)">
           <IconWorkspace />
         </span>
       </div>

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router-dom";
+﻿import { Outlet, useLocation } from "react-router-dom";
 import { WorkspaceViewsStateProvider } from "../../contexts/WorkspaceViewsStateContext";
 import { PageHeader } from "./PageHeader";
 import { Sidebar } from "./Sidebar";
@@ -9,13 +9,13 @@ export function AppShell() {
 
   return (
     <WorkspaceViewsStateProvider>
-      <div className="flex h-screen flex-col overflow-hidden bg-[var(--bg-screen)] p-3">
-        <div className="flex min-h-0 flex-1 overflow-hidden rounded-[var(--radius-lg)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-container)]">
+      <div className="flex h-screen flex-col overflow-hidden bg-(--bg-screen) p-3">
+        <div className="flex min-h-0 flex-1 overflow-hidden rounded-(--radius-lg) bg-(--bg-surface-1) shadow-(--shadow-container)">
           <Sidebar />
-          <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--bg-canvas)]">
+          <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-(--bg-canvas)">
             <PageHeader />
             <div
-              className={`main-content-scroll min-h-0 flex-1 overflow-auto p-[var(--padding-page)] ${isViewsRoute ? "pl-0" : ""}`}
+              className={`main-content-scroll min-h-0 flex-1 overflow-auto p-(--padding-page) ${isViewsRoute ? "pl-0" : ""}`}
             >
               <Outlet />
             </div>

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -1,4 +1,5 @@
-﻿import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
+import { ModulesFilterProvider } from "../../contexts/ModulesFilterContext";
 import { WorkspaceViewsStateProvider } from "../../contexts/WorkspaceViewsStateContext";
 import { PageHeader } from "./PageHeader";
 import { Sidebar } from "./Sidebar";
@@ -9,19 +10,21 @@ export function AppShell() {
 
   return (
     <WorkspaceViewsStateProvider>
-      <div className="flex h-screen flex-col overflow-hidden bg-(--bg-screen) p-3">
-        <div className="flex min-h-0 flex-1 overflow-hidden rounded-(--radius-lg) bg-(--bg-surface-1) shadow-(--shadow-container)">
-          <Sidebar />
-          <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-(--bg-canvas)">
-            <PageHeader />
-            <div
-              className={`main-content-scroll min-h-0 flex-1 overflow-auto p-(--padding-page) ${isViewsRoute ? "pl-0" : ""}`}
-            >
-              <Outlet />
-            </div>
-          </main>
+      <ModulesFilterProvider>
+        <div className="flex h-screen flex-col overflow-hidden bg-(--bg-screen) p-3">
+          <div className="flex min-h-0 flex-1 overflow-hidden rounded-(--radius-lg) bg-(--bg-surface-1) shadow-(--shadow-container)">
+            <Sidebar />
+            <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-(--bg-canvas)">
+              <PageHeader />
+              <div
+                className={`main-content-scroll min-h-0 flex-1 overflow-auto p-(--padding-page) ${isViewsRoute ? "pl-0" : ""}`}
+              >
+                <Outlet />
+              </div>
+            </main>
+          </div>
         </div>
-      </div>
+      </ModulesFilterProvider>
     </WorkspaceViewsStateProvider>
   );
 }

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -95,9 +95,7 @@ export function Header() {
       </div>
 
       <div className="flex items-center gap-3">
-        <span className="text-sm text-(--txt-secondary)">
-          {user?.name}
-        </span>
+        <span className="text-sm text-(--txt-secondary)">{user?.name}</span>
         <Button variant="ghost" size="sm" onClick={logout}>
           Log out
         </Button>

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Button } from "../ui";
 import { useAuth } from "../../contexts/AuthContext";
@@ -62,13 +62,13 @@ export function Header() {
 
   return (
     <header
-      className="flex h-[var(--height-header)] shrink-0 items-center justify-between border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4"
+      className="flex h-(--height-header) shrink-0 items-center justify-between border-b border-(--border-subtle) bg-(--bg-surface-1) px-4"
       role="banner"
     >
       <div className="flex items-center gap-4">
         <Link
           to={workspace ? `/${workspace.slug}` : "/"}
-          className="text-lg font-semibold text-[var(--txt-primary)] no-underline hover:text-[var(--txt-accent-primary)]"
+          className="text-lg font-semibold text-(--txt-primary) no-underline hover:text-(--txt-accent-primary)"
         >
           Devlane
         </Link>
@@ -78,16 +78,16 @@ export function Header() {
         >
           {breadcrumbs.map((b, i) => (
             <span key={i} className="flex items-center gap-2">
-              {i > 0 && <span className="text-[var(--txt-tertiary)]">/</span>}
+              {i > 0 && <span className="text-(--txt-tertiary)">/</span>}
               {b.href ? (
                 <Link
                   to={b.href}
-                  className="text-[var(--txt-secondary)] no-underline hover:text-[var(--txt-primary)]"
+                  className="text-(--txt-secondary) no-underline hover:text-(--txt-primary)"
                 >
                   {b.label}
                 </Link>
               ) : (
-                <span className="text-[var(--txt-primary)]">{b.label}</span>
+                <span className="text-(--txt-primary)">{b.label}</span>
               )}
             </span>
           ))}
@@ -95,7 +95,7 @@ export function Header() {
       </div>
 
       <div className="flex items-center gap-3">
-        <span className="text-sm text-[var(--txt-secondary)]">
+        <span className="text-sm text-(--txt-secondary)">
           {user?.name}
         </span>
         <Button variant="ghost" size="sm" onClick={logout}>

--- a/ui/src/components/layout/InstanceAdminLayout.tsx
+++ b/ui/src/components/layout/InstanceAdminLayout.tsx
@@ -314,9 +314,7 @@ export function InstanceAdminLayout() {
             {breadcrumbTail && (
               <>
                 <span className="text-(--txt-icon-tertiary)">&gt;</span>
-                <span className="text-(--txt-primary)">
-                  {breadcrumbTail}
-                </span>
+                <span className="text-(--txt-primary)">{breadcrumbTail}</span>
               </>
             )}
           </div>

--- a/ui/src/components/layout/InstanceAdminLayout.tsx
+++ b/ui/src/components/layout/InstanceAdminLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
+﻿import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 
 const IconGlobe = () => (
   <svg
@@ -235,13 +235,13 @@ export function InstanceAdminLayout() {
   const breadcrumbTail = segments[1] === "create" ? "Create" : null;
 
   return (
-    <div className="flex h-screen flex-col bg-[var(--bg-canvas)]">
+    <div className="flex h-screen flex-col bg-(--bg-canvas)">
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left sidebar */}
-        <aside className="flex w-72 shrink-0 flex-col border-r border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
-          <div className="shrink-0 border-b border-[var(--border-subtle)] px-3 py-3">
-            <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-primary)]">
-              <span className="flex size-7 items-center justify-center rounded-md bg-[var(--bg-layer-2)] text-[var(--txt-icon-secondary)]">
+        <aside className="flex w-72 shrink-0 flex-col border-r border-(--border-subtle) bg-(--bg-surface-1)">
+          <div className="shrink-0 border-b border-(--border-subtle) px-3 py-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-(--txt-primary)">
+              <span className="flex size-7 items-center justify-center rounded-md bg-(--bg-layer-2) text-(--txt-icon-secondary)">
                 <IconGlobe />
               </span>
               Instance admin
@@ -257,17 +257,17 @@ export function InstanceAdminLayout() {
                   className={({ isActive }) =>
                     `mb-0.5 flex gap-2 rounded-md px-2.5 py-2 text-left no-underline transition-colors ${
                       isActive
-                        ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                        : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-primary)]"
+                        ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                        : "text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
                     }`
                   }
                 >
-                  <span className="mt-px shrink-0 text-[var(--txt-icon-secondary)] [&_svg]:size-4">
+                  <span className="mt-px shrink-0 text-(--txt-icon-secondary) [&_svg]:size-4">
                     <Icon />
                   </span>
                   <div className="min-w-0 flex-1 overflow-hidden">
                     <div className="text-sm font-medium">{label}</div>
-                    <div className="truncate text-[10px] leading-tight text-[var(--txt-tertiary)]">
+                    <div className="truncate text-[10px] leading-tight text-(--txt-tertiary)">
                       {desc}
                     </div>
                   </div>
@@ -275,12 +275,12 @@ export function InstanceAdminLayout() {
               );
             })}
           </nav>
-          <div className="flex shrink-0 flex-col gap-0.5 border-t border-[var(--border-subtle)] p-1.5">
+          <div className="flex shrink-0 flex-col gap-0.5 border-t border-(--border-subtle) p-1.5">
             <a
               href="http://localhost:5173"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--txt-secondary)] no-underline hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-primary)]"
+              className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-(--txt-secondary) no-underline hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
             >
               <IconExternalLink />
               Redirect to Devlane
@@ -288,14 +288,14 @@ export function InstanceAdminLayout() {
             <div className="flex gap-0.5">
               <button
                 type="button"
-                className="flex size-7 shrink-0 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)] [&_svg]:size-4"
+                className="flex size-7 shrink-0 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary) [&_svg]:size-4"
                 aria-label="Help"
               >
                 <IconHelp />
               </button>
               <Link
                 to="/acme"
-                className="flex size-7 shrink-0 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)] [&_svg]:size-4"
+                className="flex size-7 shrink-0 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary) [&_svg]:size-4"
                 aria-label="Back"
               >
                 <IconArrowLeft />
@@ -306,15 +306,15 @@ export function InstanceAdminLayout() {
 
         {/* Main content */}
         <main className="min-w-0 flex-1 overflow-auto p-5">
-          <div className="mb-4 flex items-center gap-1.5 text-xs text-[var(--txt-secondary)] [&_svg]:size-3.5">
+          <div className="mb-4 flex items-center gap-1.5 text-xs text-(--txt-secondary) [&_svg]:size-3.5">
             <IconSettings />
             <span>Settings</span>
-            <span className="text-[var(--txt-icon-tertiary)]">&gt;</span>
-            <span className="text-[var(--txt-primary)]">{breadcrumbLabel}</span>
+            <span className="text-(--txt-icon-tertiary)">&gt;</span>
+            <span className="text-(--txt-primary)">{breadcrumbLabel}</span>
             {breadcrumbTail && (
               <>
-                <span className="text-[var(--txt-icon-tertiary)]">&gt;</span>
-                <span className="text-[var(--txt-primary)]">
+                <span className="text-(--txt-icon-tertiary)">&gt;</span>
+                <span className="text-(--txt-primary)">
                   {breadcrumbTail}
                 </span>
               </>

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -993,10 +993,7 @@ function ProjectSectionHeader({
         <>
           {showSearchInput ? (
             <div className="flex h-8 min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2">
-              <span
-                className="shrink-0 text-(--txt-icon-tertiary)"
-                aria-hidden
-              >
+              <span className="shrink-0 text-(--txt-icon-tertiary)" aria-hidden>
                 <IconSearch />
               </span>
               <input

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -793,17 +793,41 @@ function ProjectDetailHeader({
 }
 
 const IconListAlt = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
   </svg>
 );
-const IconBarChart = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+const IconBarChartModule = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <path d="M12 20V10M18 20V4M6 20v-4" />
   </svg>
 );
-const IconLayoutGrid = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+const IconLayoutGridModule = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <rect width="7" height="7" x="3" y="3" rx="1" />
     <rect width="7" height="7" x="14" y="3" rx="1" />
     <rect width="7" height="7" x="14" y="14" rx="1" />
@@ -811,7 +835,15 @@ const IconLayoutGrid = () => (
   </svg>
 );
 const IconSliders = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <line x1="4" y1="21" x2="4" y2="14" />
     <line x1="4" y1="10" x2="4" y2="3" />
     <line x1="12" y1="21" x2="12" y2="12" />
@@ -828,7 +860,6 @@ function ModuleDetailHeader({
   workspaceSlug,
   projectId,
   projectName,
-  moduleId,
   moduleName,
 }: {
   workspaceSlug: string;
@@ -839,33 +870,46 @@ function ModuleDetailHeader({
 }) {
   const baseUrl = `/${workspaceSlug}/projects/${projectId}`;
   const [moduleDropdownOpen, setModuleDropdownOpen] = useState(false);
-  const [viewLayout, setViewLayout] = useState<"list" | "board" | "calendar" | "gallery" | "timeline">("list");
+  const [viewLayout, setViewLayout] = useState<
+    "list" | "board" | "calendar" | "gallery" | "timeline"
+  >("list");
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setModuleDropdownOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setModuleDropdownOpen(false);
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const viewButtons: { id: typeof viewLayout; icon: React.ReactNode; label: string }[] = [
+  const viewButtons: {
+    id: typeof viewLayout;
+    icon: React.ReactNode;
+    label: string;
+  }[] = [
     { id: "list", icon: <IconListAlt />, label: "List" },
-    { id: "board", icon: <IconBarChart />, label: "Board" },
+    { id: "board", icon: <IconBarChartModule />, label: "Board" },
     { id: "calendar", icon: <IconCalendar />, label: "Calendar" },
-    { id: "gallery", icon: <IconLayoutGrid />, label: "Gallery" },
+    { id: "gallery", icon: <IconLayoutGridModule />, label: "Gallery" },
     { id: "timeline", icon: <IconListAlt />, label: "Timeline" },
   ];
 
   return (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-2 text-sm text-(--txt-primary)">
-        <Link to={baseUrl} className="shrink-0 truncate font-medium text-(--txt-secondary) hover:text-(--txt-primary) hover:underline">
+        <Link
+          to={baseUrl}
+          className="shrink-0 truncate font-medium text-(--txt-secondary) hover:text-(--txt-primary) hover:underline"
+        >
           {projectName}
         </Link>
         <span className="shrink-0 text-(--txt-icon-tertiary)">/</span>
-        <Link to={`${baseUrl}/modules`} className="shrink-0 truncate font-medium text-(--txt-secondary) hover:text-(--txt-primary) hover:underline">
+        <Link
+          to={`${baseUrl}/modules`}
+          className="shrink-0 truncate font-medium text-(--txt-secondary) hover:text-(--txt-primary) hover:underline"
+        >
           Modules
         </Link>
         <span className="shrink-0 text-(--txt-icon-tertiary)">/</span>
@@ -882,7 +926,11 @@ function ModuleDetailHeader({
           </button>
           {moduleDropdownOpen && (
             <div className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
-              <Link to={`${baseUrl}/modules`} className="block px-3 py-2 text-left text-sm text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)" onClick={() => setModuleDropdownOpen(false)}>
+              <Link
+                to={`${baseUrl}/modules`}
+                className="block px-3 py-2 text-left text-sm text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
+                onClick={() => setModuleDropdownOpen(false)}
+              >
                 All modules
               </Link>
             </div>
@@ -897,7 +945,9 @@ function ModuleDetailHeader({
               type="button"
               onClick={() => setViewLayout(b.id)}
               className={`flex size-7 items-center justify-center rounded-md text-(--txt-icon-secondary) transition-colors ${
-                viewLayout === b.id ? "bg-white shadow-sm text-(--txt-primary)" : "bg-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
+                viewLayout === b.id
+                  ? "bg-white shadow-sm text-(--txt-primary)"
+                  : "bg-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
               } ${i === 0 ? "rounded-l-md" : ""} ${i === viewButtons.length - 1 ? "rounded-r-md" : ""}`}
               title={b.label}
               aria-pressed={viewLayout === b.id}
@@ -906,15 +956,24 @@ function ModuleDetailHeader({
             </button>
           ))}
         </div>
-        <button type="button" className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)">
+        <button
+          type="button"
+          className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+        >
           <IconFilter />
           Filters
         </button>
-        <button type="button" className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)">
+        <button
+          type="button"
+          className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+        >
           <IconSliders />
           Display
         </button>
-        <button type="button" className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)">
+        <button
+          type="button"
+          className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+        >
           Analytics
         </button>
         <Link to={`${baseUrl}/issues?create=1`}>
@@ -923,7 +982,11 @@ function ModuleDetailHeader({
             Add work item
           </Button>
         </Link>
-        <button type="button" className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)" aria-label="More options">
+        <button
+          type="button"
+          className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
+          aria-label="More options"
+        >
           <IconMoreVertical />
         </button>
       </div>
@@ -1920,7 +1983,9 @@ export function PageHeader() {
   const isCyclesPage = projectBase && pathname === `${projectBase}/cycles`;
   const isModulesPage = projectBase && pathname === `${projectBase}/modules`;
   const isModuleDetailPage =
-    projectBase && moduleId && pathname === `${projectBase}/modules/${moduleId}`;
+    projectBase &&
+    moduleId &&
+    pathname === `${projectBase}/modules/${moduleId}`;
   const isViewsPage = projectBase && pathname === `${projectBase}/views`;
   const isPagesPage = projectBase && pathname === `${projectBase}/pages`;
   const isProjectSection =

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import {
   Link,
   useLocation,
@@ -1147,36 +1147,52 @@ function ProjectSectionHeader({
               );
             })}
           </Dropdown>
-          <Dropdown
-            id="modules-filters"
-            openId={modulesFiltersOpen}
-            onOpen={setModulesFiltersOpen}
-            label="Filters"
-            icon={<IconFilter />}
-            displayValue="Filters"
-            panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
-            align="right"
-            triggerContent={
-              <>
-                <span className="shrink-0 text-(--txt-icon-tertiary)">
-                  <IconFilter />
-                </span>
-                <span className="truncate">Filters</span>
-                <span className="shrink-0 text-(--txt-icon-tertiary)">
-                  <IconChevronDown />
-                </span>
-              </>
-            }
-            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
-          >
-            <ModuleFiltersPanel
-              workspaceSlug={workspaceSlug}
-              onOpenDateModal={(which) => {
-                setModulesFiltersOpen(null);
-                setModulesDateRangeModal(which);
-              }}
-            />
-          </Dropdown>
+          <div className="relative shrink-0">
+            <Dropdown
+              id="modules-filters"
+              openId={modulesFiltersOpen}
+              onOpen={setModulesFiltersOpen}
+              label="Filters"
+              icon={<IconFilter />}
+              displayValue="Filters"
+              panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
+              align="right"
+              triggerContent={
+                <>
+                  <span className="shrink-0 text-(--txt-icon-tertiary)">
+                    <IconFilter />
+                  </span>
+                  <span className="truncate">Filters</span>
+                  <span className="shrink-0 text-(--txt-icon-tertiary)">
+                    <IconChevronDown />
+                  </span>
+                </>
+              }
+              triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+            >
+              <ModuleFiltersPanel
+                workspaceSlug={workspaceSlug}
+                onOpenDateModal={(which) => {
+                  setModulesFiltersOpen(null);
+                  setModulesDateRangeModal(which);
+                }}
+              />
+            </Dropdown>
+            {[
+              searchParams.get("search")?.trim(),
+              searchParams.get(MODULE_FILTER_PARAM.favorites),
+              searchParams.get(MODULE_FILTER_PARAM.status)?.trim(),
+              searchParams.get(MODULE_FILTER_PARAM.lead)?.trim(),
+              searchParams.get(MODULE_FILTER_PARAM.members)?.trim(),
+              searchParams.get(MODULE_FILTER_PARAM.start_date)?.trim(),
+              searchParams.get(MODULE_FILTER_PARAM.due_date)?.trim(),
+            ].some(Boolean) && (
+              <span
+                className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-(--brand-default)"
+                aria-hidden
+              />
+            )}
+          </div>
           <div className="flex h-8 overflow-hidden rounded-lg border border-(--border-subtle) bg-(--bg-layer-2) p-0.5">
             <button
               type="button"

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -158,6 +158,24 @@ const IconCalendar = () => (
     <line x1="3" y1="10" x2="21" y2="10" />
   </svg>
 );
+const IconArrowUpDown = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="m21 16-4 4-4-4" />
+    <path d="M17 20V4" />
+    <path d="m3 8 4-4 4 4" />
+    <path d="M7 4v16" />
+  </svg>
+);
 const IconFilter = () => (
   <svg
     width="16"
@@ -891,7 +909,7 @@ function ProjectSectionHeader({
             type="button"
             className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
           >
-            Name <IconChevronDown />
+            <IconArrowUpDown /> Name <IconChevronDown />
           </button>
           <button
             type="button"

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -348,6 +348,23 @@ const IconLayoutGrid = () => (
     <rect width="7" height="7" x="3" y="14" rx="1" />
   </svg>
 );
+const IconStack = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <rect width="16" height="12" x="4" y="2" rx="1" />
+    <rect width="16" height="12" x="6" y="6" rx="1" />
+    <rect width="16" height="12" x="8" y="10" rx="1" />
+  </svg>
+);
 const IconColumns = () => (
   <svg
     width="16"
@@ -874,7 +891,7 @@ function ProjectSectionHeader({
             type="button"
             className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
           >
-            ↑ Name <IconChevronDown />
+            Name <IconChevronDown />
           </button>
           <button
             type="button"
@@ -884,8 +901,9 @@ function ProjectSectionHeader({
           </button>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--brand-default)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent bg-[var(--bg-accent-subtle)] text-[var(--brand-default)] hover:bg-[var(--bg-accent-subtle-hover)]"
             aria-label="List view"
+            title="List view"
           >
             <IconList />
           </button>
@@ -893,8 +911,17 @@ function ProjectSectionHeader({
             type="button"
             className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
             aria-label="Grid view"
+            title="Grid view"
           >
             <IconLayoutGrid />
+          </button>
+          <button
+            type="button"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+            aria-label="Stack view"
+            title="Stack view"
+          >
+            <IconStack />
           </button>
           <Button size="sm" className="gap-1.5 text-[13px] font-medium">
             <IconPlus /> Add Module

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -546,7 +546,7 @@ function ProjectSectionDropdown({
         </span>
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
+        <div className="absolute left-0 top-full z-50 mt-1 min-w-45 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
           {sections.map((section) => {
             const href =
               section === "issues"
@@ -605,28 +605,28 @@ function InboxHeader() {
       <div className="flex items-center gap-1">
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
+          className="flex size-8 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="Mark as read"
         >
           <IconCheck />
         </button>
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
+          className="flex size-8 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="Archive"
         >
           <IconArchive />
         </button>
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
+          className="flex size-8 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="Filters"
         >
           <IconFilter />
         </button>
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
+          className="flex size-8 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="More options"
         >
           <IconMoreVertical />
@@ -700,7 +700,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
         <div
           className={`overflow-hidden transition-[width] duration-200 ease-out ${searchOpen ? "w-56" : "w-0"}`}
         >
-          <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2 py-1.5">
+          <div className="flex items-center gap-2 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2 py-1.5">
             <span className="shrink-0 text-(--txt-icon-tertiary)">
               <IconSearch />
             </span>
@@ -731,7 +731,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
           <button
             type="button"
             onClick={() => setSearchOpen(true)}
-            className="flex size-8 shrink-0 items-center justify-center rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
+            className="flex size-8 shrink-0 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
             aria-label="Search projects"
           >
             <IconSearch />
@@ -739,7 +739,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
         )}
         <button
           type="button"
-          className="flex items-center gap-1.5 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+          className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
         >
           <IconCalendar />
           Created date
@@ -747,7 +747,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
         </button>
         <button
           type="button"
-          className="flex items-center gap-1.5 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+          className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
         >
           <IconFilter />
           Filters
@@ -782,7 +782,7 @@ function ProjectDetailHeader({
       <div className="flex items-center gap-2">
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
+          className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
           aria-label="Search"
         >
           <IconSearch />
@@ -925,7 +925,7 @@ function ModuleDetailHeader({
             </span>
           </button>
           {moduleDropdownOpen && (
-            <div className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
+            <div className="absolute left-0 top-full z-50 mt-1 min-w-40 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
               <Link
                 to={`${baseUrl}/modules`}
                 className="block px-3 py-2 text-left text-sm text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
@@ -1196,7 +1196,7 @@ function ProjectSectionHeader({
       return (
         <>
           {showSearchInput ? (
-            <div className="flex h-8 min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2">
+            <div className="flex h-8 min-w-35 max-w-50 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2">
               <span className="shrink-0 text-(--txt-icon-tertiary)" aria-hidden>
                 <IconSearch />
               </span>
@@ -1504,7 +1504,7 @@ function ProjectSectionHeader({
         <button
           type="button"
           onClick={() => setProjectDropdownOpen((o) => !o)}
-          className="flex h-[34px] w-8 items-center justify-center rounded-r-md border border-l-0 border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
+          className="flex h-8.5 w-8 items-center justify-center rounded-r-md border border-l-0 border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
           aria-label="Select project"
         >
           <IconChevronDown />
@@ -1950,7 +1950,7 @@ export function PageHeader() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !moduleId) {
-      setModule(null);
+      queueMicrotask(() => setModule(null));
       return;
     }
     let cancelled = false;
@@ -2090,7 +2090,7 @@ export function PageHeader() {
 
   return (
     <header
-      className="flex min-h-[52px] shrink-0 items-center justify-between border-b border-(--border-subtle) bg-(--bg-canvas) px-(--padding-page) py-3"
+      className="flex min-h-13 shrink-0 items-center justify-between border-b border-(--border-subtle) bg-(--bg-canvas) px-(--padding-page) py-3"
       role="banner"
     >
       {content}

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -14,6 +14,7 @@ import {
   WorkspaceViewsEllipsisMenu,
   CreateViewModal,
 } from "../workspace-views";
+import { CreateModuleModal } from "../CreateModuleModal";
 import { workspaceService } from "../../services/workspaceService";
 import { projectService } from "../../services/projectService";
 import { issueService } from "../../services/issueService";
@@ -806,6 +807,7 @@ function ProjectSectionHeader({
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
   const [projectSearch, setProjectSearch] = useState("");
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  const [createModuleOpen, setCreateModuleOpen] = useState(false);
   const projectDropdownRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -967,15 +969,41 @@ function ProjectSectionHeader({
       const listActive = currentLayout === "list";
       const galleryActive = currentLayout === "gallery";
       const timelineActive = currentLayout === "timeline";
+      const modulesSearch = searchParams.get("search") ?? "";
       return (
         <>
-          <button
-            type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
-            aria-label="Search"
-          >
-            <IconSearch />
-          </button>
+          <div className="flex min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2 py-1.5">
+            <span className="shrink-0 text-[var(--txt-icon-tertiary)]" aria-hidden>
+              <IconSearch />
+            </span>
+            <input
+              type="text"
+              value={modulesSearch}
+              onChange={(e) => {
+                const next = new URLSearchParams(searchParams);
+                const v = e.target.value;
+                if (v.trim()) next.set("search", v); else next.delete("search");
+                setSearchParams(next);
+              }}
+              placeholder="Search"
+              className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              aria-label="Search modules"
+            />
+            {modulesSearch.length > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  const next = new URLSearchParams(searchParams);
+                  next.delete("search");
+                  setSearchParams(next);
+                }}
+                className="shrink-0 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)] hover:text-[var(--txt-icon-secondary)]"
+                aria-label="Clear search"
+              >
+                <IconX />
+              </button>
+            )}
+          </div>
           <button
             type="button"
             className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
@@ -1029,7 +1057,12 @@ function ProjectSectionHeader({
               <IconStack />
             </button>
           </div>
-          <Button size="sm" className="gap-1.5 text-[13px] font-medium">
+          <Button
+            size="sm"
+            className="gap-1.5 text-[13px] font-medium"
+            type="button"
+            onClick={() => setCreateModuleOpen(true)}
+          >
             <IconPlus /> Add Module
           </Button>
         </>
@@ -1135,6 +1168,19 @@ function ProjectSectionHeader({
         />
       </div>
       <div className="flex items-center gap-1">{rightActions()}</div>
+      {section === "modules" && (
+        <CreateModuleModal
+          open={createModuleOpen}
+          onClose={() => setCreateModuleOpen(false)}
+          workspaceSlug={workspaceSlug}
+          projectId={projectId}
+          projectName={projectName}
+          onCreated={() => {
+            setCreateModuleOpen(false);
+            window.dispatchEvent(new CustomEvent("modules-refresh"));
+          }}
+        />
+      )}
     </>
   );
 }

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -799,8 +799,66 @@ function ProjectSectionHeader({
   section: ProjectSection;
   issueCount: number;
 }) {
+  const navigate = useNavigate();
   const baseUrl = `/${workspaceSlug}/projects/${projectId}`;
   const issuesUrl = `${baseUrl}/issues`;
+  const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
+  const [projectSearch, setProjectSearch] = useState("");
+  const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  const projectDropdownRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    projectService
+      .list(workspaceSlug)
+      .then((list) => {
+        if (!cancelled) setProjects(list ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setProjects([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        projectDropdownRef.current &&
+        !projectDropdownRef.current.contains(e.target as Node)
+      ) {
+        setProjectDropdownOpen(false);
+      }
+    };
+    if (projectDropdownOpen) {
+      document.addEventListener("mousedown", handler);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [projectDropdownOpen]);
+
+  const q = (s: string) => s.trim().toLowerCase();
+  const filteredProjects = projects.filter((p) =>
+    q(p.name).includes(q(projectSearch)),
+  );
+
+  const handleSelectProject = (targetProjectId: string) => {
+    const targetBase = `/${workspaceSlug}/projects/${targetProjectId}`;
+    const targetPath =
+      section === "issues"
+        ? `${targetBase}/issues`
+        : section === "cycles"
+          ? `${targetBase}/cycles`
+          : section === "modules"
+            ? `${targetBase}/modules`
+            : section === "views"
+              ? `${targetBase}/views`
+              : `${targetBase}/pages`;
+    setProjectDropdownOpen(false);
+    navigate(targetPath);
+  };
 
   const rightActions = () => {
     if (section === "issues") {
@@ -989,13 +1047,57 @@ function ProjectSectionHeader({
 
   return (
     <>
-      <div className="flex items-center gap-2 text-sm">
+      <div
+        className="relative flex items-center gap-2 text-sm"
+        ref={projectDropdownRef}
+      >
         <Link
-          to={baseUrl}
-          className="font-medium text-[var(--txt-secondary)] no-underline hover:text-[var(--txt-primary)]"
+          to={issuesUrl}
+          className="flex items-center gap-1.5 rounded-l-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-1.5 font-medium text-[var(--txt-secondary)] no-underline hover:bg-[var(--bg-layer-2-hover)]"
         >
           {projectName}
         </Link>
+        <button
+          type="button"
+          onClick={() => setProjectDropdownOpen((o) => !o)}
+          className="flex h-[34px] w-8 items-center justify-center rounded-r-md border border-l-0 border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+          aria-label="Select project"
+        >
+          <IconChevronDown />
+        </button>
+        {projectDropdownOpen && (
+          <div className="absolute left-0 top-full z-20 mt-1.5 w-64 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5 shadow-[var(--shadow-raised)]">
+            <div className="mb-1.5 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
+              <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <IconSearch />
+              </span>
+              <input
+                type="text"
+                placeholder="Search"
+                value={projectSearch}
+                onChange={(e) => setProjectSearch(e.target.value)}
+                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              />
+            </div>
+            <div className="max-h-64 overflow-y-auto py-0.5">
+              {filteredProjects.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => handleSelectProject(p.id)}
+                  className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                >
+                  <span className="truncate">{p.name}</span>
+                  {p.id === projectId && (
+                    <span className="shrink-0 text-[var(--txt-primary)]">
+                      <IconCheck />
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
         <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
           &gt;
         </span>

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -13,7 +13,10 @@ import {
   WorkspaceViewsDisplayDropdown,
   WorkspaceViewsEllipsisMenu,
   CreateViewModal,
+  ModuleFiltersPanel,
+  MODULE_FILTER_PARAM,
 } from "../workspace-views";
+import { DateRangeModal } from "../workspace-views/DateRangeModal";
 import { CreateModuleModal } from "../CreateModuleModal";
 import { workspaceService } from "../../services/workspaceService";
 import { projectService } from "../../services/projectService";
@@ -808,7 +811,16 @@ function ProjectSectionHeader({
   const [projectSearch, setProjectSearch] = useState("");
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
   const [createModuleOpen, setCreateModuleOpen] = useState(false);
+  const [modulesSearchExpanded, setModulesSearchExpanded] = useState(false);
+  const [modulesFiltersOpen, setModulesFiltersOpen] = useState<string | null>(
+    null,
+  );
+  const [modulesSortOpen, setModulesSortOpen] = useState<string | null>(null);
+  const [modulesDateRangeModal, setModulesDateRangeModal] = useState<
+    "start" | "due" | null
+  >(null);
   const projectDropdownRef = useRef<HTMLDivElement | null>(null);
+  const modulesSearchInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -841,6 +853,12 @@ function ProjectSectionHeader({
       document.removeEventListener("mousedown", handler);
     };
   }, [projectDropdownOpen]);
+
+  useEffect(() => {
+    if (modulesSearchExpanded) {
+      modulesSearchInputRef.current?.focus();
+    }
+  }, [modulesSearchExpanded]);
 
   const q = (s: string) => s.trim().toLowerCase();
   const filteredProjects = projects.filter((p) =>
@@ -970,60 +988,206 @@ function ProjectSectionHeader({
       const galleryActive = currentLayout === "gallery";
       const timelineActive = currentLayout === "timeline";
       const modulesSearch = searchParams.get("search") ?? "";
+      const showSearchInput = modulesSearchExpanded || modulesSearch.length > 0;
       return (
         <>
-          <div className="flex min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2 py-1.5">
-            <span className="shrink-0 text-[var(--txt-icon-tertiary)]" aria-hidden>
-              <IconSearch />
-            </span>
-            <input
-              type="text"
-              value={modulesSearch}
-              onChange={(e) => {
-                const next = new URLSearchParams(searchParams);
-                const v = e.target.value;
-                if (v.trim()) next.set("search", v); else next.delete("search");
-                setSearchParams(next);
-              }}
-              placeholder="Search"
-              className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
-              aria-label="Search modules"
-            />
-            {modulesSearch.length > 0 && (
-              <button
-                type="button"
-                onClick={() => {
+          {showSearchInput ? (
+            <div className="flex h-8 min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2">
+              <span
+                className="shrink-0 text-[var(--txt-icon-tertiary)]"
+                aria-hidden
+              >
+                <IconSearch />
+              </span>
+              <input
+                ref={modulesSearchInputRef}
+                type="text"
+                value={modulesSearch}
+                onChange={(e) => {
                   const next = new URLSearchParams(searchParams);
-                  next.delete("search");
+                  const v = e.target.value;
+                  if (v.trim()) next.set("search", v);
+                  else next.delete("search");
                   setSearchParams(next);
                 }}
-                className="shrink-0 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)] hover:text-[var(--txt-icon-secondary)]"
-                aria-label="Clear search"
-              >
-                <IconX />
-              </button>
-            )}
-          </div>
-          <button
-            type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+                onBlur={() => {
+                  if (modulesSearch.length === 0)
+                    setModulesSearchExpanded(false);
+                }}
+                placeholder="Search"
+                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                aria-label="Search modules"
+              />
+              {modulesSearch.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = new URLSearchParams(searchParams);
+                    next.delete("search");
+                    setSearchParams(next);
+                  }}
+                  className="shrink-0 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)] hover:text-[var(--txt-icon-secondary)]"
+                  aria-label="Clear search"
+                >
+                  <IconX />
+                </button>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setModulesSearchExpanded(true)}
+              className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)] hover:text-[var(--txt-icon-secondary)]"
+              aria-label="Search modules"
+            >
+              <IconSearch />
+            </button>
+          )}
+          <Dropdown
+            id="modules-sort"
+            openId={modulesSortOpen}
+            onOpen={setModulesSortOpen}
+            label="Sort by"
+            icon={<IconArrowUpDown />}
+            displayValue={(() => {
+              const sort = searchParams.get("sort") || "progress";
+              const labels: Record<string, string> = {
+                name: "Name",
+                progress: "Progress",
+                work_items: "Number of work items",
+                due_date: "Due date",
+                created_date: "Created date",
+                manual: "Manual",
+              };
+              return labels[sort] ?? "Progress";
+            })()}
+            panelClassName="min-w-[200px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+            align="left"
+            triggerContent={
+              <>
+                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                  <IconArrowUpDown />
+                </span>
+                <span className="truncate">
+                  {(() => {
+                    const sort = searchParams.get("sort") || "progress";
+                    const labels: Record<string, string> = {
+                      name: "Name",
+                      progress: "Progress",
+                      work_items: "Number of work items",
+                      due_date: "Due date",
+                      created_date: "Created date",
+                      manual: "Manual",
+                    };
+                    return labels[sort] ?? "Progress";
+                  })()}
+                </span>
+                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                  <IconChevronDown />
+                </span>
+              </>
+            }
+            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
           >
-            <IconArrowUpDown /> Progress <IconChevronDown />
-          </button>
-          <button
-            type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            {[
+              { value: "name", label: "Name" },
+              { value: "progress", label: "Progress" },
+              { value: "work_items", label: "Number of work items" },
+              { value: "due_date", label: "Due date" },
+              { value: "created_date", label: "Created date" },
+              { value: "manual", label: "Manual" },
+            ].map((opt) => {
+              const current = searchParams.get("sort") || "progress";
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => {
+                    setSearchParams((prev) => {
+                      const next = new URLSearchParams(prev);
+                      next.set("sort", opt.value);
+                      if (!prev.get("order")) next.set("order", "asc");
+                      return next;
+                    });
+                    setModulesSortOpen(null);
+                  }}
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                >
+                  {opt.label}
+                  {current === opt.value && (
+                    <span className="shrink-0 text-[var(--txt-primary)]">
+                      <IconCheck />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+            <div className="my-1 border-t border-[var(--border-subtle)]" />
+            {["asc", "desc"].map((orderValue) => {
+              const currentOrder = searchParams.get("order") || "asc";
+              const label = orderValue === "asc" ? "Ascending" : "Descending";
+              return (
+                <button
+                  key={orderValue}
+                  type="button"
+                  onClick={() => {
+                    setSearchParams((prev) => {
+                      const next = new URLSearchParams(prev);
+                      next.set("order", orderValue);
+                      return next;
+                    });
+                    setModulesSortOpen(null);
+                  }}
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                >
+                  {label}
+                  {currentOrder === orderValue && (
+                    <span className="shrink-0 text-[var(--txt-primary)]">
+                      <IconCheck />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </Dropdown>
+          <Dropdown
+            id="modules-filters"
+            openId={modulesFiltersOpen}
+            onOpen={setModulesFiltersOpen}
+            label="Filters"
+            icon={<IconFilter />}
+            displayValue="Filters"
+            panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+            align="right"
+            triggerContent={
+              <>
+                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                  <IconFilter />
+                </span>
+                <span className="truncate">Filters</span>
+                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                  <IconChevronDown />
+                </span>
+              </>
+            }
+            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
           >
-            <IconFilter /> Filters <IconChevronDown />
-          </button>
-          <div className="flex items-center gap-0.5 rounded-md bg-[var(--bg-layer-2)] p-0.5">
+            <ModuleFiltersPanel
+              workspaceSlug={workspaceSlug}
+              onOpenDateModal={(which) => {
+                setModulesFiltersOpen(null);
+                setModulesDateRangeModal(which);
+              }}
+            />
+          </Dropdown>
+          <div className="flex h-8 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] p-0.5">
             <button
               type="button"
               onClick={() => handleLayoutChange("list")}
-              className={`flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-secondary)] transition-colors ${
+              className={`flex size-7 items-center justify-center rounded-l-md text-[var(--txt-icon-secondary)] transition-colors ${
                 listActive
-                  ? "bg-[var(--bg-canvas)] shadow-sm"
-                  : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+                  ? "bg-white shadow-sm text-[var(--txt-primary)]"
+                  : "bg-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
               }`}
               aria-pressed={listActive}
               title="List layout"
@@ -1033,10 +1197,10 @@ function ProjectSectionHeader({
             <button
               type="button"
               onClick={() => handleLayoutChange("gallery")}
-              className={`flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-secondary)] transition-colors ${
+              className={`flex size-7 items-center justify-center text-[var(--txt-icon-secondary)] transition-colors ${
                 galleryActive
-                  ? "bg-[var(--bg-canvas)] shadow-sm"
-                  : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+                  ? "bg-white shadow-sm text-[var(--txt-primary)]"
+                  : "bg-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
               }`}
               aria-pressed={galleryActive}
               title="Gallery layout"
@@ -1046,10 +1210,10 @@ function ProjectSectionHeader({
             <button
               type="button"
               onClick={() => handleLayoutChange("timeline")}
-              className={`flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-secondary)] transition-colors ${
+              className={`flex size-7 items-center justify-center rounded-r-md text-[var(--txt-icon-secondary)] transition-colors ${
                 timelineActive
-                  ? "bg-[var(--bg-canvas)] shadow-sm"
-                  : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+                  ? "bg-white shadow-sm text-[var(--txt-primary)]"
+                  : "bg-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
               }`}
               aria-pressed={timelineActive}
               title="Timeline layout"
@@ -1059,7 +1223,7 @@ function ProjectSectionHeader({
           </div>
           <Button
             size="sm"
-            className="gap-1.5 text-[13px] font-medium"
+            className="ml-1 gap-1.5 h-8 text-[13px] font-medium"
             type="button"
             onClick={() => setCreateModuleOpen(true)}
           >
@@ -1169,17 +1333,58 @@ function ProjectSectionHeader({
       </div>
       <div className="flex items-center gap-1">{rightActions()}</div>
       {section === "modules" && (
-        <CreateModuleModal
-          open={createModuleOpen}
-          onClose={() => setCreateModuleOpen(false)}
-          workspaceSlug={workspaceSlug}
-          projectId={projectId}
-          projectName={projectName}
-          onCreated={() => {
-            setCreateModuleOpen(false);
-            window.dispatchEvent(new CustomEvent("modules-refresh"));
-          }}
-        />
+        <>
+          <CreateModuleModal
+            open={createModuleOpen}
+            onClose={() => setCreateModuleOpen(false)}
+            workspaceSlug={workspaceSlug}
+            projectId={projectId}
+            projectName={projectName}
+            onCreated={() => {
+              setCreateModuleOpen(false);
+              window.dispatchEvent(new CustomEvent("modules-refresh"));
+            }}
+          />
+          <DateRangeModal
+            open={modulesDateRangeModal !== null}
+            onClose={() => setModulesDateRangeModal(null)}
+            title={
+              modulesDateRangeModal === "start"
+                ? "Start date range"
+                : "Due date range"
+            }
+            after={
+              modulesDateRangeModal === "start"
+                ? (searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ??
+                  null)
+                : (searchParams.get(MODULE_FILTER_PARAM.due_after)?.trim() ??
+                  null)
+            }
+            before={
+              modulesDateRangeModal === "start"
+                ? (searchParams.get(MODULE_FILTER_PARAM.start_before)?.trim() ??
+                  null)
+                : (searchParams.get(MODULE_FILTER_PARAM.due_before)?.trim() ??
+                  null)
+            }
+            onApply={(after, before) => {
+              setSearchParams((prev) => {
+                const next = new URLSearchParams(prev);
+                if (modulesDateRangeModal === "start") {
+                  next.set(MODULE_FILTER_PARAM.start_date, "custom");
+                  next.set(MODULE_FILTER_PARAM.start_after, after);
+                  next.set(MODULE_FILTER_PARAM.start_before, before);
+                } else {
+                  next.set(MODULE_FILTER_PARAM.due_date, "custom");
+                  next.set(MODULE_FILTER_PARAM.due_after, after);
+                  next.set(MODULE_FILTER_PARAM.due_before, before);
+                }
+                return next;
+              });
+              setModulesDateRangeModal(null);
+            }}
+          />
+        </>
       )}
     </>
   );

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+﻿import { useState, useRef, useEffect } from "react";
 import {
   Link,
   useLocation,
@@ -528,23 +528,23 @@ function ProjectSectionDropdown({
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2-hover)]"
+        className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover)"
       >
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-secondary)]">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-secondary)">
           {currentIcon}
         </span>
         {currentLabel}
         {currentSection === "issues" && (
-          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--brand-200)] px-1.5 text-xs font-medium text-[var(--brand-default)]">
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-(--brand-200) px-1.5 text-xs font-medium text-(--brand-default)">
             {issueCount}
           </span>
         )}
-        <span className="ml-0.5 flex size-4 items-center justify-center text-[var(--txt-icon-tertiary)]">
+        <span className="ml-0.5 flex size-4 items-center justify-center text-(--txt-icon-tertiary)">
           <IconChevronDown />
         </span>
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]">
+        <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
           {sections.map((section) => {
             const href =
               section === "issues"
@@ -558,16 +558,16 @@ function ProjectSectionDropdown({
                 onClick={() => setOpen(false)}
                 className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm no-underline ${
                   isActive
-                    ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                    : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-primary)]"
+                    ? "bg-(--brand-200) text-(--txt-primary)"
+                    : "text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
                 }`}
               >
-                <span className="flex size-5 items-center justify-center text-[var(--txt-icon-secondary)]">
+                <span className="flex size-5 items-center justify-center text-(--txt-icon-secondary)">
                   {SECTION_ICONS[section]}
                 </span>
                 {SECTION_LABELS[section]}
                 {isActive && (
-                  <span className="ml-auto text-[var(--brand-default)]">
+                  <span className="ml-auto text-(--brand-default)">
                     <IconCheck />
                   </span>
                 )}
@@ -582,8 +582,8 @@ function ProjectSectionDropdown({
 
 function YourWorkHeader() {
   return (
-    <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
-      <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+    <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+      <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
         <IconUser />
       </span>
       Your work
@@ -594,8 +594,8 @@ function YourWorkHeader() {
 function InboxHeader() {
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+      <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
           <IconInbox />
         </span>
         Inbox
@@ -603,28 +603,28 @@ function InboxHeader() {
       <div className="flex items-center gap-1">
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="Mark as read"
         >
           <IconCheck />
         </button>
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="Archive"
         >
           <IconArchive />
         </button>
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="Filters"
         >
           <IconFilter />
         </button>
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+          className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
           aria-label="More options"
         >
           <IconMoreVertical />
@@ -637,8 +637,8 @@ function InboxHeader() {
 function SettingsHeader() {
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+      <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
           <IconSettings />
         </span>
         Settings
@@ -651,8 +651,8 @@ function SettingsHeader() {
 function HomeHeader() {
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+      <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
           <IconHome />
         </span>
         Home
@@ -661,7 +661,7 @@ function HomeHeader() {
         <Button
           variant="ghost"
           size="sm"
-          className="gap-1.5 text-[13px] font-medium text-[var(--txt-secondary)]"
+          className="gap-1.5 text-[13px] font-medium text-(--txt-secondary)"
         >
           <IconGrid />
           Manage widgets
@@ -669,7 +669,7 @@ function HomeHeader() {
         <Button
           variant="ghost"
           size="sm"
-          className="gap-1.5 text-[13px] font-medium text-[var(--txt-secondary)]"
+          className="gap-1.5 text-[13px] font-medium text-(--txt-secondary)"
         >
           <IconGitHub />
           Star us on GitHub
@@ -688,8 +688,8 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
 
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+      <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
           <IconBriefcase />
         </span>
         Projects
@@ -698,8 +698,8 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
         <div
           className={`overflow-hidden transition-[width] duration-200 ease-out ${searchOpen ? "w-56" : "w-0"}`}
         >
-          <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2 py-1.5">
-            <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+          <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2 py-1.5">
+            <span className="shrink-0 text-(--txt-icon-tertiary)">
               <IconSearch />
             </span>
             <input
@@ -709,7 +709,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
                 setSearchParams({ q: e.target.value }, { replace: true })
               }
               placeholder="Search projects"
-              className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
               aria-label="Search projects"
             />
             <button
@@ -718,7 +718,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
                 setSearchParams({}, { replace: true });
                 setSearchOpen(false);
               }}
-              className="shrink-0 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-secondary)]"
+              className="shrink-0 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-secondary)"
               aria-label="Clear search"
             >
               <IconX />
@@ -729,7 +729,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
           <button
             type="button"
             onClick={() => setSearchOpen(true)}
-            className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex size-8 shrink-0 items-center justify-center rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
             aria-label="Search projects"
           >
             <IconSearch />
@@ -737,7 +737,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
         )}
         <button
           type="button"
-          className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+          className="flex items-center gap-1.5 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
         >
           <IconCalendar />
           Created date
@@ -745,7 +745,7 @@ function ProjectsHeader({ workspaceSlug }: { workspaceSlug: string }) {
         </button>
         <button
           type="button"
-          className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+          className="flex items-center gap-1.5 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
         >
           <IconFilter />
           Filters
@@ -771,8 +771,8 @@ function ProjectDetailHeader({
 }) {
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-semibold text-[var(--txt-primary)]">
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+      <div className="flex items-center gap-2 text-sm font-semibold text-(--txt-primary)">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
           <IconBriefcase />
         </span>
         {title}
@@ -780,7 +780,7 @@ function ProjectDetailHeader({
       <div className="flex items-center gap-2">
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+          className="flex size-8 items-center justify-center rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
           aria-label="Search"
         >
           <IconSearch />
@@ -896,7 +896,7 @@ function ProjectSectionHeader({
         <>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--brand-default)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--brand-default) hover:bg-(--bg-layer-2-hover)"
             aria-label="List view"
             title="List view"
           >
@@ -904,7 +904,7 @@ function ProjectSectionHeader({
           </button>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
             aria-label="Kanban"
             title="Kanban"
           >
@@ -912,7 +912,7 @@ function ProjectSectionHeader({
           </button>
           <Link
             to={`${baseUrl}/board`}
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
             aria-label="Board"
             title="Board"
           >
@@ -920,7 +920,7 @@ function ProjectSectionHeader({
           </Link>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
             aria-label="Calendar"
             title="Calendar"
           >
@@ -928,28 +928,28 @@ function ProjectSectionHeader({
           </button>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
             aria-label="Gallery"
             title="Gallery"
           >
             <IconGrid />
           </button>
-          <div className="mx-1 w-px self-stretch bg-[var(--border-subtle)]" />
+          <div className="mx-1 w-px self-stretch bg-(--border-subtle)" />
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconFilter /> Filters <IconChevronDown />
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             Display <IconChevronDown />
           </button>
           <Link
             to={`/${workspaceSlug}/analytics/work-items`}
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] no-underline hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) no-underline hover:bg-(--bg-layer-2-hover)"
           >
             <IconBarChart /> Analytics
           </Link>
@@ -966,14 +966,14 @@ function ProjectSectionHeader({
         <>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
             aria-label="Search"
           >
             <IconSearch />
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconFilter /> Filters <IconChevronDown />
           </button>
@@ -992,9 +992,9 @@ function ProjectSectionHeader({
       return (
         <>
           {showSearchInput ? (
-            <div className="flex h-8 min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2">
+            <div className="flex h-8 min-w-[140px] max-w-[200px] items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2">
               <span
-                className="shrink-0 text-[var(--txt-icon-tertiary)]"
+                className="shrink-0 text-(--txt-icon-tertiary)"
                 aria-hidden
               >
                 <IconSearch />
@@ -1015,7 +1015,7 @@ function ProjectSectionHeader({
                     setModulesSearchExpanded(false);
                 }}
                 placeholder="Search"
-                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                 aria-label="Search modules"
               />
               {modulesSearch.length > 0 && (
@@ -1026,7 +1026,7 @@ function ProjectSectionHeader({
                     next.delete("search");
                     setSearchParams(next);
                   }}
-                  className="shrink-0 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)] hover:text-[var(--txt-icon-secondary)]"
+                  className="shrink-0 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover) hover:text-(--txt-icon-secondary)"
                   aria-label="Clear search"
                 >
                   <IconX />
@@ -1037,7 +1037,7 @@ function ProjectSectionHeader({
             <button
               type="button"
               onClick={() => setModulesSearchExpanded(true)}
-              className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)] hover:text-[var(--txt-icon-secondary)]"
+              className="flex h-8 w-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover) hover:text-(--txt-icon-secondary)"
               aria-label="Search modules"
             >
               <IconSearch />
@@ -1061,11 +1061,11 @@ function ProjectSectionHeader({
               };
               return labels[sort] ?? "Progress";
             })()}
-            panelClassName="min-w-[200px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+            panelClassName="min-w-[200px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
             align="left"
             triggerContent={
               <>
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconArrowUpDown />
                 </span>
                 <span className="truncate">
@@ -1082,12 +1082,12 @@ function ProjectSectionHeader({
                     return labels[sort] ?? "Progress";
                   })()}
                 </span>
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconChevronDown />
                 </span>
               </>
             }
-            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             {[
               { value: "name", label: "Name" },
@@ -1111,18 +1111,18 @@ function ProjectSectionHeader({
                     });
                     setModulesSortOpen(null);
                   }}
-                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 >
                   {opt.label}
                   {current === opt.value && (
-                    <span className="shrink-0 text-[var(--txt-primary)]">
+                    <span className="shrink-0 text-(--txt-primary)">
                       <IconCheck />
                     </span>
                   )}
                 </button>
               );
             })}
-            <div className="my-1 border-t border-[var(--border-subtle)]" />
+            <div className="my-1 border-t border-(--border-subtle)" />
             {["asc", "desc"].map((orderValue) => {
               const currentOrder = searchParams.get("order") || "asc";
               const label = orderValue === "asc" ? "Ascending" : "Descending";
@@ -1138,11 +1138,11 @@ function ProjectSectionHeader({
                     });
                     setModulesSortOpen(null);
                   }}
-                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 >
                   {label}
                   {currentOrder === orderValue && (
-                    <span className="shrink-0 text-[var(--txt-primary)]">
+                    <span className="shrink-0 text-(--txt-primary)">
                       <IconCheck />
                     </span>
                   )}
@@ -1157,20 +1157,20 @@ function ProjectSectionHeader({
             label="Filters"
             icon={<IconFilter />}
             displayValue="Filters"
-            panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+            panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
             align="right"
             triggerContent={
               <>
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconFilter />
                 </span>
                 <span className="truncate">Filters</span>
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconChevronDown />
                 </span>
               </>
             }
-            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            triggerClassName="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <ModuleFiltersPanel
               workspaceSlug={workspaceSlug}
@@ -1180,14 +1180,14 @@ function ProjectSectionHeader({
               }}
             />
           </Dropdown>
-          <div className="flex h-8 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] p-0.5">
+          <div className="flex h-8 overflow-hidden rounded-lg border border-(--border-subtle) bg-(--bg-layer-2) p-0.5">
             <button
               type="button"
               onClick={() => handleLayoutChange("list")}
-              className={`flex size-7 items-center justify-center rounded-l-md text-[var(--txt-icon-secondary)] transition-colors ${
+              className={`flex size-7 items-center justify-center rounded-l-md text-(--txt-icon-secondary) transition-colors ${
                 listActive
-                  ? "bg-white shadow-sm text-[var(--txt-primary)]"
-                  : "bg-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+                  ? "bg-white shadow-sm text-(--txt-primary)"
+                  : "bg-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
               }`}
               aria-pressed={listActive}
               title="List layout"
@@ -1197,10 +1197,10 @@ function ProjectSectionHeader({
             <button
               type="button"
               onClick={() => handleLayoutChange("gallery")}
-              className={`flex size-7 items-center justify-center text-[var(--txt-icon-secondary)] transition-colors ${
+              className={`flex size-7 items-center justify-center text-(--txt-icon-secondary) transition-colors ${
                 galleryActive
-                  ? "bg-white shadow-sm text-[var(--txt-primary)]"
-                  : "bg-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+                  ? "bg-white shadow-sm text-(--txt-primary)"
+                  : "bg-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
               }`}
               aria-pressed={galleryActive}
               title="Gallery layout"
@@ -1210,10 +1210,10 @@ function ProjectSectionHeader({
             <button
               type="button"
               onClick={() => handleLayoutChange("timeline")}
-              className={`flex size-7 items-center justify-center rounded-r-md text-[var(--txt-icon-secondary)] transition-colors ${
+              className={`flex size-7 items-center justify-center rounded-r-md text-(--txt-icon-secondary) transition-colors ${
                 timelineActive
-                  ? "bg-white shadow-sm text-[var(--txt-primary)]"
-                  : "bg-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+                  ? "bg-white shadow-sm text-(--txt-primary)"
+                  : "bg-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
               }`}
               aria-pressed={timelineActive}
               title="Timeline layout"
@@ -1246,13 +1246,13 @@ function ProjectSectionHeader({
         <>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconFilter /> Filters <IconChevronDown />
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             Display <IconChevronDown />
           </button>
@@ -1261,7 +1261,7 @@ function ProjectSectionHeader({
           </Button>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+            className="flex size-8 items-center justify-center rounded-md border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
             aria-label="More options"
           >
             <IconMoreVertical />
@@ -1280,22 +1280,22 @@ function ProjectSectionHeader({
       >
         <Link
           to={issuesUrl}
-          className="flex items-center gap-1.5 rounded-l-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-1.5 font-medium text-[var(--txt-secondary)] no-underline hover:bg-[var(--bg-layer-2-hover)]"
+          className="flex items-center gap-1.5 rounded-l-md border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-1.5 font-medium text-(--txt-secondary) no-underline hover:bg-(--bg-layer-2-hover)"
         >
           {projectName}
         </Link>
         <button
           type="button"
           onClick={() => setProjectDropdownOpen((o) => !o)}
-          className="flex h-[34px] w-8 items-center justify-center rounded-r-md border border-l-0 border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+          className="flex h-[34px] w-8 items-center justify-center rounded-r-md border border-l-0 border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
           aria-label="Select project"
         >
           <IconChevronDown />
         </button>
         {projectDropdownOpen && (
-          <div className="absolute left-0 top-full z-20 mt-1.5 w-64 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5 shadow-[var(--shadow-raised)]">
-            <div className="mb-1.5 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
-              <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+          <div className="absolute left-0 top-full z-20 mt-1.5 w-64 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-1.5 shadow-(--shadow-raised)">
+            <div className="mb-1.5 flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
+              <span className="shrink-0 text-(--txt-icon-tertiary)">
                 <IconSearch />
               </span>
               <input
@@ -1303,7 +1303,7 @@ function ProjectSectionHeader({
                 placeholder="Search"
                 value={projectSearch}
                 onChange={(e) => setProjectSearch(e.target.value)}
-                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
               />
             </div>
             <div className="max-h-64 overflow-y-auto py-0.5">
@@ -1312,11 +1312,11 @@ function ProjectSectionHeader({
                   key={p.id}
                   type="button"
                   onClick={() => handleSelectProject(p.id)}
-                  className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 >
                   <span className="truncate">{p.name}</span>
                   {p.id === projectId && (
-                    <span className="shrink-0 text-[var(--txt-primary)]">
+                    <span className="shrink-0 text-(--txt-primary)">
                       <IconCheck />
                     </span>
                   )}
@@ -1457,17 +1457,17 @@ function WorkspaceViewsHeader() {
 
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
+      <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
         <Link
           to={workspaceSlug ? `/${workspaceSlug}/views/all-issues` : "/"}
-          className="flex items-center gap-1.5 text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+          className="flex items-center gap-1.5 text-(--txt-secondary) hover:text-(--txt-primary)"
         >
-          <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+          <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
             <IconViewsPlane />
           </span>
           <span>Views</span>
         </Link>
-        <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
+        <span className="text-(--txt-icon-tertiary)" aria-hidden>
           &gt;
         </span>
         <Dropdown
@@ -1477,12 +1477,12 @@ function WorkspaceViewsHeader() {
           label="All work items"
           icon={<IconViewsPlane />}
           displayValue={displayName}
-          panelClassName="flex min-w-[220px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+          panelClassName="flex min-w-[220px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
           align="left"
         >
-          <div className="sticky top-0 shrink-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-2">
-            <div className="flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
-              <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+          <div className="sticky top-0 shrink-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-2">
+            <div className="flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
+              <span className="shrink-0 text-(--txt-icon-tertiary)">
                 <IconSearch />
               </span>
               <input
@@ -1490,7 +1490,7 @@ function WorkspaceViewsHeader() {
                 placeholder="Search"
                 value={viewSearch}
                 onChange={(e) => setViewSearch(e.target.value)}
-                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
               />
             </div>
           </div>
@@ -1503,14 +1503,14 @@ function WorkspaceViewsHeader() {
                 key={view.id}
                 type="button"
                 onClick={() => handleSelectView(view.id)}
-                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconLayers />
                 </span>
                 <span className="min-w-0 flex-1 truncate">{view.name}</span>
                 {selectedViewId === view.id && (
-                  <span className="shrink-0 text-[var(--txt-primary)]">
+                  <span className="shrink-0 text-(--txt-primary)">
                     <IconCheck />
                   </span>
                 )}
@@ -1596,8 +1596,8 @@ function AnalyticsHeader({ workspaceSlug }: { workspaceSlug: string }) {
 
   return (
     <>
-      <div className="flex items-center gap-2 text-sm font-medium text-[var(--txt-secondary)]">
-        <span className="flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+      <div className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+        <span className="flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
           <IconBarChart />
         </span>
         Analytics
@@ -1610,16 +1610,16 @@ function AnalyticsHeader({ workspaceSlug }: { workspaceSlug: string }) {
           label="All projects"
           icon={<IconBriefcase />}
           displayValue={selectedProject?.name ?? "All projects"}
-          panelClassName="flex min-w-[200px] max-h-52 flex-col rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)]"
+          panelClassName="flex min-w-[200px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
           align="right"
         >
-          <div className="sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-1.5">
+          <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
             <input
               type="text"
               placeholder="Search..."
               value={projectSearch}
               onChange={(e) => setProjectSearch(e.target.value)}
-              className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1 text-xs placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+              className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
             />
           </div>
           <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
@@ -1629,7 +1629,7 @@ function AnalyticsHeader({ workspaceSlug }: { workspaceSlug: string }) {
                 setSelectedProjectId(null);
                 setOpenDropdown(null);
               }}
-              className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               All projects
             </button>
@@ -1641,7 +1641,7 @@ function AnalyticsHeader({ workspaceSlug }: { workspaceSlug: string }) {
                   setSelectedProjectId(p.id);
                   setOpenDropdown(null);
                 }}
-                className="w-full text-left text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
                 {p.name}
               </button>
@@ -1832,7 +1832,7 @@ export function PageHeader() {
 
   return (
     <header
-      className="flex min-h-[52px] shrink-0 items-center justify-between border-b border-[var(--border-subtle)] bg-[var(--bg-canvas)] px-[var(--padding-page)] py-3"
+      className="flex min-h-[52px] shrink-0 items-center justify-between border-b border-(--border-subtle) bg-(--bg-canvas) px-(--padding-page) py-3"
       role="banner"
     >
       {content}

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -8,13 +8,13 @@ import {
 } from "react-router-dom";
 import { Button } from "../ui";
 import { Dropdown } from "../work-item";
+import { useModulesFilter } from "../../contexts/ModulesFilterContext";
 import {
   WorkspaceViewsFiltersDropdown,
   WorkspaceViewsDisplayDropdown,
   WorkspaceViewsEllipsisMenu,
   CreateViewModal,
   ModuleFiltersPanel,
-  MODULE_FILTER_PARAM,
 } from "../workspace-views";
 import { DateRangeModal } from "../workspace-views/DateRangeModal";
 import { CreateModuleModal } from "../CreateModuleModal";
@@ -1008,7 +1008,7 @@ function ProjectSectionHeader({
   issueCount: number;
 }) {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const modulesFilter = useModulesFilter();
   const baseUrl = `/${workspaceSlug}/projects/${projectId}`;
   const issuesUrl = `${baseUrl}/issues`;
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
@@ -1085,14 +1085,7 @@ function ProjectSectionHeader({
     navigate(targetPath);
   };
 
-  const currentLayout =
-    (searchParams.get("layout") as "list" | "gallery" | "timeline") || "list";
-
-  const handleLayoutChange = (layout: "list" | "gallery" | "timeline") => {
-    const next = new URLSearchParams(searchParams);
-    next.set("layout", layout);
-    setSearchParams(next);
-  };
+  const currentLayout = modulesFilter.layout;
 
   const rightActions = () => {
     if (section === "issues") {
@@ -1191,7 +1184,7 @@ function ProjectSectionHeader({
       const listActive = currentLayout === "list";
       const galleryActive = currentLayout === "gallery";
       const timelineActive = currentLayout === "timeline";
-      const modulesSearch = searchParams.get("search") ?? "";
+      const modulesSearch = modulesFilter.search ?? "";
       const showSearchInput = modulesSearchExpanded || modulesSearch.length > 0;
       return (
         <>
@@ -1205,11 +1198,8 @@ function ProjectSectionHeader({
                 type="text"
                 value={modulesSearch}
                 onChange={(e) => {
-                  const next = new URLSearchParams(searchParams);
                   const v = e.target.value;
-                  if (v.trim()) next.set("search", v);
-                  else next.delete("search");
-                  setSearchParams(next);
+                  modulesFilter.setSearch(v);
                 }}
                 onBlur={() => {
                   if (modulesSearch.length === 0)
@@ -1223,9 +1213,7 @@ function ProjectSectionHeader({
                 <button
                   type="button"
                   onClick={() => {
-                    const next = new URLSearchParams(searchParams);
-                    next.delete("search");
-                    setSearchParams(next);
+                    modulesFilter.setSearch("");
                   }}
                   className="shrink-0 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover) hover:text-(--txt-icon-secondary)"
                   aria-label="Clear search"
@@ -1251,7 +1239,7 @@ function ProjectSectionHeader({
             label="Sort by"
             icon={<IconArrowUpDown />}
             displayValue={(() => {
-              const sort = searchParams.get("sort") || "progress";
+              const sort = modulesFilter.sort || "progress";
               const labels: Record<string, string> = {
                 name: "Name",
                 progress: "Progress",
@@ -1271,7 +1259,7 @@ function ProjectSectionHeader({
                 </span>
                 <span className="truncate">
                   {(() => {
-                    const sort = searchParams.get("sort") || "progress";
+                    const sort = modulesFilter.sort || "progress";
                     const labels: Record<string, string> = {
                       name: "Name",
                       progress: "Progress",
@@ -1298,18 +1286,14 @@ function ProjectSectionHeader({
               { value: "created_date", label: "Created date" },
               { value: "manual", label: "Manual" },
             ].map((opt) => {
-              const current = searchParams.get("sort") || "progress";
+              const current = modulesFilter.sort || "progress";
               return (
                 <button
                   key={opt.value}
                   type="button"
                   onClick={() => {
-                    setSearchParams((prev) => {
-                      const next = new URLSearchParams(prev);
-                      next.set("sort", opt.value);
-                      if (!prev.get("order")) next.set("order", "asc");
-                      return next;
-                    });
+                    modulesFilter.setSort(opt.value);
+                    if (!modulesFilter.order) modulesFilter.setOrder("asc");
                     setModulesSortOpen(null);
                   }}
                   className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
@@ -1325,18 +1309,14 @@ function ProjectSectionHeader({
             })}
             <div className="my-1 border-t border-(--border-subtle)" />
             {["asc", "desc"].map((orderValue) => {
-              const currentOrder = searchParams.get("order") || "asc";
+              const currentOrder = modulesFilter.order || "asc";
               const label = orderValue === "asc" ? "Ascending" : "Descending";
               return (
                 <button
                   key={orderValue}
                   type="button"
                   onClick={() => {
-                    setSearchParams((prev) => {
-                      const next = new URLSearchParams(prev);
-                      next.set("order", orderValue);
-                      return next;
-                    });
+                    modulesFilter.setOrder(orderValue as "asc" | "desc");
                     setModulesSortOpen(null);
                   }}
                   className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
@@ -1383,13 +1363,13 @@ function ProjectSectionHeader({
               />
             </Dropdown>
             {[
-              searchParams.get("search")?.trim(),
-              searchParams.get(MODULE_FILTER_PARAM.favorites),
-              searchParams.get(MODULE_FILTER_PARAM.status)?.trim(),
-              searchParams.get(MODULE_FILTER_PARAM.lead)?.trim(),
-              searchParams.get(MODULE_FILTER_PARAM.members)?.trim(),
-              searchParams.get(MODULE_FILTER_PARAM.start_date)?.trim(),
-              searchParams.get(MODULE_FILTER_PARAM.due_date)?.trim(),
+              modulesFilter.search.trim(),
+              modulesFilter.favorites ? "1" : "",
+              modulesFilter.status.join(","),
+              modulesFilter.lead.join(","),
+              modulesFilter.members.join(","),
+              modulesFilter.startDateList.join(","),
+              modulesFilter.dueDateList.join(","),
             ].some(Boolean) && (
               <span
                 className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-(--brand-default)"
@@ -1400,7 +1380,7 @@ function ProjectSectionHeader({
           <div className="flex h-8 overflow-hidden rounded-lg border border-(--border-subtle) bg-(--bg-layer-2) p-0.5">
             <button
               type="button"
-              onClick={() => handleLayoutChange("list")}
+              onClick={() => modulesFilter.setLayout("list")}
               className={`flex size-7 items-center justify-center rounded-l-md text-(--txt-icon-secondary) transition-colors ${
                 listActive
                   ? "bg-white shadow-sm text-(--txt-primary)"
@@ -1413,7 +1393,7 @@ function ProjectSectionHeader({
             </button>
             <button
               type="button"
-              onClick={() => handleLayoutChange("gallery")}
+              onClick={() => modulesFilter.setLayout("gallery")}
               className={`flex size-7 items-center justify-center text-(--txt-icon-secondary) transition-colors ${
                 galleryActive
                   ? "bg-white shadow-sm text-(--txt-primary)"
@@ -1426,7 +1406,7 @@ function ProjectSectionHeader({
             </button>
             <button
               type="button"
-              onClick={() => handleLayoutChange("timeline")}
+              onClick={() => modulesFilter.setLayout("timeline")}
               className={`flex size-7 items-center justify-center rounded-r-md text-(--txt-icon-secondary) transition-colors ${
                 timelineActive
                   ? "bg-white shadow-sm text-(--txt-primary)"
@@ -1572,32 +1552,24 @@ function ProjectSectionHeader({
             }
             after={
               modulesDateRangeModal === "start"
-                ? (searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ??
-                  null)
-                : (searchParams.get(MODULE_FILTER_PARAM.due_after)?.trim() ??
-                  null)
+                ? (modulesFilter.startAfter ?? null)
+                : (modulesFilter.dueAfter ?? null)
             }
             before={
               modulesDateRangeModal === "start"
-                ? (searchParams.get(MODULE_FILTER_PARAM.start_before)?.trim() ??
-                  null)
-                : (searchParams.get(MODULE_FILTER_PARAM.due_before)?.trim() ??
-                  null)
+                ? (modulesFilter.startBefore ?? null)
+                : (modulesFilter.dueBefore ?? null)
             }
             onApply={(after, before) => {
-              setSearchParams((prev) => {
-                const next = new URLSearchParams(prev);
-                if (modulesDateRangeModal === "start") {
-                  next.set(MODULE_FILTER_PARAM.start_date, "custom");
-                  next.set(MODULE_FILTER_PARAM.start_after, after);
-                  next.set(MODULE_FILTER_PARAM.start_before, before);
-                } else {
-                  next.set(MODULE_FILTER_PARAM.due_date, "custom");
-                  next.set(MODULE_FILTER_PARAM.due_after, after);
-                  next.set(MODULE_FILTER_PARAM.due_before, before);
-                }
-                return next;
-              });
+              if (modulesDateRangeModal === "start") {
+                modulesFilter.setStartDateList(["custom"]);
+                modulesFilter.setStartAfter(after);
+                modulesFilter.setStartBefore(before);
+              } else {
+                modulesFilter.setDueDateList(["custom"]);
+                modulesFilter.setDueAfter(after);
+                modulesFilter.setDueBefore(before);
+              }
               setModulesDateRangeModal(null);
             }}
           />

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -800,6 +800,7 @@ function ProjectSectionHeader({
   issueCount: number;
 }) {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const baseUrl = `/${workspaceSlug}/projects/${projectId}`;
   const issuesUrl = `${baseUrl}/issues`;
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
@@ -858,6 +859,15 @@ function ProjectSectionHeader({
               : `${targetBase}/pages`;
     setProjectDropdownOpen(false);
     navigate(targetPath);
+  };
+
+  const currentLayout =
+    (searchParams.get("layout") as "list" | "gallery" | "timeline") || "list";
+
+  const handleLayoutChange = (layout: "list" | "gallery" | "timeline") => {
+    const next = new URLSearchParams(searchParams);
+    next.set("layout", layout);
+    setSearchParams(next);
   };
 
   const rightActions = () => {
@@ -954,6 +964,9 @@ function ProjectSectionHeader({
       );
     }
     if (section === "modules") {
+      const listActive = currentLayout === "list";
+      const galleryActive = currentLayout === "gallery";
+      const timelineActive = currentLayout === "timeline";
       return (
         <>
           <button
@@ -967,7 +980,7 @@ function ProjectSectionHeader({
             type="button"
             className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
           >
-            <IconArrowUpDown /> Name <IconChevronDown />
+            <IconArrowUpDown /> Progress <IconChevronDown />
           </button>
           <button
             type="button"
@@ -975,30 +988,47 @@ function ProjectSectionHeader({
           >
             <IconFilter /> Filters <IconChevronDown />
           </button>
-          <button
-            type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent bg-[var(--bg-accent-subtle)] text-[var(--brand-default)] hover:bg-[var(--bg-accent-subtle-hover)]"
-            aria-label="List view"
-            title="List view"
-          >
-            <IconList />
-          </button>
-          <button
-            type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
-            aria-label="Grid view"
-            title="Grid view"
-          >
-            <IconLayoutGrid />
-          </button>
-          <button
-            type="button"
-            className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
-            aria-label="Stack view"
-            title="Stack view"
-          >
-            <IconStack />
-          </button>
+          <div className="flex items-center gap-0.5 rounded-md bg-[var(--bg-layer-2)] p-0.5">
+            <button
+              type="button"
+              onClick={() => handleLayoutChange("list")}
+              className={`flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-secondary)] transition-colors ${
+                listActive
+                  ? "bg-[var(--bg-canvas)] shadow-sm"
+                  : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+              }`}
+              aria-pressed={listActive}
+              title="List layout"
+            >
+              <IconList />
+            </button>
+            <button
+              type="button"
+              onClick={() => handleLayoutChange("gallery")}
+              className={`flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-secondary)] transition-colors ${
+                galleryActive
+                  ? "bg-[var(--bg-canvas)] shadow-sm"
+                  : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+              }`}
+              aria-pressed={galleryActive}
+              title="Gallery layout"
+            >
+              <IconLayoutGrid />
+            </button>
+            <button
+              type="button"
+              onClick={() => handleLayoutChange("timeline")}
+              className={`flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-secondary)] transition-colors ${
+                timelineActive
+                  ? "bg-[var(--bg-canvas)] shadow-sm"
+                  : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+              }`}
+              aria-pressed={timelineActive}
+              title="Timeline layout"
+            >
+              <IconStack />
+            </button>
+          </div>
           <Button size="sm" className="gap-1.5 text-[13px] font-medium">
             <IconPlus /> Add Module
           </Button>
@@ -1098,9 +1128,6 @@ function ProjectSectionHeader({
             </div>
           </div>
         )}
-        <span className="text-[var(--txt-icon-tertiary)]" aria-hidden>
-          &gt;
-        </span>
         <ProjectSectionDropdown
           baseUrl={baseUrl}
           currentSection={section}

--- a/ui/src/components/layout/PageHeader.tsx
+++ b/ui/src/components/layout/PageHeader.tsx
@@ -22,10 +22,12 @@ import { workspaceService } from "../../services/workspaceService";
 import { projectService } from "../../services/projectService";
 import { issueService } from "../../services/issueService";
 import { viewService } from "../../services/viewService";
+import { moduleService } from "../../services/moduleService";
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
   IssueViewApiResponse,
+  ModuleApiResponse,
 } from "../../api/types";
 
 export type ProjectSection =
@@ -784,6 +786,145 @@ function ProjectDetailHeader({
           aria-label="Search"
         >
           <IconSearch />
+        </button>
+      </div>
+    </>
+  );
+}
+
+const IconListAlt = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
+  </svg>
+);
+const IconBarChart = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path d="M12 20V10M18 20V4M6 20v-4" />
+  </svg>
+);
+const IconLayoutGrid = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <rect width="7" height="7" x="3" y="3" rx="1" />
+    <rect width="7" height="7" x="14" y="3" rx="1" />
+    <rect width="7" height="7" x="14" y="14" rx="1" />
+    <rect width="7" height="7" x="3" y="14" rx="1" />
+  </svg>
+);
+const IconSliders = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <line x1="4" y1="21" x2="4" y2="14" />
+    <line x1="4" y1="10" x2="4" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="12" />
+    <line x1="12" y1="8" x2="12" y2="3" />
+    <line x1="20" y1="21" x2="20" y2="16" />
+    <line x1="20" y1="12" x2="20" y2="3" />
+    <line x1="1" y1="14" x2="7" y2="14" />
+    <line x1="9" y1="8" x2="15" y2="8" />
+    <line x1="17" y1="16" x2="23" y2="16" />
+  </svg>
+);
+
+function ModuleDetailHeader({
+  workspaceSlug,
+  projectId,
+  projectName,
+  moduleId,
+  moduleName,
+}: {
+  workspaceSlug: string;
+  projectId: string;
+  projectName: string;
+  moduleId: string;
+  moduleName: string;
+}) {
+  const baseUrl = `/${workspaceSlug}/projects/${projectId}`;
+  const [moduleDropdownOpen, setModuleDropdownOpen] = useState(false);
+  const [viewLayout, setViewLayout] = useState<"list" | "board" | "calendar" | "gallery" | "timeline">("list");
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setModuleDropdownOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const viewButtons: { id: typeof viewLayout; icon: React.ReactNode; label: string }[] = [
+    { id: "list", icon: <IconListAlt />, label: "List" },
+    { id: "board", icon: <IconBarChart />, label: "Board" },
+    { id: "calendar", icon: <IconCalendar />, label: "Calendar" },
+    { id: "gallery", icon: <IconLayoutGrid />, label: "Gallery" },
+    { id: "timeline", icon: <IconListAlt />, label: "Timeline" },
+  ];
+
+  return (
+    <>
+      <div className="flex min-w-0 flex-1 items-center gap-2 text-sm text-(--txt-primary)">
+        <Link to={baseUrl} className="shrink-0 truncate font-medium text-(--txt-secondary) hover:text-(--txt-primary) hover:underline">
+          {projectName}
+        </Link>
+        <span className="shrink-0 text-(--txt-icon-tertiary)">/</span>
+        <Link to={`${baseUrl}/modules`} className="shrink-0 truncate font-medium text-(--txt-secondary) hover:text-(--txt-primary) hover:underline">
+          Modules
+        </Link>
+        <span className="shrink-0 text-(--txt-icon-tertiary)">/</span>
+        <div ref={ref} className="relative shrink-0">
+          <button
+            type="button"
+            onClick={() => setModuleDropdownOpen((o) => !o)}
+            className="flex items-center gap-1 truncate rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover)"
+          >
+            <span className="min-w-0 truncate">{moduleName}</span>
+            <span className="shrink-0 text-(--txt-icon-tertiary)">
+              <IconChevronDown />
+            </span>
+          </button>
+          {moduleDropdownOpen && (
+            <div className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)">
+              <Link to={`${baseUrl}/modules`} className="block px-3 py-2 text-left text-sm text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)" onClick={() => setModuleDropdownOpen(false)}>
+                All modules
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <div className="flex h-8 overflow-hidden rounded-lg border border-(--border-subtle) bg-(--bg-layer-2) p-0.5">
+          {viewButtons.map((b, i) => (
+            <button
+              key={b.id}
+              type="button"
+              onClick={() => setViewLayout(b.id)}
+              className={`flex size-7 items-center justify-center rounded-md text-(--txt-icon-secondary) transition-colors ${
+                viewLayout === b.id ? "bg-white shadow-sm text-(--txt-primary)" : "bg-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
+              } ${i === 0 ? "rounded-l-md" : ""} ${i === viewButtons.length - 1 ? "rounded-r-md" : ""}`}
+              title={b.label}
+              aria-pressed={viewLayout === b.id}
+            >
+              {b.icon}
+            </button>
+          ))}
+        </div>
+        <button type="button" className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)">
+          <IconFilter />
+          Filters
+        </button>
+        <button type="button" className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)">
+          <IconSliders />
+          Display
+        </button>
+        <button type="button" className="flex h-8 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)">
+          Analytics
+        </button>
+        <Link to={`${baseUrl}/issues?create=1`}>
+          <Button size="sm" className="gap-1.5 text-[13px] font-medium">
+            <IconPlus />
+            Add work item
+          </Button>
+        </Link>
+        <button type="button" className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)" aria-label="More options">
+          <IconMoreVertical />
         </button>
       </div>
     </>
@@ -1672,9 +1813,10 @@ function AnalyticsHeader({ workspaceSlug }: { workspaceSlug: string }) {
 
 export function PageHeader() {
   const location = useLocation();
-  const { workspaceSlug, projectId } = useParams<{
+  const { workspaceSlug, projectId, moduleId } = useParams<{
     workspaceSlug?: string;
     projectId?: string;
+    moduleId?: string;
   }>();
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
@@ -1682,6 +1824,7 @@ export function PageHeader() {
   void projects; // reserved for future use (e.g. breadcrumb, project list)
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [projectIssueCount, setProjectIssueCount] = useState(0);
+  const [module, setModule] = useState<ModuleApiResponse | null>(null);
 
   useEffect(() => {
     if (!workspaceSlug) {
@@ -1742,6 +1885,25 @@ export function PageHeader() {
     };
   }, [workspaceSlug, projectId]);
 
+  useEffect(() => {
+    if (!workspaceSlug || !projectId || !moduleId) {
+      setModule(null);
+      return;
+    }
+    let cancelled = false;
+    moduleService
+      .get(workspaceSlug, projectId, moduleId)
+      .then((m) => {
+        if (!cancelled) setModule(m ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setModule(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId, moduleId]);
+
   const pathname = location.pathname;
 
   // Match route patterns to pick header
@@ -1757,6 +1919,8 @@ export function PageHeader() {
   const isIssuesPage = projectBase && pathname === `${projectBase}/issues`;
   const isCyclesPage = projectBase && pathname === `${projectBase}/cycles`;
   const isModulesPage = projectBase && pathname === `${projectBase}/modules`;
+  const isModuleDetailPage =
+    projectBase && moduleId && pathname === `${projectBase}/modules/${moduleId}`;
   const isViewsPage = projectBase && pathname === `${projectBase}/views`;
   const isPagesPage = projectBase && pathname === `${projectBase}/pages`;
   const isProjectSection =
@@ -1805,6 +1969,22 @@ export function PageHeader() {
     content = <AnalyticsHeader workspaceSlug={workspaceSlug} />;
   } else if (isWorkspaceViewsPage && workspaceSlug) {
     content = <WorkspaceViewsHeader />;
+  } else if (
+    isModuleDetailPage &&
+    workspaceSlug &&
+    projectId &&
+    project &&
+    module
+  ) {
+    content = (
+      <ModuleDetailHeader
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
+        projectName={project.name}
+        moduleId={module.id}
+        moduleName={module.name}
+      />
+    );
   } else if (
     isProjectSection &&
     workspaceSlug &&

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+﻿import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link, NavLink, useLocation, useParams } from "react-router-dom";
 import { workspaceService } from "../../services/workspaceService";
@@ -590,7 +590,7 @@ export function Sidebar() {
   return (
     <>
       <div
-        className="flex h-full shrink-0 flex-col border-r border-[var(--border-subtle)] bg-[var(--bg-surface-1)] transition-all duration-300 ease-in-out"
+        className="flex h-full shrink-0 flex-col border-r border-(--border-subtle) bg-(--bg-surface-1) transition-all duration-300 ease-in-out"
         style={{
           width: `${width}px`,
           minWidth: `${width}px`,
@@ -599,19 +599,19 @@ export function Sidebar() {
         role="complementary"
         aria-label="Main sidebar"
       >
-        <aside className="flex h-full w-full flex-col overflow-hidden bg-[var(--bg-surface-1)]">
+        <aside className="flex h-full w-full flex-col overflow-hidden bg-(--bg-surface-1)">
           {/* 1. Top: Workspace name (left, clickable) + User avatar (right) */}
           <div className="relative flex items-center justify-between gap-2 px-3 py-3">
             <button
               ref={workspaceTriggerRef}
               type="button"
               onClick={() => setWorkspaceDropdownOpen((o) => !o)}
-              className="group flex min-w-0 flex-1 items-center gap-2 rounded-[var(--radius-md)] py-0.5 text-left outline-none hover:bg-[var(--bg-layer-transparent-hover)] focus-visible:outline-none"
+              className="group flex min-w-0 flex-1 items-center gap-2 rounded-(--radius-md) py-0.5 text-left outline-none hover:bg-(--bg-layer-transparent-hover) focus-visible:outline-none"
               aria-expanded={workspaceDropdownOpen}
               aria-haspopup="true"
               aria-label="Workspace menu"
             >
-              <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius-md)] bg-[var(--bg-layer-1)] text-sm font-semibold text-[var(--txt-secondary)]">
+              <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-(--radius-md) bg-(--bg-layer-1) text-sm font-semibold text-(--txt-secondary)">
                 {workspace?.logo && getImageUrl(workspace.logo) ? (
                   <img
                     src={getImageUrl(workspace.logo)!}
@@ -622,12 +622,12 @@ export function Sidebar() {
                   (workspace?.name ?? "—").slice(0, 2).toUpperCase()
                 )}
               </div>
-              <span className="min-w-0 flex-1 truncate text-sm font-semibold text-[var(--txt-primary)]">
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold text-(--txt-primary)">
                 {workspace?.name ?? "Loading…"}
               </span>
               <span
                 className={cn(
-                  "shrink-0 text-[var(--txt-icon-tertiary)] transition-opacity",
+                  "shrink-0 text-(--txt-icon-tertiary) transition-opacity",
                   workspaceDropdownOpen
                     ? "opacity-100"
                     : "opacity-0 group-hover:opacity-100",
@@ -645,7 +645,7 @@ export function Sidebar() {
               <button
                 type="button"
                 onClick={() => setCollapsed(true)}
-                className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
                 aria-label="Collapse sidebar"
               >
                 <IconPanelLeft />
@@ -664,7 +664,7 @@ export function Sidebar() {
             createPortal(
               <div
                 ref={workspaceDropdownRef}
-                className="z-50 min-w-[280px] rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4 shadow-[var(--shadow-lg)]"
+                className="z-50 min-w-[280px] rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) p-4 shadow-(--shadow-lg)"
                 style={{
                   position: "fixed",
                   top: dropdownPosition.top,
@@ -675,11 +675,11 @@ export function Sidebar() {
                 role="menu"
                 aria-label="Workspace menu"
               >
-                <p className="mb-3 truncate text-sm text-[var(--txt-primary)]">
+                <p className="mb-3 truncate text-sm text-(--txt-primary)">
                   {user?.email}
                 </p>
                 <div className="mb-4 flex items-start gap-3">
-                  <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-xs font-semibold uppercase tracking-wide text-[var(--txt-secondary)]">
+                  <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full border border-(--border-subtle) bg-(--bg-layer-2) text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">
                     {workspace?.logo && getImageUrl(workspace.logo) ? (
                       <img
                         src={getImageUrl(workspace.logo)!}
@@ -691,15 +691,15 @@ export function Sidebar() {
                     )}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-semibold text-[var(--txt-primary)]">
+                    <p className="truncate text-sm font-semibold text-(--txt-primary)">
                       {workspace?.name ?? "—"}
                     </p>
-                    <p className="text-xs text-[var(--txt-tertiary)]">
+                    <p className="text-xs text-(--txt-tertiary)">
                       Members
                     </p>
                   </div>
                   <span
-                    className="shrink-0 text-[var(--txt-primary)]"
+                    className="shrink-0 text-(--txt-primary)"
                     aria-hidden
                   >
                     <IconCheck />
@@ -709,7 +709,7 @@ export function Sidebar() {
                   <Link
                     to={baseUrl ? `${baseUrl}/settings` : "/settings"}
                     onClick={() => setWorkspaceDropdownOpen(false)}
-                    className="flex flex-1 items-center justify-center gap-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-1.5 py-1.5 text-[12px] font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2-hover)] whitespace-nowrap"
+                    className="flex flex-1 items-center justify-center gap-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-1.5 py-1.5 text-[12px] font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover) whitespace-nowrap"
                   >
                     <IconSettings />
                     Settings
@@ -721,13 +721,13 @@ export function Sidebar() {
                         : "/settings"
                     }
                     onClick={() => setWorkspaceDropdownOpen(false)}
-                    className="flex flex-1 items-center justify-center gap-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-1.5 py-1.5 text-[12px] font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2-hover)] whitespace-nowrap no-underline"
+                    className="flex flex-1 items-center justify-center gap-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-1.5 py-1.5 text-[12px] font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover) whitespace-nowrap no-underline"
                   >
                     <IconUserPlus />
                     Invite members
                   </Link>
                 </div>
-                <div className="flex flex-col gap-0.5 border-t border-[var(--border-subtle)] pt-3">
+                <div className="flex flex-col gap-0.5 border-t border-(--border-subtle) pt-3">
                   <Link
                     to={
                       baseUrl
@@ -735,7 +735,7 @@ export function Sidebar() {
                         : "/settings"
                     }
                     onClick={() => setWorkspaceDropdownOpen(false)}
-                    className="flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-2 text-left text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)] no-underline"
+                    className="flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-2 text-left text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary) no-underline"
                   >
                     <IconEnvelope />
                     Workspace invites
@@ -746,7 +746,7 @@ export function Sidebar() {
                       setWorkspaceDropdownOpen(false);
                       logout();
                     }}
-                    className="flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-2 text-left text-[13px] font-medium text-[var(--txt-danger-primary)] hover:bg-[var(--bg-danger-subtle)] hover:text-[var(--txt-danger-primary)]"
+                    className="flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-2 text-left text-[13px] font-medium text-(--txt-danger-primary) hover:bg-(--bg-danger-subtle) hover:text-(--txt-danger-primary)"
                   >
                     <IconLogOut />
                     Sign out
@@ -760,7 +760,7 @@ export function Sidebar() {
           <div className="flex items-center gap-2 px-3 py-2">
             <Button
               variant="secondary"
-              className="min-w-0 flex-1 justify-start gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="min-w-0 flex-1 justify-start gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-1-hover)"
               onClick={() => setCreateWorkItemOpen(true)}
             >
               <IconPencil />
@@ -768,7 +768,7 @@ export function Sidebar() {
             </Button>
             <button
               type="button"
-              className="flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex size-9 shrink-0 items-center justify-center rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover)"
               aria-label="Search"
             >
               <IconSearch />
@@ -784,17 +784,17 @@ export function Sidebar() {
                 end
                 className={({ isActive }) =>
                   cn(
-                    "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                    "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                     isActive
-                      ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                      : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                      ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                      : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                   )
                 }
               >
                 <span
                   className={cn(
                     "flex size-4 shrink-0 items-center justify-center",
-                    "text-[var(--txt-icon-tertiary)]",
+                    "text-(--txt-icon-tertiary)",
                   )}
                 >
                   <IconHome />
@@ -806,14 +806,14 @@ export function Sidebar() {
                 end
                 className={({ isActive }) =>
                   cn(
-                    "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                    "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                     isActive
-                      ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                      : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                      ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                      : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                   )
                 }
               >
-                <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                   <IconInbox />
                 </span>
                 Inbox
@@ -827,14 +827,14 @@ export function Sidebar() {
                 end
                 className={({ isActive }) =>
                   cn(
-                    "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                    "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                     isActive
-                      ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                      : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                      ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                      : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                   )
                 }
               >
-                <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                   <IconUser />
                 </span>
                 Your work
@@ -846,14 +846,14 @@ export function Sidebar() {
               <button
                 type="button"
                 onClick={() => setWorkspaceSectionExpanded((e) => !e)}
-                className="group flex w-full items-center justify-between gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide text-[var(--txt-placeholder)] outline-none hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-secondary)]"
+                className="group flex w-full items-center justify-between gap-2 rounded-(--radius-md) px-2 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide text-(--txt-placeholder) outline-none hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-secondary)"
                 aria-expanded={workspaceSectionExpanded}
               >
                 <span>Workspace</span>
                 <span className="flex size-4 shrink-0 items-center justify-center opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100">
                   <IconChevronRight
                     className={cn(
-                      "text-[var(--txt-icon-tertiary)]",
+                      "text-(--txt-icon-tertiary)",
                       workspaceSectionExpanded && "rotate-90",
                     )}
                   />
@@ -866,14 +866,14 @@ export function Sidebar() {
                     end
                     className={({ isActive }) =>
                       cn(
-                        "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                        "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                         isActive
-                          ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                          : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                          ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                          : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                       )
                     }
                   >
-                    <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                    <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                       <IconBriefcase />
                     </span>
                     Projects
@@ -882,15 +882,15 @@ export function Sidebar() {
                     to={baseUrl ? `${baseUrl}/views/all-issues` : "/"}
                     className={({ isActive }) =>
                       cn(
-                        "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                        "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                         isActive ||
                           location.pathname.startsWith(`${baseUrl}/views`)
-                          ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                          : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                          ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                          : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                       )
                     }
                   >
-                    <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                    <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                       <IconLayoutList />
                     </span>
                     Views
@@ -900,14 +900,14 @@ export function Sidebar() {
                     end={false}
                     className={({ isActive }) =>
                       cn(
-                        "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                        "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                         isActive
-                          ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                          : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                          ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                          : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                       )
                     }
                   >
-                    <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                    <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                       <IconBarChart />
                     </span>
                     Analytics
@@ -917,14 +917,14 @@ export function Sidebar() {
                     end
                     className={({ isActive }) =>
                       cn(
-                        "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                        "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                         isActive
-                          ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                          : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                          ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                          : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                       )
                     }
                   >
-                    <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                    <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                       <IconPencil />
                     </span>
                     Drafts
@@ -934,14 +934,14 @@ export function Sidebar() {
                     end
                     className={({ isActive }) =>
                       cn(
-                        "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
+                        "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium outline-none transition-colors",
                         isActive
-                          ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]"
-                          : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                          ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)"
+                          : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                       )
                     }
                   >
-                    <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                    <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                       <IconArchive />
                     </span>
                     Archives
@@ -955,14 +955,14 @@ export function Sidebar() {
               <button
                 type="button"
                 onClick={() => setFavoritesSectionExpanded((e) => !e)}
-                className="group flex w-full items-center justify-between gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide text-[var(--txt-placeholder)] outline-none hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-secondary)]"
+                className="group flex w-full items-center justify-between gap-2 rounded-(--radius-md) px-2 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide text-(--txt-placeholder) outline-none hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-secondary)"
                 aria-expanded={favoritesSectionExpanded}
               >
                 <span>Favorites</span>
                 <span className="flex size-4 shrink-0 items-center justify-center opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100">
                   <IconChevronRight
                     className={cn(
-                      "text-[var(--txt-icon-tertiary)]",
+                      "text-(--txt-icon-tertiary)",
                       favoritesSectionExpanded && "rotate-90",
                     )}
                   />
@@ -974,9 +974,9 @@ export function Sidebar() {
                     <Link
                       key={project.id}
                       to={`${baseUrl}/projects/${project.id}`}
-                      className="flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                      className="flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     >
-                      <div className="flex size-5 shrink-0 items-center justify-center rounded-sm bg-[var(--bg-layer-1)] text-[10px] font-medium text-[var(--txt-tertiary)]">
+                      <div className="flex size-5 shrink-0 items-center justify-center rounded-sm bg-(--bg-layer-1) text-[10px] font-medium text-(--txt-tertiary)">
                         {(project.identifier ?? project.id.slice(0, 2)).slice(
                           0,
                           2,
@@ -995,14 +995,14 @@ export function Sidebar() {
                 <button
                   type="button"
                   onClick={() => setProjectsSectionExpanded((e) => !e)}
-                  className="group flex w-full items-center justify-between gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide text-[var(--txt-placeholder)] outline-none hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-secondary)]"
+                  className="group flex w-full items-center justify-between gap-2 rounded-(--radius-md) px-2 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide text-(--txt-placeholder) outline-none hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-secondary)"
                   aria-expanded={projectsSectionExpanded}
                 >
                   <span>Projects</span>
                   <span className="flex size-4 shrink-0 items-center justify-center opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100">
                     <IconChevronRight
                       className={cn(
-                        "text-[var(--txt-icon-tertiary)]",
+                        "text-(--txt-icon-tertiary)",
                         projectsSectionExpanded && "rotate-90",
                       )}
                     />
@@ -1021,11 +1021,11 @@ export function Sidebar() {
                         <button
                           type="button"
                           onClick={() => toggleProject(project.id)}
-                          className="group flex w-full items-center justify-between gap-2 rounded-[var(--radius-md)] px-1.5 py-1.5 text-left text-[13px] font-medium text-[var(--txt-secondary)] outline-none hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                          className="group flex w-full items-center justify-between gap-2 rounded-(--radius-md) px-1.5 py-1.5 text-left text-[13px] font-medium text-(--txt-secondary) outline-none hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                           aria-expanded={isExpanded}
                         >
                           <span className="flex min-w-0 flex-1 items-center gap-2">
-                            <div className="flex size-5 shrink-0 items-center justify-center rounded-sm bg-[var(--bg-layer-1)] text-[10px] font-medium text-[var(--txt-tertiary)]">
+                            <div className="flex size-5 shrink-0 items-center justify-center rounded-sm bg-(--bg-layer-1) text-[10px] font-medium text-(--txt-tertiary)">
                               {(
                                 project.identifier ?? project.id.slice(0, 2)
                               ).slice(0, 2)}
@@ -1035,28 +1035,28 @@ export function Sidebar() {
                           <span className="flex size-5 shrink-0 items-center justify-center opacity-0 transition-[opacity,transform] duration-150 group-hover:opacity-100">
                             <IconChevronRight
                               className={cn(
-                                "text-[var(--txt-icon-tertiary)]",
+                                "text-(--txt-icon-tertiary)",
                                 isExpanded && "rotate-90",
                               )}
                             />
                           </span>
                         </button>
                         {isExpanded && (
-                          <div className="ml-5 flex flex-col gap-0.5 border-l border-[var(--border-subtle)] pl-2">
+                          <div className="ml-5 flex flex-col gap-0.5 border-l border-(--border-subtle) pl-2">
                             {projectNavItems.map(({ key, to, label, Icon }) => (
                               <NavLink
                                 key={key}
                                 to={`${projectUrl}/${to}`}
                                 className={({ isActive }) =>
                                   cn(
-                                    "flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1 text-[13px] font-medium outline-none",
+                                    "flex w-full items-center gap-2 rounded-(--radius-md) px-2 py-1 text-[13px] font-medium outline-none",
                                     isActive
-                                      ? "bg-[var(--bg-layer-transparent-active)] text-[var(--txt-primary)]"
-                                      : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]",
+                                      ? "bg-(--bg-layer-transparent-active) text-(--txt-primary)"
+                                      : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)",
                                   )
                                 }
                               >
-                                <span className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                                <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
                                   <Icon />
                                 </span>
                                 {label}
@@ -1073,25 +1073,25 @@ export function Sidebar() {
           </div>
 
           {/* 8. Footer: Community + Help + Settings */}
-          <div className="flex items-center justify-between gap-2 border-t border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2 border-t border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2.5">
             {/* <Button
               variant="secondary"
               size="sm"
-              className="rounded-full px-3 text-[12px] font-medium text-[var(--txt-accent-primary)]"
+              className="rounded-full px-3 text-[12px] font-medium text-(--txt-accent-primary)"
             >
               Community
             </Button> */}
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
-                className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-icon-secondary)]"
+                className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-icon-secondary)"
                 aria-label="Help"
               >
                 <IconHelp />
               </button>
               <Link
                 to={baseUrl ? `${baseUrl}/settings` : "/settings"}
-                className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-icon-secondary)]"
+                className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-icon-secondary)"
                 aria-label="Settings"
               >
                 <IconBook />
@@ -1103,13 +1103,13 @@ export function Sidebar() {
 
       {collapsed && (
         <div
-          className="flex shrink-0 flex-col items-center border-r border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-3"
+          className="flex shrink-0 flex-col items-center border-r border-(--border-subtle) bg-(--bg-surface-1) py-3"
           style={{ width: "48px", minWidth: "48px" }}
         >
           <button
             type="button"
             onClick={() => setCollapsed(false)}
-            className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+            className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
             aria-label="Expand sidebar"
           >
             <span className="rotate-180">

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -694,14 +694,9 @@ export function Sidebar() {
                     <p className="truncate text-sm font-semibold text-(--txt-primary)">
                       {workspace?.name ?? "—"}
                     </p>
-                    <p className="text-xs text-(--txt-tertiary)">
-                      Members
-                    </p>
+                    <p className="text-xs text-(--txt-tertiary)">Members</p>
                   </div>
-                  <span
-                    className="shrink-0 text-(--txt-primary)"
-                    aria-hidden
-                  >
+                  <span className="shrink-0 text-(--txt-primary)" aria-hidden>
                     <IconCheck />
                   </span>
                 </div>

--- a/ui/src/components/ui/Avatar.tsx
+++ b/ui/src/components/ui/Avatar.tsx
@@ -1,4 +1,4 @@
-import { cn } from "../../lib/utils";
+﻿import { cn } from "../../lib/utils";
 
 export type AvatarSize = "sm" | "md" | "lg";
 
@@ -28,7 +28,7 @@ export function Avatar({ name, src, size = "md", className }: AvatarProps) {
   return (
     <span
       className={cn(
-        "inline-flex shrink-0 items-center justify-center rounded-full bg-[var(--bg-accent-primary)] font-medium text-[var(--txt-on-color)]",
+        "inline-flex shrink-0 items-center justify-center rounded-full bg-(--bg-accent-primary) font-medium text-(--txt-on-color)",
         sizeStyles[size],
         className,
       )}

--- a/ui/src/components/ui/Badge.tsx
+++ b/ui/src/components/ui/Badge.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes } from "react";
+﻿import { type HTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 export type BadgeVariant =
@@ -13,11 +13,11 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]",
-  success: "bg-[var(--bg-success-subtle)] text-[var(--txt-success-primary)]",
-  warning: "bg-[var(--bg-warning-subtle)] text-[var(--txt-warning-primary)]",
-  danger: "bg-[var(--bg-danger-subtle)] text-[var(--txt-danger-primary)]",
-  neutral: "bg-[var(--bg-layer-1)] text-[var(--txt-secondary)]",
+  default: "bg-(--bg-accent-subtle) text-(--txt-accent-primary)",
+  success: "bg-(--bg-success-subtle) text-(--txt-success-primary)",
+  warning: "bg-(--bg-warning-subtle) text-(--txt-warning-primary)",
+  danger: "bg-(--bg-danger-subtle) text-(--txt-danger-primary)",
+  neutral: "bg-(--bg-layer-1) text-(--txt-secondary)",
 };
 
 export function Badge({

--- a/ui/src/components/ui/Button.tsx
+++ b/ui/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ButtonHTMLAttributes } from "react";
+﻿import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
@@ -12,19 +12,19 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:
-    "bg-[var(--bg-accent-primary)] text-[var(--txt-on-color)] hover:bg-[var(--bg-accent-primary-hover)] active:bg-[var(--bg-accent-primary-active)] disabled:opacity-50",
+    "bg-(--bg-accent-primary) text-(--txt-on-color) hover:bg-(--bg-accent-primary-hover) active:bg-(--bg-accent-primary-active) disabled:opacity-50",
   secondary:
-    "bg-[var(--bg-layer-1)] text-[var(--txt-primary)] border border-[var(--border-subtle)] hover:bg-[var(--bg-layer-1-hover)] active:bg-[var(--bg-layer-1-active)] disabled:opacity-50",
+    "bg-(--bg-layer-1) text-(--txt-primary) border border-(--border-subtle) hover:bg-(--bg-layer-1-hover) active:bg-(--bg-layer-1-active) disabled:opacity-50",
   ghost:
-    "bg-transparent text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1)] active:bg-[var(--bg-layer-1-hover)] disabled:opacity-50",
+    "bg-transparent text-(--txt-primary) hover:bg-(--bg-layer-1) active:bg-(--bg-layer-1-hover) disabled:opacity-50",
   danger:
-    "bg-[var(--bg-danger-primary)] text-[var(--txt-on-color)] hover:bg-[var(--bg-danger-primary-hover)] active:opacity-90 disabled:opacity-50",
+    "bg-(--bg-danger-primary) text-(--txt-on-color) hover:bg-(--bg-danger-primary-hover) active:opacity-90 disabled:opacity-50",
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
-  sm: "h-8 px-3 text-sm rounded-[var(--radius-md)]",
-  md: "h-9 px-4 text-sm rounded-[var(--radius-md)]",
-  lg: "h-10 px-5 text-base rounded-[var(--radius-lg)]",
+  sm: "h-8 px-3 text-sm rounded-(--radius-md)",
+  md: "h-9 px-4 text-sm rounded-(--radius-md)",
+  lg: "h-10 px-5 text-base rounded-(--radius-lg)",
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/ui/src/components/ui/Card.tsx
+++ b/ui/src/components/ui/Card.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes } from "react";
+﻿import { type HTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
@@ -14,10 +14,10 @@ export function Card({
   return (
     <div
       className={cn(
-        "rounded-[var(--radius-lg)] bg-[var(--bg-layer-2)]",
+        "rounded-(--radius-lg) bg-(--bg-layer-2)",
         variant === "elevated" &&
-          "border border-[var(--border-subtle)] shadow-[var(--shadow-raised)]",
-        variant === "outlined" && "border border-[var(--border-subtle)]",
+          "border border-(--border-subtle) shadow-(--shadow-raised)",
+        variant === "outlined" && "border border-(--border-subtle)",
         className,
       )}
       {...props}
@@ -34,7 +34,7 @@ export function CardHeader({ className, children, ...props }: CardHeaderProps) {
   return (
     <div
       className={cn(
-        "border-b border-[var(--border-subtle)] px-4 py-3",
+        "border-b border-(--border-subtle) px-4 py-3",
         className,
       )}
       {...props}

--- a/ui/src/components/ui/Card.tsx
+++ b/ui/src/components/ui/Card.tsx
@@ -33,10 +33,7 @@ export type CardHeaderProps = HTMLAttributes<HTMLDivElement>;
 export function CardHeader({ className, children, ...props }: CardHeaderProps) {
   return (
     <div
-      className={cn(
-        "border-b border-(--border-subtle) px-4 py-3",
-        className,
-      )}
+      className={cn("border-b border-(--border-subtle) px-4 py-3", className)}
       {...props}
     >
       {children}

--- a/ui/src/components/ui/Input.tsx
+++ b/ui/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type InputHTMLAttributes } from "react";
+﻿import { forwardRef, type InputHTMLAttributes } from "react";
 import { cn } from "../../lib/utils";
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -14,7 +14,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         {label && (
           <label
             htmlFor={inputId}
-            className="text-sm font-medium text-[var(--txt-secondary)]"
+            className="text-sm font-medium text-(--txt-secondary)"
           >
             {label}
           </label>
@@ -23,14 +23,14 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           id={inputId}
           className={cn(
-            "h-9 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none",
-            error && "border-[var(--border-danger-strong)]",
+            "h-9 w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none",
+            error && "border-(--border-danger-strong)",
             className,
           )}
           {...props}
         />
         {error && (
-          <span className="text-xs text-[var(--txt-danger-primary)]">
+          <span className="text-xs text-(--txt-danger-primary)">
             {error}
           </span>
         )}

--- a/ui/src/components/ui/Input.tsx
+++ b/ui/src/components/ui/Input.tsx
@@ -30,9 +30,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           {...props}
         />
         {error && (
-          <span className="text-xs text-(--txt-danger-primary)">
-            {error}
-          </span>
+          <span className="text-xs text-(--txt-danger-primary)">{error}</span>
         )}
       </div>
     );

--- a/ui/src/components/ui/Modal.tsx
+++ b/ui/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+﻿import { useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "../../lib/utils";
 
@@ -42,28 +42,28 @@ export function Modal({
       aria-labelledby="modal-title"
     >
       <div
-        className="absolute inset-0 bg-[var(--bg-backdrop)]"
+        className="absolute inset-0 bg-(--bg-backdrop)"
         onClick={onClose}
         aria-hidden
       />
       <div
         className={cn(
-          "relative z-10 w-full max-w-md rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-overlay)]",
+          "relative z-10 w-full max-w-md rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay)",
           className,
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="border-b border-[var(--border-subtle)] px-5 py-4">
+        <div className="border-b border-(--border-subtle) px-5 py-4">
           <h2
             id="modal-title"
-            className="text-lg font-semibold text-[var(--txt-primary)]"
+            className="text-lg font-semibold text-(--txt-primary)"
           >
             {title}
           </h2>
         </div>
         <div className="px-5 py-4">{children}</div>
         {footer != null && (
-          <div className="flex justify-end gap-2 border-t border-[var(--border-subtle)] px-5 py-4">
+          <div className="flex justify-end gap-2 border-t border-(--border-subtle) px-5 py-4">
             {footer}
           </div>
         )}

--- a/ui/src/components/ui/Skeleton.tsx
+++ b/ui/src/components/ui/Skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "../../lib/utils";
+﻿import { cn } from "../../lib/utils";
 
 interface SkeletonProps {
   className?: string;
@@ -7,7 +7,7 @@ interface SkeletonProps {
 export function Skeleton({ className }: SkeletonProps) {
   return (
     <div
-      className={cn("animate-pulse rounded bg-[var(--neutral-300)]", className)}
+      className={cn("animate-pulse rounded bg-(--neutral-300)", className)}
       aria-hidden
     />
   );

--- a/ui/src/components/work-item/CommentEditor.tsx
+++ b/ui/src/components/work-item/CommentEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+﻿import { useEffect } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -61,11 +61,11 @@ export function CommentEditor({
   };
 
   const buttonBase =
-    "inline-flex h-8 w-8 items-center justify-center rounded border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)] disabled:opacity-40";
+    "inline-flex h-8 w-8 items-center justify-center rounded border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary) disabled:opacity-40";
 
   return (
-    <div className="rounded-md bg-[var(--bg-surface-1)]">
-      <div className="flex items-center gap-1 border-b border-[var(--border-subtle)] px-2 py-1">
+    <div className="rounded-md bg-(--bg-surface-1)">
+      <div className="flex items-center gap-1 border-b border-(--border-subtle) px-2 py-1">
         <button
           type="button"
           className={buttonBase}
@@ -114,7 +114,7 @@ export function CommentEditor({
         >
           {"</>"}
         </button>
-        <div className="ml-auto flex items-center gap-2 text-[11px] text-[var(--txt-tertiary)]">
+        <div className="ml-auto flex items-center gap-2 text-[11px] text-(--txt-tertiary)">
           {showShortcutHint && (
             <span className="hidden sm:inline">
               Ctrl / Cmd + Enter to comment
@@ -123,7 +123,7 @@ export function CommentEditor({
           {onCancel && (
             <button
               type="button"
-              className="rounded px-2 py-1 text-xs hover:bg-[var(--bg-layer-1-hover)]"
+              className="rounded px-2 py-1 text-xs hover:bg-(--bg-layer-1-hover)"
               onClick={onCancel}
               disabled={isSubmitting}
             >
@@ -132,7 +132,7 @@ export function CommentEditor({
           )}
           <button
             type="button"
-            className="inline-flex items-center justify-center rounded-md bg-[var(--bg-accent-primary)] px-3 py-1 text-xs font-medium text-[var(--txt-on-color)] hover:bg-[var(--bg-accent-primary-hover)] disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-md bg-(--bg-accent-primary) px-3 py-1 text-xs font-medium text-(--txt-on-color) hover:bg-(--bg-accent-primary-hover) disabled:opacity-50"
             disabled={isSubmitting}
             onClick={handleSubmit}
           >

--- a/ui/src/components/work-item/DatePickerTrigger.tsx
+++ b/ui/src/components/work-item/DatePickerTrigger.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+﻿import { useRef } from "react";
 
 /* eslint-disable react-refresh/only-export-components -- formatDateForDisplay shared util; keep in same file for future use */
 export function formatDateForDisplay(isoDate: string): string {
@@ -31,8 +31,8 @@ export function DatePickerTrigger({
   const displayValue = value ? formatDateForDisplay(value) : "";
 
   return (
-    <div className="relative inline-flex min-w-0 shrink-0 items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-1.5 py-1 text-xs text-[var(--txt-secondary)] [&_svg]:size-3">
-      <span className="shrink-0 text-[var(--txt-icon-tertiary)]">{icon}</span>
+    <div className="relative inline-flex min-w-0 shrink-0 items-center gap-1 rounded border border-(--border-subtle) bg-(--bg-layer-2) px-1.5 py-1 text-xs text-(--txt-secondary) [&_svg]:size-3">
+      <span className="shrink-0 text-(--txt-icon-tertiary)">{icon}</span>
       <span className="truncate">{displayValue || placeholder}</span>
       <input
         ref={inputRef}

--- a/ui/src/components/work-item/Dropdown.tsx
+++ b/ui/src/components/work-item/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+﻿import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 const DROPDOWN_Z_INDEX = 9999;
@@ -45,8 +45,8 @@ export function Dropdown({
   const open = openId === id;
 
   const defaultTriggerClass = compact
-    ? "inline-flex min-w-0 items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-1.5 py-1 text-xs text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)] [&_svg]:size-3"
-    : "inline-flex min-w-0 items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-sm text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]";
+    ? "inline-flex min-w-0 items-center gap-1 rounded border border-(--border-subtle) bg-(--bg-layer-2) px-1.5 py-1 text-xs text-(--txt-secondary) hover:bg-(--bg-layer-2-hover) [&_svg]:size-3"
+    : "inline-flex min-w-0 items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-sm text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)";
 
   useLayoutEffect(() => {
     if (!open || !triggerRef.current) {
@@ -91,7 +91,7 @@ export function Dropdown({
       >
         {triggerContent ?? (
           <>
-            <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+            <span className="shrink-0 text-(--txt-icon-tertiary)">
               {icon}
             </span>
             <span className="truncate">{displayValue || label}</span>
@@ -105,7 +105,7 @@ export function Dropdown({
             ref={panelRef}
             className={
               panelClassName ??
-              "max-h-60 min-w-[140px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+              "max-h-60 min-w-[140px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
             }
             style={{
               position: "fixed",

--- a/ui/src/components/work-item/Dropdown.tsx
+++ b/ui/src/components/work-item/Dropdown.tsx
@@ -91,9 +91,7 @@ export function Dropdown({
       >
         {triggerContent ?? (
           <>
-            <span className="shrink-0 text-(--txt-icon-tertiary)">
-              {icon}
-            </span>
+            <span className="shrink-0 text-(--txt-icon-tertiary)">{icon}</span>
             <span className="truncate">{displayValue || label}</span>
           </>
         )}

--- a/ui/src/components/work-item/SelectParentModal.tsx
+++ b/ui/src/components/work-item/SelectParentModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 const IconSearch = () => (
@@ -54,25 +54,25 @@ export function SelectParentModal({
       aria-labelledby="select-parent-title"
     >
       <div
-        className="absolute inset-0 bg-[var(--bg-backdrop)]"
+        className="absolute inset-0 bg-(--bg-backdrop)"
         onClick={onClose}
         aria-hidden
       />
       <div
-        className="relative z-10 w-full max-w-md rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-overlay)]"
+        className="relative z-10 w-full max-w-md rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay)"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="border-b border-[var(--border-subtle)] px-4 py-3">
+        <div className="border-b border-(--border-subtle) px-4 py-3">
           <h2
             id="select-parent-title"
-            className="text-sm font-semibold text-[var(--txt-primary)]"
+            className="text-sm font-semibold text-(--txt-primary)"
           >
             Select parent
           </h2>
         </div>
         <div className="flex flex-col p-3">
-          <div className="mb-3 flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-[var(--txt-secondary)] focus-within:border-[var(--border-strong)] focus-within:outline-none">
-            <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+          <div className="mb-3 flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-(--txt-secondary) focus-within:border-(--border-strong) focus-within:outline-none">
+            <span className="shrink-0 text-(--txt-icon-tertiary)">
               <IconSearch />
             </span>
             <input
@@ -80,19 +80,19 @@ export function SelectParentModal({
               placeholder="Type to search"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="min-w-0 flex-1 bg-transparent text-sm placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              className="min-w-0 flex-1 bg-transparent text-sm placeholder:text-(--txt-placeholder) focus:outline-none"
             />
           </div>
-          <div className="max-h-64 overflow-auto rounded border border-[var(--border-subtle)]">
+          <div className="max-h-64 overflow-auto rounded border border-(--border-subtle)">
             <button
               type="button"
               onClick={() => {
                 onChange(null);
                 onClose();
               }}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
             >
-              <span className="text-[var(--txt-icon-tertiary)]">•</span>
+              <span className="text-(--txt-icon-tertiary)">•</span>
               No parent
             </button>
             {filteredIssues.map((i) => (
@@ -103,9 +103,9 @@ export function SelectParentModal({
                   onChange(i.id);
                   onClose();
                 }}
-                className="flex w-full items-center gap-2 truncate px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex w-full items-center gap-2 truncate px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   •
                 </span>
                 <span className="truncate">{i.title}</span>

--- a/ui/src/components/work-item/SelectParentModal.tsx
+++ b/ui/src/components/work-item/SelectParentModal.tsx
@@ -105,9 +105,7 @@ export function SelectParentModal({
                 }}
                 className="flex w-full items-center gap-2 truncate px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
-                <span className="shrink-0 text-(--txt-icon-tertiary)">
-                  •
-                </span>
+                <span className="shrink-0 text-(--txt-icon-tertiary)">•</span>
                 <span className="truncate">{i.title}</span>
               </button>
             ))}

--- a/ui/src/components/workspace-views/CreateViewModal.tsx
+++ b/ui/src/components/workspace-views/CreateViewModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+﻿import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Modal } from "../ui";
 import { Button, Input } from "../ui";
@@ -113,7 +113,7 @@ export function CreateViewModal({
           autoFocus
         />
         <div>
-          <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
             Description
           </label>
           <textarea
@@ -121,7 +121,7 @@ export function CreateViewModal({
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Optional description"
             rows={3}
-            className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+            className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
           />
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -137,8 +137,8 @@ export function CreateViewModal({
             icon={null}
             displayValue=""
             triggerContent={<span>Filters</span>}
-            triggerClassName="inline-flex items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
-            panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+            triggerClassName="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+            panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
             align="left"
           >
             {workspaceSlug && (
@@ -163,8 +163,8 @@ export function CreateViewModal({
             icon={null}
             displayValue=""
             triggerContent={<span>Display</span>}
-            triggerClassName="inline-flex items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
-            panelClassName="flex min-w-[280px] max-w-[320px] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+            triggerClassName="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+            panelClassName="flex min-w-[280px] max-w-[320px] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
             align="left"
           >
             <WorkspaceViewsDisplayPanel
@@ -174,7 +174,7 @@ export function CreateViewModal({
           </Dropdown>
         </div>
         {error && (
-          <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+          <p className="text-sm text-(--txt-danger-primary)">{error}</p>
         )}
       </form>
     </Modal>

--- a/ui/src/components/workspace-views/DateRangeModal.tsx
+++ b/ui/src/components/workspace-views/DateRangeModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+﻿import { useState, useEffect } from "react";
 import { Modal } from "../ui";
 
 const MONTHS = [
@@ -145,10 +145,10 @@ export function DateRangeModal({
             onClick={() => (isStart ? setStartDate(date) : setEndDate(date))}
             className={`flex h-8 w-8 min-h-8 min-w-8 shrink-0 items-center justify-center rounded-full text-sm leading-none overflow-hidden ${
               selected
-                ? "bg-[var(--brand-default)] text-white"
+                ? "bg-(--brand-default) text-white"
                 : inRange
-                  ? "bg-[var(--brand-200)] text-[var(--brand-default)]"
-                  : "text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2)]"
+                  ? "bg-(--brand-200) text-(--brand-default)"
+                  : "text-(--txt-primary) hover:bg-(--bg-layer-2)"
             }`}
           >
             <span className="truncate">{d}</span>
@@ -170,7 +170,7 @@ export function DateRangeModal({
     return (
       <div className="flex flex-col">
         <div className="flex items-center justify-between pb-2">
-          <span className="text-sm font-medium text-[var(--txt-primary)]">
+          <span className="text-sm font-medium text-(--txt-primary)">
             {MONTHS[month]} ▾ {year}
           </span>
           <div className="flex gap-1">
@@ -180,7 +180,7 @@ export function DateRangeModal({
                 if (month === 0) setLeftYear((y) => y - 1);
                 setLeftMonth((m) => (m === 0 ? 11 : m - 1));
               }}
-              className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)]"
+              className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2)"
               aria-label="Previous month"
             >
               ←
@@ -191,7 +191,7 @@ export function DateRangeModal({
                 if (month === 11) setLeftYear((y) => y + 1);
                 setLeftMonth((m) => (m === 11 ? 0 : m + 1));
               }}
-              className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)]"
+              className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2)"
               aria-label="Next month"
             >
               →
@@ -200,7 +200,7 @@ export function DateRangeModal({
         </div>
         <table className="table-fixed w-full min-w-[14rem] text-left text-sm">
           <thead>
-            <tr className="text-[var(--txt-tertiary)]">
+            <tr className="text-(--txt-tertiary)">
               {["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"].map((day) => (
                 <th
                   key={day}
@@ -224,18 +224,18 @@ export function DateRangeModal({
       title={title}
       className="max-w-[520px]"
       footer={
-        <div className="flex justify-end gap-2 border-t border-[var(--border-subtle)] px-5 py-4">
+        <div className="flex justify-end gap-2 border-t border-(--border-subtle) px-5 py-4">
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-1.5 text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-1.5 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover)"
           >
             Cancel
           </button>
           <button
             type="button"
             onClick={handleApply}
-            className="rounded-md bg-[var(--brand-default)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+            className="rounded-md bg-(--brand-default) px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
           >
             Apply
           </button>
@@ -251,7 +251,7 @@ export function DateRangeModal({
             {renderCalendar(rightYear, rightMonth, false)}
           </div>
         </div>
-        <p className="mt-4 text-sm text-[var(--txt-secondary)]">
+        <p className="mt-4 text-sm text-(--txt-secondary)">
           After: {formatDisplay(startDate)} Before: {formatDisplay(endDate)}
         </p>
       </div>

--- a/ui/src/components/workspace-views/ModuleFiltersPanel.tsx
+++ b/ui/src/components/workspace-views/ModuleFiltersPanel.tsx
@@ -1,0 +1,527 @@
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { DateRangeModal } from "./DateRangeModal";
+import { CollapsibleSection } from "./WorkspaceViewsFiltersShared";
+import { DATE_PRESET_LABELS, FILTER_ICONS } from "./WorkspaceViewsFiltersData";
+import { DATE_PRESETS } from "../../types/workspaceViewFilters";
+import type { DatePreset } from "../../types/workspaceViewFilters";
+import { Avatar } from "../ui";
+import { getImageUrl } from "../../lib/utils";
+import { workspaceService } from "../../services/workspaceService";
+import type { WorkspaceMemberApiResponse } from "../../api/types";
+
+export const MODULE_FILTER_PARAM = {
+  favorites: "module_favorites",
+  status: "module_status",
+  lead: "module_lead",
+  members: "module_members",
+  start_date: "start_date",
+  due_date: "due_date",
+  start_after: "start_after",
+  start_before: "start_before",
+  due_after: "due_after",
+  due_before: "due_before",
+} as const;
+
+const MODULE_STATUSES = [
+  { id: "backlog", label: "Backlog" },
+  { id: "planned", label: "Planned" },
+  { id: "in_progress", label: "In Progress" },
+  { id: "paused", label: "Paused" },
+  { id: "completed", label: "Completed" },
+  { id: "cancelled", label: "Cancelled" },
+] as const;
+
+function parseList(value: string | null): string[] {
+  if (!value?.trim()) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function ModuleStatusIcon({ statusId }: { statusId: string }) {
+  if (statusId === "backlog" || statusId === "planned") {
+    return (
+      <span
+        className="flex size-4 shrink-0 items-center justify-center rounded border border-[var(--border-subtle)] border-dashed text-[var(--txt-icon-tertiary)]"
+        aria-hidden
+      >
+        <span className="size-2 rounded-full border border-current border-dashed" />
+      </span>
+    );
+  }
+  if (statusId === "in_progress") {
+    return (
+      <span
+        className="flex size-4 shrink-0 items-center justify-center text-amber-500"
+        aria-hidden
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      </span>
+    );
+  }
+  if (statusId === "paused") {
+    return (
+      <span
+        className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]"
+        aria-hidden
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="10" y1="8" x2="10" y2="16" />
+          <line x1="14" y1="8" x2="14" y2="16" />
+        </svg>
+      </span>
+    );
+  }
+  if (statusId === "completed") {
+    return (
+      <span
+        className="flex size-4 shrink-0 items-center justify-center rounded-full bg-green-500/20 text-green-600"
+        aria-hidden
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </span>
+    );
+  }
+  if (statusId === "cancelled") {
+    return (
+      <span
+        className="flex size-4 shrink-0 items-center justify-center rounded-full bg-red-500/20 text-red-500"
+        aria-hidden
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </span>
+    );
+  }
+  return null;
+}
+
+export interface ModuleFiltersPanelProps {
+  workspaceSlug: string;
+  /** When provided, called when user clicks Custom (start/due) so parent can close dropdown and show date modal */
+  onOpenDateModal?: (which: "start" | "due") => void;
+}
+
+export function ModuleFiltersPanel({
+  workspaceSlug,
+  onOpenDateModal,
+}: ModuleFiltersPanelProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState("");
+  const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
+  const [sectionOpen, setSectionOpen] = useState({
+    favorites: true,
+    status: true,
+    lead: true,
+    members: true,
+    start_date: true,
+    due_date: true,
+  });
+
+  useEffect(() => {
+    if (!workspaceSlug) return;
+    let cancelled = false;
+    workspaceService
+      .listMembers(workspaceSlug)
+      .then((list) => {
+        if (!cancelled) setMembers(list ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setMembers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug]);
+
+  const favorites = searchParams.get(MODULE_FILTER_PARAM.favorites) === "1";
+  const statusList = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
+  const leadIds = parseList(searchParams.get(MODULE_FILTER_PARAM.lead));
+  const memberIds = parseList(searchParams.get(MODULE_FILTER_PARAM.members));
+  const startDateRaw =
+    searchParams.get(MODULE_FILTER_PARAM.start_date)?.trim() ?? "";
+  const startDateSelected: DatePreset | "" = DATE_PRESETS.includes(
+    startDateRaw as DatePreset,
+  )
+    ? (startDateRaw as DatePreset)
+    : "";
+  const dueDateRaw =
+    searchParams.get(MODULE_FILTER_PARAM.due_date)?.trim() ?? "";
+  const dueDateSelected: DatePreset | "" = DATE_PRESETS.includes(
+    dueDateRaw as DatePreset,
+  )
+    ? (dueDateRaw as DatePreset)
+    : "";
+  const startAfter =
+    searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ?? null;
+  const startBefore =
+    searchParams.get(MODULE_FILTER_PARAM.start_before)?.trim() ?? null;
+  const dueAfter =
+    searchParams.get(MODULE_FILTER_PARAM.due_after)?.trim() ?? null;
+  const dueBefore =
+    searchParams.get(MODULE_FILTER_PARAM.due_before)?.trim() ?? null;
+
+  const toggleSection = (key: keyof typeof sectionOpen) => {
+    setSectionOpen((s) => ({ ...s, [key]: !s[key] }));
+  };
+
+  const openDateModal = (which: "start" | "due") => {
+    if (onOpenDateModal) {
+      onOpenDateModal(which);
+    }
+  };
+
+  const updateParams = (updater: (prev: URLSearchParams) => void) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      updater(next);
+      return next;
+    });
+  };
+
+  const filterSearch = (label: string) =>
+    !search.trim() || label.toLowerCase().includes(search.trim().toLowerCase());
+
+  const q = (s: string) => s.trim().toLowerCase();
+  const filteredMembers = members.filter((m) =>
+    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(
+      q(search),
+    ),
+  );
+  const displayName = (m: WorkspaceMemberApiResponse) =>
+    m.member_display_name?.trim() ?? m.member_email ?? m.member_id.slice(0, 12);
+
+  return (
+    <>
+      <div className="sticky top-0 shrink-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-2">
+        <div className="flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
+          <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+            <FILTER_ICONS.search />
+          </span>
+          <input
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+          />
+        </div>
+      </div>
+      <div
+        className="min-h-0 flex-1 overflow-y-auto py-1"
+        style={{ maxHeight: "min(70vh, 28rem)" }}
+      >
+        <CollapsibleSection
+          title="Favorites"
+          open={sectionOpen.favorites}
+          onToggle={() => toggleSection("favorites")}
+        >
+          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]">
+            <input
+              type="checkbox"
+              checked={favorites}
+              onChange={() => {
+                updateParams((next) => {
+                  if (next.get(MODULE_FILTER_PARAM.favorites) === "1")
+                    next.delete(MODULE_FILTER_PARAM.favorites);
+                  else next.set(MODULE_FILTER_PARAM.favorites, "1");
+                });
+              }}
+              className="rounded border-[var(--border-subtle)]"
+            />
+            <span>Favorites</span>
+          </label>
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Status"
+          open={sectionOpen.status}
+          onToggle={() => toggleSection("status")}
+        >
+          {MODULE_STATUSES.filter((s) => filterSearch(s.label)).map((s) => (
+            <label
+              key={s.id}
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+            >
+              <input
+                type="checkbox"
+                checked={statusList.includes(s.id)}
+                onChange={() => {
+                  updateParams((next) => {
+                    const nextList = statusList.includes(s.id)
+                      ? statusList.filter((x) => x !== s.id)
+                      : [...statusList, s.id];
+                    if (nextList.length)
+                      next.set(MODULE_FILTER_PARAM.status, nextList.join(","));
+                    else next.delete(MODULE_FILTER_PARAM.status);
+                  });
+                }}
+                className="rounded border-[var(--border-subtle)]"
+              />
+              <ModuleStatusIcon statusId={s.id} />
+              <span>{s.label}</span>
+            </label>
+          ))}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Lead"
+          open={sectionOpen.lead}
+          onToggle={() => toggleSection("lead")}
+        >
+          {filteredMembers.slice(0, 8).map((m) => (
+            <label
+              key={m.member_id}
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+            >
+              <input
+                type="checkbox"
+                checked={leadIds.includes(m.member_id)}
+                onChange={() => {
+                  updateParams((next) => {
+                    const nextList = leadIds.includes(m.member_id)
+                      ? leadIds.filter((id) => id !== m.member_id)
+                      : [...leadIds, m.member_id];
+                    if (nextList.length)
+                      next.set(MODULE_FILTER_PARAM.lead, nextList.join(","));
+                    else next.delete(MODULE_FILTER_PARAM.lead);
+                  });
+                }}
+                className="rounded border-[var(--border-subtle)]"
+              />
+              <Avatar
+                name={displayName(m)}
+                src={getImageUrl(m.member_avatar) ?? undefined}
+                size="sm"
+                className="h-6 w-6 shrink-0 text-xs"
+              />
+              <span className="truncate">{displayName(m)}</span>
+            </label>
+          ))}
+          {filteredMembers.length > 8 && (
+            <button
+              type="button"
+              className="px-3 py-1.5 text-left text-sm text-[var(--brand-default)] hover:underline"
+            >
+              View all
+            </button>
+          )}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Members"
+          open={sectionOpen.members}
+          onToggle={() => toggleSection("members")}
+        >
+          {filteredMembers.slice(0, 8).map((m) => (
+            <label
+              key={m.member_id}
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+            >
+              <input
+                type="checkbox"
+                checked={memberIds.includes(m.member_id)}
+                onChange={() => {
+                  updateParams((next) => {
+                    const nextList = memberIds.includes(m.member_id)
+                      ? memberIds.filter((id) => id !== m.member_id)
+                      : [...memberIds, m.member_id];
+                    if (nextList.length)
+                      next.set(MODULE_FILTER_PARAM.members, nextList.join(","));
+                    else next.delete(MODULE_FILTER_PARAM.members);
+                  });
+                }}
+                className="rounded border-[var(--border-subtle)]"
+              />
+              <Avatar
+                name={displayName(m)}
+                src={getImageUrl(m.member_avatar) ?? undefined}
+                size="sm"
+                className="h-6 w-6 shrink-0 text-xs"
+              />
+              <span className="truncate">{displayName(m)}</span>
+            </label>
+          ))}
+          {filteredMembers.length > 8 && (
+            <button
+              type="button"
+              className="px-3 py-1.5 text-left text-sm text-[var(--brand-default)] hover:underline"
+            >
+              View all
+            </button>
+          )}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Start date"
+          open={sectionOpen.start_date}
+          onToggle={() => toggleSection("start_date")}
+        >
+          {DATE_PRESETS.filter((d) => filterSearch(DATE_PRESET_LABELS[d])).map(
+            (d) =>
+              d === "custom" ? (
+                <label
+                  key={d}
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (startDateSelected === "custom") {
+                      updateParams((next) => {
+                        next.delete(MODULE_FILTER_PARAM.start_date);
+                        next.delete(MODULE_FILTER_PARAM.start_after);
+                        next.delete(MODULE_FILTER_PARAM.start_before);
+                      });
+                    } else {
+                      openDateModal("start");
+                    }
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="start_date_filter"
+                    checked={startDateSelected === "custom"}
+                    readOnly
+                    tabIndex={-1}
+                    className="border-[var(--border-subtle)]"
+                  />
+                  <span>{DATE_PRESET_LABELS[d]}</span>
+                </label>
+              ) : (
+                <label
+                  key={d}
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                >
+                  <input
+                    type="radio"
+                    name="start_date_filter"
+                    checked={startDateSelected === d}
+                    onChange={() => {
+                      updateParams((next) => {
+                        if (startDateSelected === d) {
+                          next.delete(MODULE_FILTER_PARAM.start_date);
+                          next.delete(MODULE_FILTER_PARAM.start_after);
+                          next.delete(MODULE_FILTER_PARAM.start_before);
+                        } else {
+                          next.set(MODULE_FILTER_PARAM.start_date, d);
+                          next.delete(MODULE_FILTER_PARAM.start_after);
+                          next.delete(MODULE_FILTER_PARAM.start_before);
+                        }
+                      });
+                    }}
+                    className="border-[var(--border-subtle)]"
+                  />
+                  <span>{DATE_PRESET_LABELS[d]}</span>
+                </label>
+              ),
+          )}
+        </CollapsibleSection>
+
+        <CollapsibleSection
+          title="Due date"
+          open={sectionOpen.due_date}
+          onToggle={() => toggleSection("due_date")}
+        >
+          {DATE_PRESETS.filter((d) => filterSearch(DATE_PRESET_LABELS[d])).map(
+            (d) =>
+              d === "custom" ? (
+                <label
+                  key={d}
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (dueDateSelected === "custom") {
+                      updateParams((next) => {
+                        next.delete(MODULE_FILTER_PARAM.due_date);
+                        next.delete(MODULE_FILTER_PARAM.due_after);
+                        next.delete(MODULE_FILTER_PARAM.due_before);
+                      });
+                    } else {
+                      openDateModal("due");
+                    }
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="due_date_filter"
+                    checked={dueDateSelected === "custom"}
+                    readOnly
+                    tabIndex={-1}
+                    className="border-[var(--border-subtle)]"
+                  />
+                  <span>{DATE_PRESET_LABELS[d]}</span>
+                </label>
+              ) : (
+                <label
+                  key={d}
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                >
+                  <input
+                    type="radio"
+                    name="due_date_filter"
+                    checked={dueDateSelected === d}
+                    onChange={() => {
+                      updateParams((next) => {
+                        if (dueDateSelected === d) {
+                          next.delete(MODULE_FILTER_PARAM.due_date);
+                          next.delete(MODULE_FILTER_PARAM.due_after);
+                          next.delete(MODULE_FILTER_PARAM.due_before);
+                        } else {
+                          next.set(MODULE_FILTER_PARAM.due_date, d);
+                          next.delete(MODULE_FILTER_PARAM.due_after);
+                          next.delete(MODULE_FILTER_PARAM.due_before);
+                        }
+                      });
+                    }}
+                    className="border-[var(--border-subtle)]"
+                  />
+                  <span>{DATE_PRESET_LABELS[d]}</span>
+                </label>
+              ),
+          )}
+        </CollapsibleSection>
+      </div>
+
+      {/* Date range modal is rendered in PageHeader when onOpenDateModal is used, so it stays visible after dropdown closes */}
+    </>
+  );
+}

--- a/ui/src/components/workspace-views/ModuleFiltersPanel.tsx
+++ b/ui/src/components/workspace-views/ModuleFiltersPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useModulesFilter } from "../../contexts/ModulesFilterContext";
 import { CollapsibleSection } from "./WorkspaceViewsFiltersShared";
 import { DATE_PRESET_LABELS, FILTER_ICONS } from "./WorkspaceViewsFiltersData";
 import { DATE_PRESETS } from "../../types/workspaceViewFilters";
@@ -7,19 +7,6 @@ import { Avatar } from "../ui";
 import { getImageUrl } from "../../lib/utils";
 import { workspaceService } from "../../services/workspaceService";
 import type { WorkspaceMemberApiResponse } from "../../api/types";
-
-export const MODULE_FILTER_PARAM = {
-  favorites: "module_favorites",
-  status: "module_status",
-  lead: "module_lead",
-  members: "module_members",
-  start_date: "start_date",
-  due_date: "due_date",
-  start_after: "start_after",
-  start_before: "start_before",
-  due_after: "due_after",
-  due_before: "due_before",
-} as const;
 
 const MODULE_STATUSES = [
   { id: "backlog", label: "Backlog" },
@@ -29,14 +16,6 @@ const MODULE_STATUSES = [
   { id: "completed", label: "Completed" },
   { id: "cancelled", label: "Cancelled" },
 ] as const;
-
-function parseList(value: string | null): string[] {
-  if (!value?.trim()) return [];
-  return value
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
 
 function ModuleStatusIcon({ statusId }: { statusId: string }) {
   if (statusId === "backlog" || statusId === "planned") {
@@ -142,9 +121,11 @@ export function ModuleFiltersPanel({
   workspaceSlug,
   onOpenDateModal,
 }: ModuleFiltersPanelProps) {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = useModulesFilter();
   const [search, setSearch] = useState("");
-  const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
+  const [members, setWorkspaceMembers] = useState<WorkspaceMemberApiResponse[]>(
+    [],
+  );
   const [sectionOpen, setSectionOpen] = useState({
     favorites: true,
     status: true,
@@ -160,24 +141,34 @@ export function ModuleFiltersPanel({
     workspaceService
       .listMembers(workspaceSlug)
       .then((list) => {
-        if (!cancelled) setMembers(list ?? []);
+        if (!cancelled) setWorkspaceMembers(list ?? []);
       })
       .catch(() => {
-        if (!cancelled) setMembers([]);
+        if (!cancelled) setWorkspaceMembers([]);
       });
     return () => {
       cancelled = true;
     };
   }, [workspaceSlug]);
 
-  const favorites = searchParams.get(MODULE_FILTER_PARAM.favorites) === "1";
-  const statusList = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
-  const leadIds = parseList(searchParams.get(MODULE_FILTER_PARAM.lead));
-  const memberIds = parseList(searchParams.get(MODULE_FILTER_PARAM.members));
-  const startDateList = parseList(
-    searchParams.get(MODULE_FILTER_PARAM.start_date),
-  );
-  const dueDateList = parseList(searchParams.get(MODULE_FILTER_PARAM.due_date));
+  const {
+    favorites,
+    status: statusList,
+    lead: leadIds,
+    members: memberIds,
+    startDateList,
+    dueDateList,
+    setFavorites,
+    setStatus,
+    setLead,
+    setMembers: setMemberIds,
+    setStartDateList,
+    setDueDateList,
+    setStartAfter,
+    setStartBefore,
+    setDueAfter,
+    setDueBefore,
+  } = filter;
   const hasCustomStart = startDateList.includes("custom");
   const hasCustomDue = dueDateList.includes("custom");
 
@@ -189,14 +180,6 @@ export function ModuleFiltersPanel({
     if (onOpenDateModal) {
       onOpenDateModal(which);
     }
-  };
-
-  const updateParams = (updater: (prev: URLSearchParams) => void) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      updater(next);
-      return next;
-    });
   };
 
   const filterSearch = (label: string) =>
@@ -240,13 +223,7 @@ export function ModuleFiltersPanel({
             <input
               type="checkbox"
               checked={favorites}
-              onChange={() => {
-                updateParams((next) => {
-                  if (next.get(MODULE_FILTER_PARAM.favorites) === "1")
-                    next.delete(MODULE_FILTER_PARAM.favorites);
-                  else next.set(MODULE_FILTER_PARAM.favorites, "1");
-                });
-              }}
+              onChange={() => setFavorites(!favorites)}
               className="rounded border-(--border-subtle)"
             />
             <span>Favorites</span>
@@ -267,14 +244,11 @@ export function ModuleFiltersPanel({
                 type="checkbox"
                 checked={statusList.includes(s.id)}
                 onChange={() => {
-                  updateParams((next) => {
-                    const nextList = statusList.includes(s.id)
+                  setStatus(
+                    statusList.includes(s.id)
                       ? statusList.filter((x) => x !== s.id)
-                      : [...statusList, s.id];
-                    if (nextList.length)
-                      next.set(MODULE_FILTER_PARAM.status, nextList.join(","));
-                    else next.delete(MODULE_FILTER_PARAM.status);
-                  });
+                      : [...statusList, s.id],
+                  );
                 }}
                 className="rounded border-(--border-subtle)"
               />
@@ -298,14 +272,11 @@ export function ModuleFiltersPanel({
                 type="checkbox"
                 checked={leadIds.includes(m.member_id)}
                 onChange={() => {
-                  updateParams((next) => {
-                    const nextList = leadIds.includes(m.member_id)
+                  setLead(
+                    leadIds.includes(m.member_id)
                       ? leadIds.filter((id) => id !== m.member_id)
-                      : [...leadIds, m.member_id];
-                    if (nextList.length)
-                      next.set(MODULE_FILTER_PARAM.lead, nextList.join(","));
-                    else next.delete(MODULE_FILTER_PARAM.lead);
-                  });
+                      : [...leadIds, m.member_id],
+                  );
                 }}
                 className="rounded border-(--border-subtle)"
               />
@@ -342,14 +313,11 @@ export function ModuleFiltersPanel({
                 type="checkbox"
                 checked={memberIds.includes(m.member_id)}
                 onChange={() => {
-                  updateParams((next) => {
-                    const nextList = memberIds.includes(m.member_id)
+                  setMemberIds(
+                    memberIds.includes(m.member_id)
                       ? memberIds.filter((id) => id !== m.member_id)
-                      : [...memberIds, m.member_id];
-                    if (nextList.length)
-                      next.set(MODULE_FILTER_PARAM.members, nextList.join(","));
-                    else next.delete(MODULE_FILTER_PARAM.members);
-                  });
+                      : [...memberIds, m.member_id],
+                  );
                 }}
                 className="rounded border-(--border-subtle)"
               />
@@ -387,11 +355,9 @@ export function ModuleFiltersPanel({
                     e.preventDefault();
                     e.stopPropagation();
                     if (hasCustomStart) {
-                      updateParams((next) => {
-                        next.delete(MODULE_FILTER_PARAM.start_date);
-                        next.delete(MODULE_FILTER_PARAM.start_after);
-                        next.delete(MODULE_FILTER_PARAM.start_before);
-                      });
+                      setStartDateList([]);
+                      setStartAfter(null);
+                      setStartBefore(null);
                     } else {
                       openDateModal("start");
                     }
@@ -415,30 +381,23 @@ export function ModuleFiltersPanel({
                     type="checkbox"
                     checked={!hasCustomStart && startDateList.includes(d)}
                     onChange={() => {
-                      updateParams((next) => {
-                        if (hasCustomStart) {
-                          next.set(MODULE_FILTER_PARAM.start_date, d);
-                          next.delete(MODULE_FILTER_PARAM.start_after);
-                          next.delete(MODULE_FILTER_PARAM.start_before);
-                        } else {
-                          const presets = startDateList.filter(
-                            (x) => x !== "custom",
-                          );
-                          const nextList = presets.includes(d)
-                            ? presets.filter((x) => x !== d)
-                            : [...presets, d];
-                          if (nextList.length)
-                            next.set(
-                              MODULE_FILTER_PARAM.start_date,
-                              nextList.join(","),
-                            );
-                          else {
-                            next.delete(MODULE_FILTER_PARAM.start_date);
-                            next.delete(MODULE_FILTER_PARAM.start_after);
-                            next.delete(MODULE_FILTER_PARAM.start_before);
-                          }
+                      if (hasCustomStart) {
+                        setStartDateList([d]);
+                        setStartAfter(null);
+                        setStartBefore(null);
+                      } else {
+                        const presets = startDateList.filter(
+                          (x) => x !== "custom",
+                        );
+                        const nextList = presets.includes(d)
+                          ? presets.filter((x) => x !== d)
+                          : [...presets, d];
+                        setStartDateList(nextList);
+                        if (nextList.length === 0) {
+                          setStartAfter(null);
+                          setStartBefore(null);
                         }
-                      });
+                      }
                     }}
                     className="rounded border-(--border-subtle)"
                   />
@@ -463,11 +422,9 @@ export function ModuleFiltersPanel({
                     e.preventDefault();
                     e.stopPropagation();
                     if (hasCustomDue) {
-                      updateParams((next) => {
-                        next.delete(MODULE_FILTER_PARAM.due_date);
-                        next.delete(MODULE_FILTER_PARAM.due_after);
-                        next.delete(MODULE_FILTER_PARAM.due_before);
-                      });
+                      setDueDateList([]);
+                      setDueAfter(null);
+                      setDueBefore(null);
                     } else {
                       openDateModal("due");
                     }
@@ -491,30 +448,23 @@ export function ModuleFiltersPanel({
                     type="checkbox"
                     checked={!hasCustomDue && dueDateList.includes(d)}
                     onChange={() => {
-                      updateParams((next) => {
-                        if (hasCustomDue) {
-                          next.set(MODULE_FILTER_PARAM.due_date, d);
-                          next.delete(MODULE_FILTER_PARAM.due_after);
-                          next.delete(MODULE_FILTER_PARAM.due_before);
-                        } else {
-                          const presets = dueDateList.filter(
-                            (x) => x !== "custom",
-                          );
-                          const nextList = presets.includes(d)
-                            ? presets.filter((x) => x !== d)
-                            : [...presets, d];
-                          if (nextList.length)
-                            next.set(
-                              MODULE_FILTER_PARAM.due_date,
-                              nextList.join(","),
-                            );
-                          else {
-                            next.delete(MODULE_FILTER_PARAM.due_date);
-                            next.delete(MODULE_FILTER_PARAM.due_after);
-                            next.delete(MODULE_FILTER_PARAM.due_before);
-                          }
+                      if (hasCustomDue) {
+                        setDueDateList([d]);
+                        setDueAfter(null);
+                        setDueBefore(null);
+                      } else {
+                        const presets = dueDateList.filter(
+                          (x) => x !== "custom",
+                        );
+                        const nextList = presets.includes(d)
+                          ? presets.filter((x) => x !== d)
+                          : [...presets, d];
+                        setDueDateList(nextList);
+                        if (nextList.length === 0) {
+                          setDueAfter(null);
+                          setDueBefore(null);
                         }
-                      });
+                      }
                     }}
                     className="rounded border-(--border-subtle)"
                   />

--- a/ui/src/components/workspace-views/ModuleFiltersPanel.tsx
+++ b/ui/src/components/workspace-views/ModuleFiltersPanel.tsx
@@ -1,10 +1,8 @@
 import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
-import { DateRangeModal } from "./DateRangeModal";
 import { CollapsibleSection } from "./WorkspaceViewsFiltersShared";
 import { DATE_PRESET_LABELS, FILTER_ICONS } from "./WorkspaceViewsFiltersData";
 import { DATE_PRESETS } from "../../types/workspaceViewFilters";
-import type { DatePreset } from "../../types/workspaceViewFilters";
 import { Avatar } from "../ui";
 import { getImageUrl } from "../../lib/utils";
 import { workspaceService } from "../../services/workspaceService";
@@ -44,7 +42,7 @@ function ModuleStatusIcon({ statusId }: { statusId: string }) {
   if (statusId === "backlog" || statusId === "planned") {
     return (
       <span
-        className="flex size-4 shrink-0 items-center justify-center rounded border border-[var(--border-subtle)] border-dashed text-[var(--txt-icon-tertiary)]"
+        className="flex size-4 shrink-0 items-center justify-center rounded border border-(--border-subtle) border-dashed text-(--txt-icon-tertiary)"
         aria-hidden
       >
         <span className="size-2 rounded-full border border-current border-dashed" />
@@ -74,7 +72,7 @@ function ModuleStatusIcon({ statusId }: { statusId: string }) {
   if (statusId === "paused") {
     return (
       <span
-        className="flex size-4 shrink-0 items-center justify-center text-[var(--txt-icon-tertiary)]"
+        className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)"
         aria-hidden
       >
         <svg
@@ -176,28 +174,12 @@ export function ModuleFiltersPanel({
   const statusList = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
   const leadIds = parseList(searchParams.get(MODULE_FILTER_PARAM.lead));
   const memberIds = parseList(searchParams.get(MODULE_FILTER_PARAM.members));
-  const startDateRaw =
-    searchParams.get(MODULE_FILTER_PARAM.start_date)?.trim() ?? "";
-  const startDateSelected: DatePreset | "" = DATE_PRESETS.includes(
-    startDateRaw as DatePreset,
-  )
-    ? (startDateRaw as DatePreset)
-    : "";
-  const dueDateRaw =
-    searchParams.get(MODULE_FILTER_PARAM.due_date)?.trim() ?? "";
-  const dueDateSelected: DatePreset | "" = DATE_PRESETS.includes(
-    dueDateRaw as DatePreset,
-  )
-    ? (dueDateRaw as DatePreset)
-    : "";
-  const startAfter =
-    searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ?? null;
-  const startBefore =
-    searchParams.get(MODULE_FILTER_PARAM.start_before)?.trim() ?? null;
-  const dueAfter =
-    searchParams.get(MODULE_FILTER_PARAM.due_after)?.trim() ?? null;
-  const dueBefore =
-    searchParams.get(MODULE_FILTER_PARAM.due_before)?.trim() ?? null;
+  const startDateList = parseList(
+    searchParams.get(MODULE_FILTER_PARAM.start_date),
+  );
+  const dueDateList = parseList(searchParams.get(MODULE_FILTER_PARAM.due_date));
+  const hasCustomStart = startDateList.includes("custom");
+  const hasCustomDue = dueDateList.includes("custom");
 
   const toggleSection = (key: keyof typeof sectionOpen) => {
     setSectionOpen((s) => ({ ...s, [key]: !s[key] }));
@@ -231,9 +213,9 @@ export function ModuleFiltersPanel({
 
   return (
     <>
-      <div className="sticky top-0 shrink-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-2">
-        <div className="flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
-          <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+      <div className="sticky top-0 shrink-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-2">
+        <div className="flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
+          <span className="shrink-0 text-(--txt-icon-tertiary)">
             <FILTER_ICONS.search />
           </span>
           <input
@@ -241,7 +223,7 @@ export function ModuleFiltersPanel({
             placeholder="Search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+            className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
           />
         </div>
       </div>
@@ -254,7 +236,7 @@ export function ModuleFiltersPanel({
           open={sectionOpen.favorites}
           onToggle={() => toggleSection("favorites")}
         >
-          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]">
+          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)">
             <input
               type="checkbox"
               checked={favorites}
@@ -265,7 +247,7 @@ export function ModuleFiltersPanel({
                   else next.set(MODULE_FILTER_PARAM.favorites, "1");
                 });
               }}
-              className="rounded border-[var(--border-subtle)]"
+              className="rounded border-(--border-subtle)"
             />
             <span>Favorites</span>
           </label>
@@ -279,7 +261,7 @@ export function ModuleFiltersPanel({
           {MODULE_STATUSES.filter((s) => filterSearch(s.label)).map((s) => (
             <label
               key={s.id}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -294,7 +276,7 @@ export function ModuleFiltersPanel({
                     else next.delete(MODULE_FILTER_PARAM.status);
                   });
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
               <ModuleStatusIcon statusId={s.id} />
               <span>{s.label}</span>
@@ -310,7 +292,7 @@ export function ModuleFiltersPanel({
           {filteredMembers.slice(0, 8).map((m) => (
             <label
               key={m.member_id}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -325,7 +307,7 @@ export function ModuleFiltersPanel({
                     else next.delete(MODULE_FILTER_PARAM.lead);
                   });
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
               <Avatar
                 name={displayName(m)}
@@ -339,7 +321,7 @@ export function ModuleFiltersPanel({
           {filteredMembers.length > 8 && (
             <button
               type="button"
-              className="px-3 py-1.5 text-left text-sm text-[var(--brand-default)] hover:underline"
+              className="px-3 py-1.5 text-left text-sm text-(--brand-default) hover:underline"
             >
               View all
             </button>
@@ -354,7 +336,7 @@ export function ModuleFiltersPanel({
           {filteredMembers.slice(0, 8).map((m) => (
             <label
               key={m.member_id}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -369,7 +351,7 @@ export function ModuleFiltersPanel({
                     else next.delete(MODULE_FILTER_PARAM.members);
                   });
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
               <Avatar
                 name={displayName(m)}
@@ -383,7 +365,7 @@ export function ModuleFiltersPanel({
           {filteredMembers.length > 8 && (
             <button
               type="button"
-              className="px-3 py-1.5 text-left text-sm text-[var(--brand-default)] hover:underline"
+              className="px-3 py-1.5 text-left text-sm text-(--brand-default) hover:underline"
             >
               View all
             </button>
@@ -400,11 +382,11 @@ export function ModuleFiltersPanel({
               d === "custom" ? (
                 <label
                   key={d}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    if (startDateSelected === "custom") {
+                    if (hasCustomStart) {
                       updateParams((next) => {
                         next.delete(MODULE_FILTER_PARAM.start_date);
                         next.delete(MODULE_FILTER_PARAM.start_after);
@@ -416,38 +398,49 @@ export function ModuleFiltersPanel({
                   }}
                 >
                   <input
-                    type="radio"
-                    name="start_date_filter"
-                    checked={startDateSelected === "custom"}
+                    type="checkbox"
+                    checked={hasCustomStart}
                     readOnly
                     tabIndex={-1}
-                    className="border-[var(--border-subtle)]"
+                    className="rounded border-(--border-subtle)"
                   />
                   <span>{DATE_PRESET_LABELS[d]}</span>
                 </label>
               ) : (
                 <label
                   key={d}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 >
                   <input
-                    type="radio"
-                    name="start_date_filter"
-                    checked={startDateSelected === d}
+                    type="checkbox"
+                    checked={!hasCustomStart && startDateList.includes(d)}
                     onChange={() => {
                       updateParams((next) => {
-                        if (startDateSelected === d) {
-                          next.delete(MODULE_FILTER_PARAM.start_date);
-                          next.delete(MODULE_FILTER_PARAM.start_after);
-                          next.delete(MODULE_FILTER_PARAM.start_before);
-                        } else {
+                        if (hasCustomStart) {
                           next.set(MODULE_FILTER_PARAM.start_date, d);
                           next.delete(MODULE_FILTER_PARAM.start_after);
                           next.delete(MODULE_FILTER_PARAM.start_before);
+                        } else {
+                          const presets = startDateList.filter(
+                            (x) => x !== "custom",
+                          );
+                          const nextList = presets.includes(d)
+                            ? presets.filter((x) => x !== d)
+                            : [...presets, d];
+                          if (nextList.length)
+                            next.set(
+                              MODULE_FILTER_PARAM.start_date,
+                              nextList.join(","),
+                            );
+                          else {
+                            next.delete(MODULE_FILTER_PARAM.start_date);
+                            next.delete(MODULE_FILTER_PARAM.start_after);
+                            next.delete(MODULE_FILTER_PARAM.start_before);
+                          }
                         }
                       });
                     }}
-                    className="border-[var(--border-subtle)]"
+                    className="rounded border-(--border-subtle)"
                   />
                   <span>{DATE_PRESET_LABELS[d]}</span>
                 </label>
@@ -465,11 +458,11 @@ export function ModuleFiltersPanel({
               d === "custom" ? (
                 <label
                   key={d}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    if (dueDateSelected === "custom") {
+                    if (hasCustomDue) {
                       updateParams((next) => {
                         next.delete(MODULE_FILTER_PARAM.due_date);
                         next.delete(MODULE_FILTER_PARAM.due_after);
@@ -481,38 +474,49 @@ export function ModuleFiltersPanel({
                   }}
                 >
                   <input
-                    type="radio"
-                    name="due_date_filter"
-                    checked={dueDateSelected === "custom"}
+                    type="checkbox"
+                    checked={hasCustomDue}
                     readOnly
                     tabIndex={-1}
-                    className="border-[var(--border-subtle)]"
+                    className="rounded border-(--border-subtle)"
                   />
                   <span>{DATE_PRESET_LABELS[d]}</span>
                 </label>
               ) : (
                 <label
                   key={d}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 >
                   <input
-                    type="radio"
-                    name="due_date_filter"
-                    checked={dueDateSelected === d}
+                    type="checkbox"
+                    checked={!hasCustomDue && dueDateList.includes(d)}
                     onChange={() => {
                       updateParams((next) => {
-                        if (dueDateSelected === d) {
-                          next.delete(MODULE_FILTER_PARAM.due_date);
-                          next.delete(MODULE_FILTER_PARAM.due_after);
-                          next.delete(MODULE_FILTER_PARAM.due_before);
-                        } else {
+                        if (hasCustomDue) {
                           next.set(MODULE_FILTER_PARAM.due_date, d);
                           next.delete(MODULE_FILTER_PARAM.due_after);
                           next.delete(MODULE_FILTER_PARAM.due_before);
+                        } else {
+                          const presets = dueDateList.filter(
+                            (x) => x !== "custom",
+                          );
+                          const nextList = presets.includes(d)
+                            ? presets.filter((x) => x !== d)
+                            : [...presets, d];
+                          if (nextList.length)
+                            next.set(
+                              MODULE_FILTER_PARAM.due_date,
+                              nextList.join(","),
+                            );
+                          else {
+                            next.delete(MODULE_FILTER_PARAM.due_date);
+                            next.delete(MODULE_FILTER_PARAM.due_after);
+                            next.delete(MODULE_FILTER_PARAM.due_before);
+                          }
                         }
                       });
                     }}
-                    className="border-[var(--border-subtle)]"
+                    className="rounded border-(--border-subtle)"
                   />
                   <span>{DATE_PRESET_LABELS[d]}</span>
                 </label>

--- a/ui/src/components/workspace-views/WorkspaceViewsDisplayDropdown.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsDisplayDropdown.tsx
@@ -1,4 +1,4 @@
-import { Dropdown } from "../work-item";
+﻿import { Dropdown } from "../work-item";
 import { useWorkspaceViewsState } from "../../contexts/WorkspaceViewsStateContext";
 import { WorkspaceViewsDisplayPanel } from "./WorkspaceViewsDisplayPanel";
 
@@ -38,7 +38,7 @@ export function WorkspaceViewsDisplayDropdown({
       label="Display"
       icon={<IconLayoutGrid />}
       displayValue="Display"
-      panelClassName="flex min-w-[280px] max-w-[320px] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+      panelClassName="flex min-w-[280px] max-w-[320px] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
       align="right"
     >
       <WorkspaceViewsDisplayPanel

--- a/ui/src/components/workspace-views/WorkspaceViewsDisplayPanel.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsDisplayPanel.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   type DisplayPropertyKey,
   type WorkspaceViewDisplay,
   DISPLAY_PROPERTY_KEYS,
@@ -27,8 +27,8 @@ export function WorkspaceViewsDisplayPanel({
 
   return (
     <div className="flex flex-col">
-      <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3">
-        <p className="text-xs font-medium text-[var(--txt-secondary)]">
+      <div className="border-b border-(--border-subtle) bg-(--bg-surface-1) p-3">
+        <p className="text-xs font-medium text-(--txt-secondary)">
           Display Properties
         </p>
       </div>
@@ -42,8 +42,8 @@ export function WorkspaceViewsDisplayPanel({
               onClick={() => toggleProperty(key)}
               className={`rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors ${
                 selected
-                  ? "border-transparent bg-[var(--brand-default)] text-white"
-                  : "border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2)]"
+                  ? "border-transparent bg-(--brand-default) text-white"
+                  : "border-(--border-subtle) bg-(--bg-surface-1) text-(--txt-secondary) hover:bg-(--bg-layer-2)"
               }`}
             >
               {DISPLAY_PROPERTY_LABELS[key]}
@@ -51,8 +51,8 @@ export function WorkspaceViewsDisplayPanel({
           );
         })}
       </div>
-      <div className="border-t border-[var(--border-subtle)] p-3">
-        <label className="flex cursor-pointer items-center gap-2 text-sm text-[var(--txt-primary)]">
+      <div className="border-t border-(--border-subtle) p-3">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-(--txt-primary)">
           <input
             type="checkbox"
             checked={display.showSubWorkItems}
@@ -62,7 +62,7 @@ export function WorkspaceViewsDisplayPanel({
                 showSubWorkItems: e.target.checked,
               }))
             }
-            className="rounded border-[var(--border-subtle)]"
+            className="rounded border-(--border-subtle)"
           />
           <span>Show sub-work items</span>
         </label>

--- a/ui/src/components/workspace-views/WorkspaceViewsEllipsisMenu.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsEllipsisMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+﻿import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useLocation } from "react-router-dom";
 
@@ -113,7 +113,7 @@ export function WorkspaceViewsEllipsisMenu() {
         ref={triggerRef}
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
+        className="flex size-8 items-center justify-center rounded-md border border-transparent text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-icon-secondary)"
         aria-label="More options"
       >
         <IconMoreVertical />
@@ -123,7 +123,7 @@ export function WorkspaceViewsEllipsisMenu() {
         createPortal(
           <div
             ref={panelRef}
-            className="min-w-[180px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+            className="min-w-[180px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
             style={{
               position: "fixed",
               top: position.top,
@@ -134,9 +134,9 @@ export function WorkspaceViewsEllipsisMenu() {
             <button
               type="button"
               onClick={handleOpenInNewTab}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
-              <span className="text-[var(--txt-icon-tertiary)]">
+              <span className="text-(--txt-icon-tertiary)">
                 <IconExternal />
               </span>
               Open in new tab
@@ -144,9 +144,9 @@ export function WorkspaceViewsEllipsisMenu() {
             <button
               type="button"
               onClick={handleCopyLink}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
-              <span className="text-[var(--txt-icon-tertiary)]">
+              <span className="text-(--txt-icon-tertiary)">
                 <IconLink />
               </span>
               Copy link

--- a/ui/src/components/workspace-views/WorkspaceViewsFiltersData.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsFiltersData.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-refresh/only-export-components -- Shared constants and icon maps for filter UI */
+﻿/* eslint-disable react-refresh/only-export-components -- Shared constants and icon maps for filter UI */
 import type { ReactNode } from "react";
 import type {
   Priority,
@@ -96,15 +96,15 @@ const IconLow = () => (
   </span>
 );
 const IconNone = () => (
-  <span className="flex size-4 items-center justify-center text-[10px] text-[var(--txt-icon-tertiary)]">
+  <span className="flex size-4 items-center justify-center text-[10px] text-(--txt-icon-tertiary)">
     —
   </span>
 );
 const IconBacklog = () => (
-  <span className="flex size-4 items-center justify-center rounded-full border border-[var(--border-subtle)]" />
+  <span className="flex size-4 items-center justify-center rounded-full border border-(--border-subtle)" />
 );
 const IconUnstarted = () => (
-  <span className="flex size-4 items-center justify-center rounded-full border-2 border-[var(--border-subtle)]" />
+  <span className="flex size-4 items-center justify-center rounded-full border-2 border-(--border-subtle)" />
 );
 const IconStarted = () => (
   <span className="flex size-4 items-center justify-center rounded-full border-2 border-amber-500 bg-amber-500/20" />
@@ -115,7 +115,7 @@ const IconCompleted = () => (
   </span>
 );
 const IconCanceled = () => (
-  <span className="flex size-4 items-center justify-center rounded-full border border-[var(--border-subtle)] text-[10px] text-[var(--txt-icon-tertiary)]">
+  <span className="flex size-4 items-center justify-center rounded-full border border-(--border-subtle) text-[10px] text-(--txt-icon-tertiary)">
     ✕
   </span>
 );

--- a/ui/src/components/workspace-views/WorkspaceViewsFiltersDropdown.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsFiltersDropdown.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+﻿import { useParams } from "react-router-dom";
 import { Dropdown } from "../work-item";
 import { useWorkspaceViewsState } from "../../contexts/WorkspaceViewsStateContext";
 import { FILTER_ICONS } from "./WorkspaceViewsFiltersData";
@@ -26,7 +26,7 @@ export function WorkspaceViewsFiltersDropdown({
       label="Filters"
       icon={<FILTER_ICONS.filter />}
       displayValue="Filters"
-      panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-[var(--shadow-raised)] overflow-hidden"
+      panelClassName="flex w-[280px] max-h-[min(70vh,28rem)] flex-col rounded-md border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised) overflow-hidden"
       align="right"
     >
       <WorkspaceViewsFiltersPanel

--- a/ui/src/components/workspace-views/WorkspaceViewsFiltersPanel.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsFiltersPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { DateRangeModal } from "./DateRangeModal";
 import { CollapsibleSection } from "./WorkspaceViewsFiltersShared";
 import {
@@ -153,7 +153,7 @@ export function WorkspaceViewsFiltersPanel({
         {PRIORITIES.filter((p) => filterSearch(PRIORITY_LABELS[p])).map((p) => (
           <label
             key={p}
-            className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+            className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
           >
             <input
               type="checkbox"
@@ -166,7 +166,7 @@ export function WorkspaceViewsFiltersPanel({
                     : [...prev.priority, p],
                 }));
               }}
-              className="rounded border-[var(--border-subtle)]"
+              className="rounded border-(--border-subtle)"
             />
             <span className="flex size-4 shrink-0 items-center justify-center">
               {PRIORITY_ICONS[p]}
@@ -185,7 +185,7 @@ export function WorkspaceViewsFiltersPanel({
           (g) => (
             <label
               key={g}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -198,7 +198,7 @@ export function WorkspaceViewsFiltersPanel({
                       : [...prev.stateGroup, g],
                   }));
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
               <span className="flex size-4 shrink-0 items-center justify-center">
                 {STATE_GROUP_ICONS[g]}
@@ -215,7 +215,7 @@ export function WorkspaceViewsFiltersPanel({
         onToggle={() => toggleSection("assignee")}
       >
         {currentUser && filterSearch("You") && (
-          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]">
+          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)">
             <input
               type="checkbox"
               checked={filters.assigneeIds.includes(currentUser.id)}
@@ -227,7 +227,7 @@ export function WorkspaceViewsFiltersPanel({
                     : [...prev.assigneeIds, currentUser.id],
                 }));
               }}
-              className="rounded border-[var(--border-subtle)]"
+              className="rounded border-(--border-subtle)"
             />
             {getImageUrl(currentUser.avatarUrl) ? (
               <img
@@ -236,7 +236,7 @@ export function WorkspaceViewsFiltersPanel({
                 className="size-5 shrink-0 rounded-full object-cover"
               />
             ) : (
-              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-200)] text-[10px] font-medium text-[var(--brand-default)]">
+              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--brand-200) text-[10px] font-medium text-(--brand-default)">
                 {currentUser.name?.charAt(0) ?? "?"}
               </span>
             )}
@@ -254,7 +254,7 @@ export function WorkspaceViewsFiltersPanel({
           .map((m) => (
             <label
               key={m.id}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -267,7 +267,7 @@ export function WorkspaceViewsFiltersPanel({
                       : [...prev.assigneeIds, m.member_id],
                   }));
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
               {getImageUrl(m.member_avatar) ? (
                 <img
@@ -276,7 +276,7 @@ export function WorkspaceViewsFiltersPanel({
                   className="size-5 shrink-0 rounded-full object-cover"
                 />
               ) : (
-                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-2)] text-[10px] text-[var(--txt-secondary)]">
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-2) text-[10px] text-(--txt-secondary)">
                   {(m.member_display_name ?? m.member_email ?? "?").charAt(0)}
                 </span>
               )}
@@ -293,7 +293,7 @@ export function WorkspaceViewsFiltersPanel({
         onToggle={() => toggleSection("created_by")}
       >
         {currentUser && filterSearch("You") && (
-          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]">
+          <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)">
             <input
               type="checkbox"
               checked={filters.createdByIds.includes(currentUser.id)}
@@ -305,7 +305,7 @@ export function WorkspaceViewsFiltersPanel({
                     : [...prev.createdByIds, currentUser.id],
                 }));
               }}
-              className="rounded border-[var(--border-subtle)]"
+              className="rounded border-(--border-subtle)"
             />
             {getImageUrl(currentUser.avatarUrl) ? (
               <img
@@ -314,7 +314,7 @@ export function WorkspaceViewsFiltersPanel({
                 className="size-5 shrink-0 rounded-full object-cover"
               />
             ) : (
-              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-200)] text-[10px] font-medium text-[var(--brand-default)]">
+              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--brand-200) text-[10px] font-medium text-(--brand-default)">
                 {currentUser.name?.charAt(0) ?? "?"}
               </span>
             )}
@@ -332,7 +332,7 @@ export function WorkspaceViewsFiltersPanel({
           .map((m) => (
             <label
               key={m.id}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -345,7 +345,7 @@ export function WorkspaceViewsFiltersPanel({
                       : [...prev.createdByIds, m.member_id],
                   }));
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
               {getImageUrl(m.member_avatar) ? (
                 <img
@@ -354,7 +354,7 @@ export function WorkspaceViewsFiltersPanel({
                   className="size-5 shrink-0 rounded-full object-cover"
                 />
               ) : (
-                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-2)] text-[10px] text-[var(--txt-secondary)]">
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-2) text-[10px] text-(--txt-secondary)">
                   {(m.member_display_name ?? m.member_email ?? "?").charAt(0)}
                 </span>
               )}
@@ -371,7 +371,7 @@ export function WorkspaceViewsFiltersPanel({
         onToggle={() => toggleSection("label")}
       >
         {allLabels.length === 0 ? (
-          <p className="px-3 py-2 text-sm text-[var(--txt-tertiary)]">
+          <p className="px-3 py-2 text-sm text-(--txt-tertiary)">
             No labels in workspace. Add labels in a project to filter by them.
           </p>
         ) : (
@@ -380,7 +380,7 @@ export function WorkspaceViewsFiltersPanel({
             .map((l) => (
               <label
                 key={l.id}
-                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
                 <input
                   type="checkbox"
@@ -393,7 +393,7 @@ export function WorkspaceViewsFiltersPanel({
                         : [...prev.labelIds, l.id],
                     }));
                   }}
-                  className="rounded border-[var(--border-subtle)]"
+                  className="rounded border-(--border-subtle)"
                 />
                 <span
                   className="size-3 shrink-0 rounded-full"
@@ -417,7 +417,7 @@ export function WorkspaceViewsFiltersPanel({
           .map((p) => (
             <label
               key={p.id}
-              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
             >
               <input
                 type="checkbox"
@@ -430,9 +430,9 @@ export function WorkspaceViewsFiltersPanel({
                       : [...prev.projectIds, p.id],
                   }));
                 }}
-                className="rounded border-[var(--border-subtle)]"
+                className="rounded border-(--border-subtle)"
               />
-              <span className="text-[var(--txt-icon-tertiary)]">
+              <span className="text-(--txt-icon-tertiary)">
                 <FILTER_ICONS.project />
               </span>
               <span className="truncate">{p.name}</span>
@@ -448,7 +448,7 @@ export function WorkspaceViewsFiltersPanel({
         {GROUPING_OPTIONS.map((g) => (
           <label
             key={g}
-            className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+            className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
           >
             <input
               type="radio"
@@ -457,7 +457,7 @@ export function WorkspaceViewsFiltersPanel({
               onChange={() =>
                 onFiltersChange((prev) => ({ ...prev, grouping: g }))
               }
-              className="border-[var(--border-subtle)]"
+              className="border-(--border-subtle)"
             />
             <span>
               {g === "all"
@@ -480,7 +480,7 @@ export function WorkspaceViewsFiltersPanel({
             d === "custom" ? (
               <label
                 key={d}
-                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 onClick={(e) => {
                   e.preventDefault();
                   openDateModal("start");
@@ -491,14 +491,14 @@ export function WorkspaceViewsFiltersPanel({
                   checked={filters.startDate.includes("custom")}
                   readOnly
                   tabIndex={-1}
-                  className="rounded border-[var(--border-subtle)]"
+                  className="rounded border-(--border-subtle)"
                 />
                 <span>{DATE_PRESET_LABELS[d]}</span>
               </label>
             ) : (
               <label
                 key={d}
-                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
                 <input
                   type="checkbox"
@@ -511,7 +511,7 @@ export function WorkspaceViewsFiltersPanel({
                         : [...prev.startDate, d],
                     }));
                   }}
-                  className="rounded border-[var(--border-subtle)]"
+                  className="rounded border-(--border-subtle)"
                 />
                 <span>{DATE_PRESET_LABELS[d]}</span>
               </label>
@@ -529,7 +529,7 @@ export function WorkspaceViewsFiltersPanel({
             d === "custom" ? (
               <label
                 key={d}
-                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                 onClick={(e) => {
                   e.preventDefault();
                   openDateModal("due");
@@ -540,14 +540,14 @@ export function WorkspaceViewsFiltersPanel({
                   checked={filters.dueDate.includes("custom")}
                   readOnly
                   tabIndex={-1}
-                  className="rounded border-[var(--border-subtle)]"
+                  className="rounded border-(--border-subtle)"
                 />
                 <span>{DATE_PRESET_LABELS[d]}</span>
               </label>
             ) : (
               <label
                 key={d}
-                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
               >
                 <input
                   type="checkbox"
@@ -560,7 +560,7 @@ export function WorkspaceViewsFiltersPanel({
                         : [...prev.dueDate, d],
                     }));
                   }}
-                  className="rounded border-[var(--border-subtle)]"
+                  className="rounded border-(--border-subtle)"
                 />
                 <span>{DATE_PRESET_LABELS[d]}</span>
               </label>
@@ -573,9 +573,9 @@ export function WorkspaceViewsFiltersPanel({
   return (
     <>
       {compact && (
-        <div className="sticky top-0 shrink-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-2">
-          <div className="flex items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5">
-            <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+        <div className="sticky top-0 shrink-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-2">
+          <div className="flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
+            <span className="shrink-0 text-(--txt-icon-tertiary)">
               <FILTER_ICONS.search />
             </span>
             <input
@@ -583,7 +583,7 @@ export function WorkspaceViewsFiltersPanel({
               placeholder="Search"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
             />
           </div>
         </div>

--- a/ui/src/components/workspace-views/WorkspaceViewsFiltersShared.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsFiltersShared.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+﻿import type { ReactNode } from "react";
 import { FILTER_ICONS } from "./WorkspaceViewsFiltersData";
 
 export interface CollapsibleSectionProps {
@@ -15,14 +15,14 @@ export function CollapsibleSection({
   children,
 }: CollapsibleSectionProps) {
   return (
-    <div className="border-b border-[var(--border-subtle)] last:border-b-0">
+    <div className="border-b border-(--border-subtle) last:border-b-0">
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-semibold text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+        className="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-semibold text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
       >
         {title}
-        <span className="text-[var(--txt-icon-tertiary)]">
+        <span className="text-(--txt-icon-tertiary)">
           {controlledOpen ? (
             <FILTER_ICONS.chevronUp />
           ) : (

--- a/ui/src/components/workspace-views/WorkspaceViewsLayoutSelector.tsx
+++ b/ui/src/components/workspace-views/WorkspaceViewsLayoutSelector.tsx
@@ -1,4 +1,4 @@
-import { useWorkspaceViewsState } from "../../contexts/WorkspaceViewsStateContext";
+﻿import { useWorkspaceViewsState } from "../../contexts/WorkspaceViewsStateContext";
 import {
   VIEW_LAYOUTS,
   VIEW_LAYOUT_LABELS,
@@ -116,7 +116,7 @@ export function WorkspaceViewsLayoutSelector() {
   };
 
   return (
-    <div className="flex items-center gap-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] p-0.5">
+    <div className="flex items-center gap-0.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-1) p-0.5">
       {VIEW_LAYOUTS.map((l) => {
         const Icon = LAYOUT_ICONS[l];
         const isActive = layout === l;
@@ -128,8 +128,8 @@ export function WorkspaceViewsLayoutSelector() {
             title={VIEW_LAYOUT_LABELS[l]}
             className={`flex size-8 items-center justify-center rounded transition-colors ${
               isActive
-                ? "bg-[var(--bg-layer-2)] text-[var(--txt-primary)]"
-                : "text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-secondary)]"
+                ? "bg-(--bg-layer-2) text-(--txt-primary)"
+                : "text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2) hover:text-(--txt-secondary)"
             }`}
             aria-pressed={isActive}
             aria-label={VIEW_LAYOUT_LABELS[l]}

--- a/ui/src/components/workspace-views/index.ts
+++ b/ui/src/components/workspace-views/index.ts
@@ -10,5 +10,5 @@ export { WorkspaceViewsEllipsisMenu } from "./WorkspaceViewsEllipsisMenu";
 export { WorkspaceViewsLayoutSelector } from "./WorkspaceViewsLayoutSelector";
 export { CreateViewModal } from "./CreateViewModal";
 export type { CreateViewModalProps } from "./CreateViewModal";
-export { ModuleFiltersPanel, MODULE_FILTER_PARAM } from "./ModuleFiltersPanel";
+export { ModuleFiltersPanel } from "./ModuleFiltersPanel";
 export type { ModuleFiltersPanelProps } from "./ModuleFiltersPanel";

--- a/ui/src/components/workspace-views/index.ts
+++ b/ui/src/components/workspace-views/index.ts
@@ -10,3 +10,5 @@ export { WorkspaceViewsEllipsisMenu } from "./WorkspaceViewsEllipsisMenu";
 export { WorkspaceViewsLayoutSelector } from "./WorkspaceViewsLayoutSelector";
 export { CreateViewModal } from "./CreateViewModal";
 export type { CreateViewModalProps } from "./CreateViewModal";
+export { ModuleFiltersPanel, MODULE_FILTER_PARAM } from "./ModuleFiltersPanel";
+export type { ModuleFiltersPanelProps } from "./ModuleFiltersPanel";

--- a/ui/src/contexts/ModulesFilterContext.tsx
+++ b/ui/src/contexts/ModulesFilterContext.tsx
@@ -1,0 +1,212 @@
+/* eslint-disable react-refresh/only-export-components -- Context file exports hooks + provider */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ModulesLayout = "list" | "gallery" | "timeline";
+
+export interface ModulesFilterState {
+  search: string;
+  layout: ModulesLayout;
+  sort: string;
+  order: "asc" | "desc";
+  favorites: boolean;
+  status: string[];
+  lead: string[];
+  members: string[];
+  startDateList: string[];
+  dueDateList: string[];
+  startAfter: string | null;
+  startBefore: string | null;
+  dueAfter: string | null;
+  dueBefore: string | null;
+}
+
+export interface ModulesFilterContextValue extends ModulesFilterState {
+  setSearch: (v: string) => void;
+  setLayout: (v: ModulesLayout) => void;
+  setSort: (v: string) => void;
+  setOrder: (v: "asc" | "desc") => void;
+  setFavorites: (v: boolean) => void;
+  setStatus: (v: string[] | ((prev: string[]) => string[])) => void;
+  setLead: (v: string[] | ((prev: string[]) => string[])) => void;
+  setMembers: (v: string[] | ((prev: string[]) => string[])) => void;
+  setStartDateList: (v: string[] | ((prev: string[]) => string[])) => void;
+  setDueDateList: (v: string[] | ((prev: string[]) => string[])) => void;
+  setStartAfter: (v: string | null) => void;
+  setStartBefore: (v: string | null) => void;
+  setDueAfter: (v: string | null) => void;
+  setDueBefore: (v: string | null) => void;
+  updateFilter: (
+    updater: (prev: ModulesFilterState) => Partial<ModulesFilterState>,
+  ) => void;
+}
+
+const defaultState: ModulesFilterState = {
+  search: "",
+  layout: "list",
+  sort: "progress",
+  order: "asc",
+  favorites: false,
+  status: [],
+  lead: [],
+  members: [],
+  startDateList: [],
+  dueDateList: [],
+  startAfter: null,
+  startBefore: null,
+  dueAfter: null,
+  dueBefore: null,
+};
+
+const ModulesFilterContext = createContext<ModulesFilterContextValue | null>(
+  null,
+);
+
+export function ModulesFilterProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ModulesFilterState>(defaultState);
+
+  const updateFilter = useCallback(
+    (updater: (prev: ModulesFilterState) => Partial<ModulesFilterState>) => {
+      setState((prev) => ({ ...prev, ...updater(prev) }));
+    },
+    [],
+  );
+
+  const setSearch = useCallback((v: string) => {
+    setState((prev) => ({ ...prev, search: v }));
+  }, []);
+  const setLayout = useCallback((v: ModulesLayout) => {
+    setState((prev) => ({ ...prev, layout: v }));
+  }, []);
+  const setSort = useCallback((v: string) => {
+    setState((prev) => ({ ...prev, sort: v }));
+  }, []);
+  const setOrder = useCallback((v: "asc" | "desc") => {
+    setState((prev) => ({ ...prev, order: v }));
+  }, []);
+  const setFavorites = useCallback((v: boolean) => {
+    setState((prev) => ({ ...prev, favorites: v }));
+  }, []);
+  const setStatus = useCallback(
+    (v: string[] | ((prev: string[]) => string[])) => {
+      setState((prev) => ({
+        ...prev,
+        status: typeof v === "function" ? v(prev.status) : v,
+      }));
+    },
+    [],
+  );
+  const setLead = useCallback(
+    (v: string[] | ((prev: string[]) => string[])) => {
+      setState((prev) => ({
+        ...prev,
+        lead: typeof v === "function" ? v(prev.lead) : v,
+      }));
+    },
+    [],
+  );
+  const setMembers = useCallback(
+    (v: string[] | ((prev: string[]) => string[])) => {
+      setState((prev) => ({
+        ...prev,
+        members: typeof v === "function" ? v(prev.members) : v,
+      }));
+    },
+    [],
+  );
+  const setStartDateList = useCallback(
+    (v: string[] | ((prev: string[]) => string[])) => {
+      setState((prev) => ({
+        ...prev,
+        startDateList: typeof v === "function" ? v(prev.startDateList) : v,
+      }));
+    },
+    [],
+  );
+  const setDueDateList = useCallback(
+    (v: string[] | ((prev: string[]) => string[])) => {
+      setState((prev) => ({
+        ...prev,
+        dueDateList: typeof v === "function" ? v(prev.dueDateList) : v,
+      }));
+    },
+    [],
+  );
+  const setStartAfter = useCallback((v: string | null) => {
+    setState((prev) => ({ ...prev, startAfter: v }));
+  }, []);
+  const setStartBefore = useCallback((v: string | null) => {
+    setState((prev) => ({ ...prev, startBefore: v }));
+  }, []);
+  const setDueAfter = useCallback((v: string | null) => {
+    setState((prev) => ({ ...prev, dueAfter: v }));
+  }, []);
+  const setDueBefore = useCallback((v: string | null) => {
+    setState((prev) => ({ ...prev, dueBefore: v }));
+  }, []);
+
+  const value = useMemo<ModulesFilterContextValue>(
+    () => ({
+      ...state,
+      setSearch,
+      setLayout,
+      setSort,
+      setOrder,
+      setFavorites,
+      setStatus,
+      setLead,
+      setMembers,
+      setStartDateList,
+      setDueDateList,
+      setStartAfter,
+      setStartBefore,
+      setDueAfter,
+      setDueBefore,
+      updateFilter,
+    }),
+    [
+      state,
+      setSearch,
+      setLayout,
+      setSort,
+      setOrder,
+      setFavorites,
+      setStatus,
+      setLead,
+      setMembers,
+      setStartDateList,
+      setDueDateList,
+      setStartAfter,
+      setStartBefore,
+      setDueAfter,
+      setDueBefore,
+      updateFilter,
+    ],
+  );
+
+  return (
+    <ModulesFilterContext.Provider value={value}>
+      {children}
+    </ModulesFilterContext.Provider>
+  );
+}
+
+export function useModulesFilter(): ModulesFilterContextValue {
+  const ctx = useContext(ModulesFilterContext);
+  if (!ctx) {
+    throw new Error(
+      "useModulesFilter must be used within ModulesFilterProvider",
+    );
+  }
+  return ctx;
+}
+
+export function useModulesFilterOrNull(): ModulesFilterContextValue | null {
+  return useContext(ModulesFilterContext);
+}

--- a/ui/src/hooks/useModuleFavorites.ts
+++ b/ui/src/hooks/useModuleFavorites.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY_PREFIX = "module_favorites";
+
+function storageKey(workspaceId: string, projectId: string): string {
+  return `${STORAGE_KEY_PREFIX}_${workspaceId}_${projectId}`;
+}
+
+function loadFavorites(workspaceId: string, projectId: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey(workspaceId, projectId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function useModuleFavorites(
+  workspaceId: string | undefined,
+  projectId: string | undefined,
+) {
+  const [favoriteModuleIds, setFavoriteModuleIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!workspaceId || !projectId) {
+      setFavoriteModuleIds([]);
+      return;
+    }
+    setFavoriteModuleIds(loadFavorites(workspaceId, projectId));
+  }, [workspaceId, projectId]);
+
+  const toggleFavorite = useCallback(
+    (moduleId: string) => {
+      if (!workspaceId || !projectId) return;
+      setFavoriteModuleIds((prev) => {
+        const next = prev.includes(moduleId)
+          ? prev.filter((id) => id !== moduleId)
+          : [...prev, moduleId];
+        try {
+          localStorage.setItem(
+            storageKey(workspaceId, projectId),
+            JSON.stringify(next),
+          );
+        } catch {
+          // ignore
+        }
+        return next;
+      });
+    },
+    [workspaceId, projectId],
+  );
+
+  const isFavorite = useCallback(
+    (moduleId: string) => favoriteModuleIds.includes(moduleId),
+    [favoriteModuleIds],
+  );
+
+  return { favoriteModuleIds, toggleFavorite, isFavorite };
+}

--- a/ui/src/hooks/useModuleFavorites.ts
+++ b/ui/src/hooks/useModuleFavorites.ts
@@ -26,11 +26,9 @@ export function useModuleFavorites(
   const [favoriteModuleIds, setFavoriteModuleIds] = useState<string[]>([]);
 
   useEffect(() => {
-    if (!workspaceId || !projectId) {
-      setFavoriteModuleIds([]);
-      return;
-    }
-    setFavoriteModuleIds(loadFavorites(workspaceId, projectId));
+    const next =
+      workspaceId && projectId ? loadFavorites(workspaceId, projectId) : [];
+    queueMicrotask(() => setFavoriteModuleIds(next));
   }, [workspaceId, projectId]);
 
   const toggleFavorite = useCallback(

--- a/ui/src/lib/slug.ts
+++ b/ui/src/lib/slug.ts
@@ -1,0 +1,7 @@
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}

--- a/ui/src/pages/AnalyticsOverviewPage.tsx
+++ b/ui/src/pages/AnalyticsOverviewPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   Radar,
@@ -89,14 +89,14 @@ export function AnalyticsOverviewPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="text-[var(--txt-secondary)]">Workspace not found.</div>
+      <div className="text-(--txt-secondary)">Workspace not found.</div>
     );
   }
 
@@ -133,22 +133,22 @@ export function AnalyticsOverviewPage() {
   return (
     <div className="space-y-6 pb-8">
       {/* Tabs */}
-      <div className="flex gap-1 border-b border-[var(--border-subtle)]">
+      <div className="flex gap-1 border-b border-(--border-subtle)">
         <Link
           to={`${baseUrl}/overview`}
-          className="border-b-2 border-[var(--brand-default)] px-4 py-2.5 text-sm font-medium text-[var(--txt-primary)] no-underline"
+          className="border-b-2 border-(--brand-default) px-4 py-2.5 text-sm font-medium text-(--txt-primary) no-underline"
         >
           Overview
         </Link>
         <Link
           to={`${baseUrl}/work-items`}
-          className="border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-[var(--txt-secondary)] no-underline hover:text-[var(--txt-primary)]"
+          className="border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-(--txt-secondary) no-underline hover:text-(--txt-primary)"
         >
           Work items
         </Link>
       </div>
 
-      <h2 className="text-lg font-semibold text-[var(--txt-primary)]">
+      <h2 className="text-lg font-semibold text-(--txt-primary)">
         Overview
       </h2>
 
@@ -157,12 +157,12 @@ export function AnalyticsOverviewPage() {
         {summaryCards.map(({ label, value }) => (
           <div
             key={label}
-            className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3"
+            className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
           >
-            <p className="text-xs font-medium text-[var(--txt-tertiary)]">
+            <p className="text-xs font-medium text-(--txt-tertiary)">
               {label}
             </p>
-            <p className="mt-1 text-2xl font-semibold text-[var(--txt-primary)]">
+            <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
               {value}
             </p>
           </div>
@@ -172,17 +172,17 @@ export function AnalyticsOverviewPage() {
       {/* Project Insights (with Work Items + Summary of Projects) | Active Projects - same row */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
         {/* Project Insights: contains Work Items and Summary of Projects (same row) */}
-        <section className="min-w-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-6">
-          <h3 className="mb-4 text-base font-semibold text-[var(--txt-primary)]">
+        <section className="min-w-0 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-6">
+          <h3 className="mb-4 text-base font-semibold text-(--txt-primary)">
             Project Insights
           </h3>
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-[3fr_2fr]">
             {/* Work Items - radar chart */}
             <div className="min-w-0">
-              <h4 className="mb-3 text-sm font-semibold text-[var(--txt-primary)]">
+              <h4 className="mb-3 text-sm font-semibold text-(--txt-primary)">
                 Work Items
               </h4>
-              <div className="rounded-md bg-[var(--bg-surface-1)] p-4">
+              <div className="rounded-md bg-(--bg-surface-1) p-4">
                 <div className="h-[400px] w-full">
                   <ResponsiveContainer width="100%" height="100%">
                     <RechartsRadarChart
@@ -217,23 +217,23 @@ export function AnalyticsOverviewPage() {
 
             {/* Summary of Projects */}
             <div className="min-w-0">
-              <h4 className="mb-2 text-sm font-semibold text-[var(--txt-primary)]">
+              <h4 className="mb-2 text-sm font-semibold text-(--txt-primary)">
                 Summary of Projects
               </h4>
-              <p className="mb-1 text-sm font-semibold text-[var(--txt-primary)]">
+              <p className="mb-1 text-sm font-semibold text-(--txt-primary)">
                 All Projects
               </p>
-              <p className="mb-3 text-sm text-[var(--txt-tertiary)]">
+              <p className="mb-3 text-sm text-(--txt-tertiary)">
                 Trend on charts
               </p>
               <ul className="space-y-3 text-sm">
                 {radarDimensions.map((d) => (
                   <li
                     key={d.name}
-                    className="flex items-center justify-between gap-4 text-[var(--txt-secondary)]"
+                    className="flex items-center justify-between gap-4 text-(--txt-secondary)"
                   >
                     <span>{d.name}</span>
-                    <span className="shrink-0 font-medium tabular-nums text-[var(--txt-primary)]">
+                    <span className="shrink-0 font-medium tabular-nums text-(--txt-primary)">
                       {d.value}
                     </span>
                   </li>
@@ -245,22 +245,22 @@ export function AnalyticsOverviewPage() {
 
         {/* Active Projects */}
         <section className="min-w-0">
-          <h3 className="mb-4 text-base font-semibold text-[var(--txt-primary)]">
+          <h3 className="mb-4 text-base font-semibold text-(--txt-primary)">
             Active Projects
           </h3>
           <ul className="space-y-2">
             {projects.map((p) => (
               <li
                 key={p.id}
-                className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3"
+                className="flex items-center gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
               >
-                <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-[var(--bg-layer-2)] text-sm font-medium text-[var(--txt-icon-secondary)]">
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-(--bg-layer-2) text-sm font-medium text-(--txt-icon-secondary)">
                   {p.name.charAt(0)}
                 </span>
-                <span className="min-w-0 flex-1 truncate font-medium text-[var(--txt-primary)]">
+                <span className="min-w-0 flex-1 truncate font-medium text-(--txt-primary)">
                   {p.name}
                 </span>
-                <span className="shrink-0 rounded bg-[var(--bg-danger-subtle)] px-2 py-0.5 text-xs font-medium text-[var(--txt-danger-primary)]">
+                <span className="shrink-0 rounded bg-(--bg-danger-subtle) px-2 py-0.5 text-xs font-medium text-(--txt-danger-primary)">
                   0%
                 </span>
               </li>

--- a/ui/src/pages/AnalyticsOverviewPage.tsx
+++ b/ui/src/pages/AnalyticsOverviewPage.tsx
@@ -95,9 +95,7 @@ export function AnalyticsOverviewPage() {
     );
   }
   if (!workspace) {
-    return (
-      <div className="text-(--txt-secondary)">Workspace not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Workspace not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/analytics`;
@@ -148,9 +146,7 @@ export function AnalyticsOverviewPage() {
         </Link>
       </div>
 
-      <h2 className="text-lg font-semibold text-(--txt-primary)">
-        Overview
-      </h2>
+      <h2 className="text-lg font-semibold text-(--txt-primary)">Overview</h2>
 
       {/* Summary cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
@@ -159,9 +155,7 @@ export function AnalyticsOverviewPage() {
             key={label}
             className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
           >
-            <p className="text-xs font-medium text-(--txt-tertiary)">
-              {label}
-            </p>
+            <p className="text-xs font-medium text-(--txt-tertiary)">{label}</p>
             <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
               {value}
             </p>

--- a/ui/src/pages/AnalyticsWorkItemsPage.tsx
+++ b/ui/src/pages/AnalyticsWorkItemsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   LineChart,
@@ -245,14 +245,14 @@ export function AnalyticsWorkItemsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="text-[var(--txt-secondary)]">Workspace not found.</div>
+      <div className="text-(--txt-secondary)">Workspace not found.</div>
     );
   }
 
@@ -261,64 +261,64 @@ export function AnalyticsWorkItemsPage() {
   return (
     <div className="space-y-6 pb-8">
       {/* Tabs */}
-      <div className="flex gap-1 border-b border-[var(--border-subtle)]">
+      <div className="flex gap-1 border-b border-(--border-subtle)">
         <Link
           to={`${baseUrl}/overview`}
-          className="border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-[var(--txt-secondary)] no-underline hover:text-[var(--txt-primary)]"
+          className="border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-(--txt-secondary) no-underline hover:text-(--txt-primary)"
         >
           Overview
         </Link>
         <Link
           to={`${baseUrl}/work-items`}
-          className="border-b-2 border-[var(--brand-default)] px-4 py-2.5 text-sm font-medium text-[var(--txt-primary)] no-underline"
+          className="border-b-2 border-(--brand-default) px-4 py-2.5 text-sm font-medium text-(--txt-primary) no-underline"
         >
           Work items
         </Link>
       </div>
 
-      <h2 className="text-lg font-semibold text-[var(--txt-primary)]">
+      <h2 className="text-lg font-semibold text-(--txt-primary)">
         Work items
       </h2>
 
       {/* KPIs */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3">
-          <p className="text-xs font-medium text-[var(--txt-tertiary)]">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3">
+          <p className="text-xs font-medium text-(--txt-tertiary)">
             Total Work items
           </p>
-          <p className="mt-1 text-2xl font-semibold text-[var(--txt-primary)]">
+          <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
             {issues.length}
           </p>
         </div>
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3">
-          <p className="text-xs font-medium text-[var(--txt-tertiary)]">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3">
+          <p className="text-xs font-medium text-(--txt-tertiary)">
             Started Work items
           </p>
-          <p className="mt-1 text-2xl font-semibold text-[var(--txt-primary)]">
+          <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
             {startedCount}
           </p>
         </div>
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3">
-          <p className="text-xs font-medium text-[var(--txt-tertiary)]">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3">
+          <p className="text-xs font-medium text-(--txt-tertiary)">
             Backlog Work items
           </p>
-          <p className="mt-1 text-2xl font-semibold text-[var(--txt-primary)]">
+          <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
             {backlogCount}
           </p>
         </div>
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3">
-          <p className="text-xs font-medium text-[var(--txt-tertiary)]">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3">
+          <p className="text-xs font-medium text-(--txt-tertiary)">
             Unstarted Work items
           </p>
-          <p className="mt-1 text-2xl font-semibold text-[var(--txt-primary)]">
+          <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
             {unstartedCount}
           </p>
         </div>
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3">
-          <p className="text-xs font-medium text-[var(--txt-tertiary)]">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3">
+          <p className="text-xs font-medium text-(--txt-tertiary)">
             Completed Work items
           </p>
-          <p className="mt-1 text-2xl font-semibold text-[var(--txt-primary)]">
+          <p className="mt-1 text-2xl font-semibold text-(--txt-primary)">
             {completedCount}
           </p>
         </div>
@@ -326,10 +326,10 @@ export function AnalyticsWorkItemsPage() {
 
       {/* Created vs Resolved */}
       <section>
-        <h3 className="mb-4 text-base font-semibold text-[var(--txt-primary)]">
+        <h3 className="mb-4 text-base font-semibold text-(--txt-primary)">
           Created vs Resolved
         </h3>
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-6">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-6">
           <div className="h-[280px] w-full">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart
@@ -376,7 +376,7 @@ export function AnalyticsWorkItemsPage() {
                   iconType="square"
                   iconSize={10}
                   formatter={(value) => (
-                    <span className="text-xs text-[var(--txt-secondary)]">
+                    <span className="text-xs text-(--txt-secondary)">
                       {value}
                     </span>
                   )}
@@ -407,31 +407,31 @@ export function AnalyticsWorkItemsPage() {
 
       {/* Customized Insights */}
       <section>
-        <h3 className="mb-4 flex items-center gap-2 text-base font-semibold text-[var(--txt-primary)]">
+        <h3 className="mb-4 flex items-center gap-2 text-base font-semibold text-(--txt-primary)">
           <IconBriefcase />
           Customized Insights
         </h3>
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconBriefcase /> Work item <span className="opacity-60">∨</span>
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconCalendar /> Priority <span className="opacity-60">∨</span>
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconSettings /> Add Property <span className="opacity-60">∨</span>
           </button>
         </div>
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-6">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-6">
           <div className="h-[280px] w-full">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart
@@ -485,29 +485,29 @@ export function AnalyticsWorkItemsPage() {
       <section>
         <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-2">
-            <h3 className="text-base font-semibold text-[var(--txt-primary)]">
+            <h3 className="text-base font-semibold text-(--txt-primary)">
               {priorityRows.length} Priority
               {priorityRows.length !== 1 ? "ies" : ""}
             </h3>
-            <span className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)]">
+            <span className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary)">
               <IconSearch />
             </span>
           </div>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconDownload /> Export as csv
           </button>
         </div>
-        <div className="overflow-x-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
+        <div className="overflow-x-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
           <table className="w-full text-left text-sm">
             <thead>
-              <tr className="border-b border-[var(--border-subtle)]">
-                <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+              <tr className="border-b border-(--border-subtle)">
+                <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                   Priority
                 </th>
-                <th className="py-3 font-medium text-[var(--txt-secondary)]">
+                <th className="py-3 font-medium text-(--txt-secondary)">
                   Count
                 </th>
               </tr>
@@ -516,12 +516,12 @@ export function AnalyticsWorkItemsPage() {
               {priorityRows.map(({ priority, count }) => (
                 <tr
                   key={priority}
-                  className="border-b border-[var(--border-subtle)] last:border-0"
+                  className="border-b border-(--border-subtle) last:border-0"
                 >
-                  <td className="py-3 pr-4 text-[var(--txt-primary)]">
+                  <td className="py-3 pr-4 text-(--txt-primary)">
                     {priority}
                   </td>
-                  <td className="py-3 text-[var(--txt-secondary)]">{count}</td>
+                  <td className="py-3 text-(--txt-secondary)">{count}</td>
                 </tr>
               ))}
             </tbody>
@@ -533,40 +533,40 @@ export function AnalyticsWorkItemsPage() {
       <section>
         <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-2">
-            <h3 className="text-base font-semibold text-[var(--txt-primary)]">
+            <h3 className="text-base font-semibold text-(--txt-primary)">
               {projects.length} Projects
             </h3>
-            <span className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)]">
+            <span className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary)">
               <IconSearch />
             </span>
           </div>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconDownload /> Export as csv
           </button>
         </div>
-        <div className="overflow-x-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
+        <div className="overflow-x-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
           <table className="w-full text-left text-sm">
             <thead>
-              <tr className="border-b border-[var(--border-subtle)]">
-                <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+              <tr className="border-b border-(--border-subtle)">
+                <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                   Project
                 </th>
-                <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                   Backlog
                 </th>
-                <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                   Started
                 </th>
-                <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                   Unstarted
                 </th>
-                <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                   Completed
                 </th>
-                <th className="py-3 font-medium text-[var(--txt-secondary)]">
+                <th className="py-3 font-medium text-(--txt-secondary)">
                   Cancelled
                 </th>
               </tr>
@@ -583,31 +583,31 @@ export function AnalyticsWorkItemsPage() {
                 }) => (
                   <tr
                     key={project.id}
-                    className="border-b border-[var(--border-subtle)] last:border-0"
+                    className="border-b border-(--border-subtle) last:border-0"
                   >
                     <td className="py-3 pr-4">
                       <div className="flex items-center gap-2">
-                        <span className="flex size-6 items-center justify-center rounded bg-[var(--bg-layer-2)] text-[10px] font-medium text-[var(--txt-icon-secondary)]">
+                        <span className="flex size-6 items-center justify-center rounded bg-(--bg-layer-2) text-[10px] font-medium text-(--txt-icon-secondary)">
                           <IconBriefcase />
                         </span>
-                        <span className="text-[var(--txt-primary)]">
+                        <span className="text-(--txt-primary)">
                           {project.name}
                         </span>
                       </div>
                     </td>
-                    <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                    <td className="py-3 pr-4 text-(--txt-secondary)">
                       {backlog}
                     </td>
-                    <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                    <td className="py-3 pr-4 text-(--txt-secondary)">
                       {started}
                     </td>
-                    <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                    <td className="py-3 pr-4 text-(--txt-secondary)">
                       {unstarted}
                     </td>
-                    <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                    <td className="py-3 pr-4 text-(--txt-secondary)">
                       {completed}
                     </td>
-                    <td className="py-3 text-[var(--txt-secondary)]">
+                    <td className="py-3 text-(--txt-secondary)">
                       {cancelled}
                     </td>
                   </tr>

--- a/ui/src/pages/AnalyticsWorkItemsPage.tsx
+++ b/ui/src/pages/AnalyticsWorkItemsPage.tsx
@@ -251,9 +251,7 @@ export function AnalyticsWorkItemsPage() {
     );
   }
   if (!workspace) {
-    return (
-      <div className="text-(--txt-secondary)">Workspace not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Workspace not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/analytics`;
@@ -276,9 +274,7 @@ export function AnalyticsWorkItemsPage() {
         </Link>
       </div>
 
-      <h2 className="text-lg font-semibold text-(--txt-primary)">
-        Work items
-      </h2>
+      <h2 className="text-lg font-semibold text-(--txt-primary)">Work items</h2>
 
       {/* KPIs */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
@@ -518,9 +514,7 @@ export function AnalyticsWorkItemsPage() {
                   key={priority}
                   className="border-b border-(--border-subtle) last:border-0"
                 >
-                  <td className="py-3 pr-4 text-(--txt-primary)">
-                    {priority}
-                  </td>
+                  <td className="py-3 pr-4 text-(--txt-primary)">{priority}</td>
                   <td className="py-3 text-(--txt-secondary)">{count}</td>
                 </tr>
               ))}
@@ -607,9 +601,7 @@ export function AnalyticsWorkItemsPage() {
                     <td className="py-3 pr-4 text-(--txt-secondary)">
                       {completed}
                     </td>
-                    <td className="py-3 text-(--txt-secondary)">
-                      {cancelled}
-                    </td>
+                    <td className="py-3 text-(--txt-secondary)">{cancelled}</td>
                   </tr>
                 ),
               )}

--- a/ui/src/pages/ArchivesPage.tsx
+++ b/ui/src/pages/ArchivesPage.tsx
@@ -4,9 +4,7 @@ export function ArchivesPage() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
   return (
     <div className="mx-auto max-w-4xl space-y-6 pb-8">
-      <h1 className="text-2xl font-semibold text-(--txt-primary)">
-        Archives
-      </h1>
+      <h1 className="text-2xl font-semibold text-(--txt-primary)">Archives</h1>
       <p className="text-sm text-(--txt-secondary)">
         Archived projects and items. (Placeholder for {workspaceSlug})
       </p>

--- a/ui/src/pages/ArchivesPage.tsx
+++ b/ui/src/pages/ArchivesPage.tsx
@@ -1,13 +1,13 @@
-import { useParams } from "react-router-dom";
+﻿import { useParams } from "react-router-dom";
 
 export function ArchivesPage() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
   return (
     <div className="mx-auto max-w-4xl space-y-6 pb-8">
-      <h1 className="text-2xl font-semibold text-[var(--txt-primary)]">
+      <h1 className="text-2xl font-semibold text-(--txt-primary)">
         Archives
       </h1>
-      <p className="text-sm text-[var(--txt-secondary)]">
+      <p className="text-sm text-(--txt-secondary)">
         Archived projects and items. (Placeholder for {workspaceSlug})
       </p>
     </div>

--- a/ui/src/pages/BoardPage.tsx
+++ b/ui/src/pages/BoardPage.tsx
@@ -81,9 +81,7 @@ export function BoardPage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
@@ -94,9 +92,7 @@ export function BoardPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-(--txt-primary)">
-        Board
-      </h1>
+      <h1 className="text-2xl font-semibold text-(--txt-primary)">Board</h1>
       <div className="flex gap-4 overflow-x-auto pb-4">
         {issuesByState.map(({ state, issues: stateIssues }) => (
           <div
@@ -110,9 +106,7 @@ export function BoardPage() {
                 borderLeftColor: state.color ?? "var(--border-subtle)",
               }}
             >
-              <h2 className="font-medium text-(--txt-primary)">
-                {state.name}
-              </h2>
+              <h2 className="font-medium text-(--txt-primary)">{state.name}</h2>
               <p className="text-xs text-(--txt-tertiary)">
                 {stateIssues.length} issue{stateIssues.length !== 1 ? "s" : ""}
               </p>

--- a/ui/src/pages/BoardPage.tsx
+++ b/ui/src/pages/BoardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Card, CardContent, Badge } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
@@ -75,14 +75,14 @@ export function BoardPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
@@ -94,26 +94,26 @@ export function BoardPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-[var(--txt-primary)]">
+      <h1 className="text-2xl font-semibold text-(--txt-primary)">
         Board
       </h1>
       <div className="flex gap-4 overflow-x-auto pb-4">
         {issuesByState.map(({ state, issues: stateIssues }) => (
           <div
             key={state.id}
-            className="flex w-72 shrink-0 flex-col rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--bg-layer-1)]"
+            className="flex w-72 shrink-0 flex-col rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-layer-1)"
           >
             <div
-              className="border-b border-[var(--border-subtle)] px-4 py-3"
+              className="border-b border-(--border-subtle) px-4 py-3"
               style={{
                 borderLeftWidth: "4px",
                 borderLeftColor: state.color ?? "var(--border-subtle)",
               }}
             >
-              <h2 className="font-medium text-[var(--txt-primary)]">
+              <h2 className="font-medium text-(--txt-primary)">
                 {state.name}
               </h2>
-              <p className="text-xs text-[var(--txt-tertiary)]">
+              <p className="text-xs text-(--txt-tertiary)">
                 {stateIssues.length} issue{stateIssues.length !== 1 ? "s" : ""}
               </p>
             </div>
@@ -126,10 +126,10 @@ export function BoardPage() {
                 >
                   <Card
                     variant="elevated"
-                    className="cursor-pointer transition-shadow hover:shadow-[var(--shadow-overlay)]"
+                    className="cursor-pointer transition-shadow hover:shadow-(--shadow-overlay)"
                   >
                     <CardContent className="p-3">
-                      <p className="font-medium text-[var(--txt-primary)]">
+                      <p className="font-medium text-(--txt-primary)">
                         {issue.name}
                       </p>
                       <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -148,7 +148,7 @@ export function BoardPage() {
                 </Link>
               ))}
               {stateIssues.length === 0 && (
-                <p className="py-4 text-center text-sm text-[var(--txt-tertiary)]">
+                <p className="py-4 text-center text-sm text-(--txt-tertiary)">
                   No issues
                 </p>
               )}

--- a/ui/src/pages/CyclesPage.tsx
+++ b/ui/src/pages/CyclesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Avatar } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
@@ -18,7 +18,7 @@ const IconTrendingUp = () => (
     fill="none"
     stroke="currentColor"
     strokeWidth="1.5"
-    className="text-[var(--txt-icon-tertiary)]"
+    className="text-(--txt-icon-tertiary)"
     aria-hidden
   >
     <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
@@ -33,7 +33,7 @@ const IconActivity = () => (
     fill="none"
     stroke="currentColor"
     strokeWidth="1.5"
-    className="text-[var(--txt-icon-tertiary)]"
+    className="text-(--txt-icon-tertiary)"
     aria-hidden
   >
     <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
@@ -47,7 +47,7 @@ const IconBarChart = () => (
     fill="none"
     stroke="currentColor"
     strokeWidth="1.5"
-    className="text-[var(--txt-icon-tertiary)]"
+    className="text-(--txt-icon-tertiary)"
     aria-hidden
   >
     <line x1="12" y1="20" x2="12" y2="10" />
@@ -204,14 +204,14 @@ export function CyclesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
@@ -223,22 +223,22 @@ export function CyclesPage() {
     <div className="space-y-8">
       {/* Active cycle */}
       <section>
-        <h2 className="mb-4 flex items-center gap-2 text-base font-semibold text-[var(--txt-primary)]">
+        <h2 className="mb-4 flex items-center gap-2 text-base font-semibold text-(--txt-primary)">
           <span
-            className="flex h-2.5 w-2.5 rounded-full bg-[var(--warning-default)]"
+            className="flex h-2.5 w-2.5 rounded-full bg-(--warning-default)"
             aria-hidden
           />
           Active cycle
         </h2>
         {activeCycle ? (
           <div className="space-y-4">
-            <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4">
+            <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <p className="font-medium text-[var(--txt-primary)]">
+                  <p className="font-medium text-(--txt-primary)">
                     {activeCycle.name}
                   </p>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     {Math.round(
                       (getIssueCount(activeCycle.id) /
                         Math.max(1, getIssueCount(activeCycle.id))) *
@@ -247,10 +247,10 @@ export function CyclesPage() {
                     % completion
                   </p>
                 </div>
-                <div className="flex items-center gap-2 text-sm text-[var(--txt-secondary)]">
+                <div className="flex items-center gap-2 text-sm text-(--txt-secondary)">
                   <Link
                     to={`${baseUrl}/cycles/${activeCycle.id}`}
-                    className="flex items-center gap-1 no-underline hover:text-[var(--txt-primary)]"
+                    className="flex items-center gap-1 no-underline hover:text-(--txt-primary)"
                   >
                     <IconEye /> More details
                   </Link>
@@ -273,14 +273,14 @@ export function CyclesPage() {
                   )}
                   <button
                     type="button"
-                    className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                    className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                     aria-label="Star"
                   >
                     <IconStar />
                   </button>
                   <button
                     type="button"
-                    className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                    className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                     aria-label="More"
                   >
                     <IconMoreVertical />
@@ -289,55 +289,55 @@ export function CyclesPage() {
               </div>
             </div>
             <div className="grid gap-4 sm:grid-cols-3">
-              <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4">
-                <h3 className="text-sm font-medium text-[var(--txt-primary)]">
+              <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4">
+                <h3 className="text-sm font-medium text-(--txt-primary)">
                   Progress
                 </h3>
                 <div className="mt-4 flex flex-col items-center justify-center py-6">
                   <IconTrendingUp />
-                  <p className="mt-2 text-center text-sm text-[var(--txt-tertiary)]">
+                  <p className="mt-2 text-center text-sm text-(--txt-tertiary)">
                     Add work items to the cycle to view it&apos;s progress
                   </p>
                 </div>
               </div>
-              <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4">
-                <h3 className="text-sm font-medium text-[var(--txt-primary)]">
+              <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4">
+                <h3 className="text-sm font-medium text-(--txt-primary)">
                   Work item burndown
                 </h3>
                 <div className="mt-4 flex flex-col items-center justify-center py-6">
                   <IconActivity />
-                  <p className="mt-2 text-center text-sm text-[var(--txt-tertiary)]">
+                  <p className="mt-2 text-center text-sm text-(--txt-tertiary)">
                     Add work items to the cycle to view the burndown chart.
                   </p>
                 </div>
               </div>
-              <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4">
-                <h3 className="text-sm font-medium text-[var(--txt-primary)]">
+              <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4">
+                <h3 className="text-sm font-medium text-(--txt-primary)">
                   Priority work items
                 </h3>
-                <div className="mt-2 flex gap-1 border-b border-[var(--border-subtle)]">
+                <div className="mt-2 flex gap-1 border-b border-(--border-subtle)">
                   <button
                     type="button"
-                    className="border-b-2 border-[var(--brand-default)] px-2 py-1.5 text-xs font-medium text-[var(--txt-primary)]"
+                    className="border-b-2 border-(--brand-default) px-2 py-1.5 text-xs font-medium text-(--txt-primary)"
                   >
                     Priority work items
                   </button>
                   <button
                     type="button"
-                    className="px-2 py-1.5 text-xs font-medium text-[var(--txt-tertiary)] hover:text-[var(--txt-secondary)]"
+                    className="px-2 py-1.5 text-xs font-medium text-(--txt-tertiary) hover:text-(--txt-secondary)"
                   >
                     Assignees
                   </button>
                   <button
                     type="button"
-                    className="px-2 py-1.5 text-xs font-medium text-[var(--txt-tertiary)] hover:text-[var(--txt-secondary)]"
+                    className="px-2 py-1.5 text-xs font-medium text-(--txt-tertiary) hover:text-(--txt-secondary)"
                   >
                     Labels
                   </button>
                 </div>
                 <div className="flex flex-col items-center justify-center py-6">
                   <IconBarChart />
-                  <p className="mt-2 text-center text-sm text-[var(--txt-tertiary)]">
+                  <p className="mt-2 text-center text-sm text-(--txt-tertiary)">
                     Observe high priority work items tackled in the cycle at a
                     glance.
                   </p>
@@ -346,7 +346,7 @@ export function CyclesPage() {
             </div>
           </div>
         ) : (
-          <p className="text-sm text-[var(--txt-tertiary)]">No active cycle.</p>
+          <p className="text-sm text-(--txt-tertiary)">No active cycle.</p>
         )}
       </section>
 
@@ -355,9 +355,9 @@ export function CyclesPage() {
         <button
           type="button"
           onClick={() => setUpcomingOpen((o) => !o)}
-          className="flex w-full items-center gap-2 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-2.5 text-left text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+          className="flex w-full items-center gap-2 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-2.5 text-left text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
         >
-          <span className="flex h-2 w-2 rounded-full border-2 border-dashed border-[var(--brand-default)] bg-transparent" />
+          <span className="flex h-2 w-2 rounded-full border-2 border-dashed border-(--brand-default) bg-transparent" />
           Upcoming cycle {upcomingCycles.length}
           <span className="ml-auto">
             {upcomingOpen ? <IconChevronUp /> : <IconChevronDown />}
@@ -366,7 +366,7 @@ export function CyclesPage() {
         {upcomingOpen && (
           <div className="mt-2 space-y-2 pl-4">
             {upcomingCycles.length === 0 ? (
-              <p className="py-4 text-sm text-[var(--txt-tertiary)]">
+              <p className="py-4 text-sm text-(--txt-tertiary)">
                 No upcoming cycles.
               </p>
             ) : (
@@ -374,12 +374,12 @@ export function CyclesPage() {
                 <Link
                   key={c.id}
                   to={`${baseUrl}/cycles/${c.id}`}
-                  className="block rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3 text-sm no-underline hover:bg-[var(--bg-layer-1-hover)]"
+                  className="block rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-3 text-sm no-underline hover:bg-(--bg-layer-1-hover)"
                 >
-                  <span className="font-medium text-[var(--txt-primary)]">
+                  <span className="font-medium text-(--txt-primary)">
                     {c.name}
                   </span>
-                  <span className="ml-2 text-[var(--txt-tertiary)]">
+                  <span className="ml-2 text-(--txt-tertiary)">
                     {c.start_date && c.end_date
                       ? formatDateRange(c.start_date, c.end_date)
                       : "No dates"}
@@ -396,9 +396,9 @@ export function CyclesPage() {
         <button
           type="button"
           onClick={() => setCompletedOpen((o) => !o)}
-          className="flex w-full items-center gap-2 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-2.5 text-left text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+          className="flex w-full items-center gap-2 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-2.5 text-left text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
         >
-          <span className="flex h-2 w-2 rounded-full bg-[var(--success-default)]" />
+          <span className="flex h-2 w-2 rounded-full bg-(--success-default)" />
           Completed cycle {completedCycles.length}
           <span className="ml-auto">
             {completedOpen ? <IconChevronUp /> : <IconChevronDown />}
@@ -407,7 +407,7 @@ export function CyclesPage() {
         {completedOpen && (
           <div className="mt-2 space-y-2 pl-4">
             {completedCycles.length === 0 ? (
-              <p className="py-4 text-sm text-[var(--txt-tertiary)]">
+              <p className="py-4 text-sm text-(--txt-tertiary)">
                 No completed cycles.
               </p>
             ) : (
@@ -415,12 +415,12 @@ export function CyclesPage() {
                 <Link
                   key={c.id}
                   to={`${baseUrl}/cycles/${c.id}`}
-                  className="block rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3 text-sm no-underline hover:bg-[var(--bg-layer-1-hover)]"
+                  className="block rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-3 text-sm no-underline hover:bg-(--bg-layer-1-hover)"
                 >
-                  <span className="font-medium text-[var(--txt-primary)]">
+                  <span className="font-medium text-(--txt-primary)">
                     {c.name}
                   </span>
-                  <span className="ml-2 text-[var(--txt-tertiary)]">
+                  <span className="ml-2 text-(--txt-tertiary)">
                     {c.start_date && c.end_date
                       ? formatDateRange(c.start_date, c.end_date)
                       : "No dates"}

--- a/ui/src/pages/CyclesPage.tsx
+++ b/ui/src/pages/CyclesPage.tsx
@@ -210,9 +210,7 @@ export function CyclesPage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;

--- a/ui/src/pages/DraftsPage.tsx
+++ b/ui/src/pages/DraftsPage.tsx
@@ -1,13 +1,13 @@
-import { useParams } from "react-router-dom";
+﻿import { useParams } from "react-router-dom";
 
 export function DraftsPage() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
   return (
     <div className="mx-auto max-w-4xl space-y-6 pb-8">
-      <h1 className="text-2xl font-semibold text-[var(--txt-primary)]">
+      <h1 className="text-2xl font-semibold text-(--txt-primary)">
         Drafts
       </h1>
-      <p className="text-sm text-[var(--txt-secondary)]">
+      <p className="text-sm text-(--txt-secondary)">
         Draft work items. (Placeholder for {workspaceSlug})
       </p>
     </div>

--- a/ui/src/pages/DraftsPage.tsx
+++ b/ui/src/pages/DraftsPage.tsx
@@ -4,9 +4,7 @@ export function DraftsPage() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
   return (
     <div className="mx-auto max-w-4xl space-y-6 pb-8">
-      <h1 className="text-2xl font-semibold text-(--txt-primary)">
-        Drafts
-      </h1>
+      <h1 className="text-2xl font-semibold text-(--txt-primary)">Drafts</h1>
       <p className="text-sm text-(--txt-secondary)">
         Draft work items. (Placeholder for {workspaceSlug})
       </p>

--- a/ui/src/pages/InviteAcceptPage.tsx
+++ b/ui/src/pages/InviteAcceptPage.tsx
@@ -326,9 +326,7 @@ export function InviteAcceptPage() {
           </p>
 
           {error && (
-            <p className="mt-3 text-sm text-(--txt-destructive)">
-              {error}
-            </p>
+            <p className="mt-3 text-sm text-(--txt-destructive)">{error}</p>
           )}
 
           <div className="mt-8 flex flex-col gap-3">

--- a/ui/src/pages/InviteAcceptPage.tsx
+++ b/ui/src/pages/InviteAcceptPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+﻿import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Card, CardContent, Button } from "../components/ui";
 import { useAuth } from "../contexts/AuthContext";
@@ -65,7 +65,7 @@ const IconGlobe = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden
-    className="shrink-0 text-[var(--txt-icon-secondary)]"
+    className="shrink-0 text-(--txt-icon-secondary)"
   >
     <circle cx="12" cy="12" r="10" />
     <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
@@ -184,18 +184,18 @@ export function InviteAcceptPage() {
 
   if (authLoading || loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
-        <p className="text-sm text-[var(--txt-tertiary)]">Loading…</p>
+      <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
+        <p className="text-sm text-(--txt-tertiary)">Loading…</p>
       </div>
     );
   }
 
   if (error && !invite) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+      <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
         <Card className="w-full max-w-md">
           <CardContent className="p-6">
-            <p className="text-sm text-[var(--txt-secondary)]">{error}</p>
+            <p className="text-sm text-(--txt-secondary)">{error}</p>
             <Button
               variant="secondary"
               className="mt-4"
@@ -214,20 +214,20 @@ export function InviteAcceptPage() {
   // Step 2: Join [workspace] — email + Continue → login
   if (step === "join") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+      <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
         <Card className="w-full max-w-md">
           <CardContent className="p-6">
-            <h1 className="flex items-center gap-2 text-2xl font-semibold text-[var(--txt-primary)]">
-              <span className="text-[var(--txt-secondary)]">Join</span>
+            <h1 className="flex items-center gap-2 text-2xl font-semibold text-(--txt-primary)">
+              <span className="text-(--txt-secondary)">Join</span>
               <IconGlobe />
               <span>{invite.workspace_name}</span>
             </h1>
-            <p className="mt-2 text-sm text-[var(--txt-secondary)]">
+            <p className="mt-2 text-sm text-(--txt-secondary)">
               Log in to start managing work with your team.
             </p>
 
             <div className="mt-6">
-              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+              <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                 Email
               </label>
               <div className="relative">
@@ -236,14 +236,14 @@ export function InviteAcceptPage() {
                   value={joinEmail}
                   onChange={(e) => setJoinEmail(e.target.value)}
                   placeholder="you@example.com"
-                  className="h-9 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                  className="h-9 w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-3 pr-9 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   autoComplete="email"
                 />
                 {joinEmail && (
                   <button
                     type="button"
                     onClick={() => setJoinEmail("")}
-                    className="absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                    className="absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                     aria-label="Clear email"
                   >
                     <IconClear />
@@ -270,7 +270,7 @@ export function InviteAcceptPage() {
               Continue
             </Button>
 
-            <p className="mt-4 text-center text-sm text-[var(--txt-secondary)]">
+            <p className="mt-4 text-center text-sm text-(--txt-secondary)">
               Already have an account?{" "}
               <button
                 type="button"
@@ -283,24 +283,24 @@ export function InviteAcceptPage() {
                     },
                   })
                 }
-                className="font-medium text-[var(--txt-accent)] hover:underline"
+                className="font-medium text-(--txt-accent) hover:underline"
               >
                 Sign in
               </button>
             </p>
 
-            <p className="mt-6 text-center text-xs text-[var(--txt-tertiary)]">
+            <p className="mt-6 text-center text-xs text-(--txt-tertiary)">
               By signing in, you understand and agree to our{" "}
               <a
                 href="/terms"
-                className="underline hover:text-[var(--txt-secondary)]"
+                className="underline hover:text-(--txt-secondary)"
               >
                 Terms of Service
               </a>{" "}
               and{" "}
               <a
                 href="/privacy"
-                className="underline hover:text-[var(--txt-secondary)]"
+                className="underline hover:text-(--txt-secondary)"
               >
                 Privacy Policy
               </a>
@@ -313,20 +313,20 @@ export function InviteAcceptPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+    <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
       <Card className="w-full max-w-lg">
         <CardContent className="p-8">
-          <h1 className="text-xl font-semibold text-[var(--txt-primary)]">
+          <h1 className="text-xl font-semibold text-(--txt-primary)">
             You have been invited to {invite.workspace_name}
           </h1>
-          <p className="mt-3 text-sm text-[var(--txt-secondary)]">
+          <p className="mt-3 text-sm text-(--txt-secondary)">
             Your workspace is where you'll create projects, collaborate on work
             items, and organize different streams of work in your Devlane
             account.
           </p>
 
           {error && (
-            <p className="mt-3 text-sm text-[var(--txt-destructive)]">
+            <p className="mt-3 text-sm text-(--txt-destructive)">
               {error}
             </p>
           )}
@@ -336,15 +336,15 @@ export function InviteAcceptPage() {
               type="button"
               onClick={handleAccept}
               disabled={accepting || ignoring}
-              className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 text-left text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)] disabled:opacity-50"
+              className="flex items-center justify-between gap-3 rounded-lg border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3 text-left text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover) disabled:opacity-50"
             >
               <span className="flex items-center gap-3">
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--bg-accent-primary)] text-[var(--txt-on-color)]">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-(--bg-accent-primary) text-(--txt-on-color)">
                   <IconCheck />
                 </span>
                 Accept
               </span>
-              <span className="text-[var(--txt-icon-tertiary)]">
+              <span className="text-(--txt-icon-tertiary)">
                 <IconChevronRight />
               </span>
             </button>
@@ -353,15 +353,15 @@ export function InviteAcceptPage() {
               type="button"
               onClick={handleIgnore}
               disabled={accepting || ignoring}
-              className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 text-left text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)] disabled:opacity-50"
+              className="flex items-center justify-between gap-3 rounded-lg border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3 text-left text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover) disabled:opacity-50"
             >
               <span className="flex items-center gap-3">
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--bg-layer-2)] text-[var(--txt-icon-secondary)]">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-(--bg-layer-2) text-(--txt-icon-secondary)">
                   <IconX />
                 </span>
                 Ignore
               </span>
-              <span className="text-[var(--txt-icon-tertiary)]">
+              <span className="text-(--txt-icon-tertiary)">
                 <IconChevronRight />
               </span>
             </button>

--- a/ui/src/pages/InviteSignUpPage.tsx
+++ b/ui/src/pages/InviteSignUpPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+﻿import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import { Card, CardContent, Button } from "../components/ui";
 import { useAuth } from "../contexts/AuthContext";
@@ -16,7 +16,7 @@ const IconGlobe = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden
-    className="shrink-0 text-[var(--txt-icon-secondary)]"
+    className="shrink-0 text-(--txt-icon-secondary)"
   >
     <circle cx="12" cy="12" r="10" />
     <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
@@ -91,12 +91,12 @@ function usePasswordRequirements(password: string) {
 
 function PasswordRequirement({ met, label }: { met: boolean; label: string }) {
   return (
-    <div className="flex items-center gap-2 text-sm text-[var(--txt-secondary)]">
+    <div className="flex items-center gap-2 text-sm text-(--txt-secondary)">
       <span
         className={`flex size-5 shrink-0 items-center justify-center rounded-full ${
           met
-            ? "bg-[var(--bg-success-primary)] text-[var(--txt-on-color)]"
-            : "bg-[var(--bg-layer-1)] text-[var(--txt-placeholder)]"
+            ? "bg-(--bg-success-primary) text-(--txt-on-color)"
+            : "bg-(--bg-layer-1) text-(--txt-placeholder)"
         }`}
         aria-hidden
       >
@@ -184,35 +184,35 @@ export function InviteSignUpPage() {
 
   if (!email || !token) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
-        <p className="text-sm text-[var(--txt-tertiary)]">Loading…</p>
+      <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
+        <p className="text-sm text-(--txt-tertiary)">Loading…</p>
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+    <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
       <Card className="w-full max-w-md">
         <CardContent className="p-6">
-          <h1 className="flex items-center gap-2 text-2xl font-semibold text-[var(--txt-primary)]">
-            <span className="text-[var(--txt-secondary)]">Join</span>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold text-(--txt-primary)">
+            <span className="text-(--txt-secondary)">Join</span>
             <IconGlobe />
             <span>{workspaceName}</span>
           </h1>
-          <p className="mt-2 text-sm text-[var(--txt-secondary)]">
+          <p className="mt-2 text-sm text-(--txt-secondary)">
             Set a password to create your account and join the workspace.
           </p>
 
           <form onSubmit={handleSubmit} className="mt-6 space-y-4">
             <div>
-              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+              <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                 Email
               </label>
               <input
                 type="email"
                 value={email}
                 readOnly
-                className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-3 py-2 text-sm text-[var(--txt-secondary)] focus:outline-none"
+                className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-1) px-3 py-2 text-sm text-(--txt-secondary) focus:outline-none"
                 aria-readonly
               />
             </div>
@@ -220,7 +220,7 @@ export function InviteSignUpPage() {
             <div>
               <label
                 htmlFor="invite-signup-password"
-                className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]"
+                className="mb-1 block text-sm font-medium text-(--txt-secondary)"
               >
                 Password
               </label>
@@ -231,13 +231,13 @@ export function InviteSignUpPage() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="Create a password"
-                  className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                  className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-3 pr-9 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   autoComplete="new-password"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword((p) => !p)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary) hover:text-(--txt-secondary)"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? <IconEyeOff /> : <IconEye />}
@@ -258,7 +258,7 @@ export function InviteSignUpPage() {
             <div>
               <label
                 htmlFor="invite-signup-confirm"
-                className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]"
+                className="mb-1 block text-sm font-medium text-(--txt-secondary)"
               >
                 Confirm password
               </label>
@@ -269,13 +269,13 @@ export function InviteSignUpPage() {
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   placeholder="Confirm password"
-                  className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                  className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-3 pr-9 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   autoComplete="new-password"
                 />
                 <button
                   type="button"
                   onClick={() => setShowConfirmPassword((p) => !p)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary) hover:text-(--txt-secondary)"
                   aria-label={
                     showConfirmPassword ? "Hide password" : "Show password"
                   }
@@ -286,7 +286,7 @@ export function InviteSignUpPage() {
             </div>
 
             {error && (
-              <p className="text-sm text-[var(--txt-destructive)]">{error}</p>
+              <p className="text-sm text-(--txt-destructive)">{error}</p>
             )}
 
             <Button
@@ -298,7 +298,7 @@ export function InviteSignUpPage() {
             </Button>
           </form>
 
-          <p className="mt-6 text-center text-sm text-[var(--txt-secondary)]">
+          <p className="mt-6 text-center text-sm text-(--txt-secondary)">
             Already have an account?{" "}
             <Link
               to="/login"
@@ -306,7 +306,7 @@ export function InviteSignUpPage() {
                 from: { pathname: "/invite", search: `?token=${token}` },
                 email,
               }}
-              className="font-medium text-[var(--txt-accent)] hover:underline"
+              className="font-medium text-(--txt-accent) hover:underline"
             >
               Sign in
             </Link>

--- a/ui/src/pages/IssueDetailPage.tsx
+++ b/ui/src/pages/IssueDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   Badge,
@@ -260,13 +260,13 @@ export function IssueDetailPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project || !issue) {
-    return <div className="text-[var(--txt-secondary)]">Issue not found.</div>;
+    return <div className="text-(--txt-secondary)">Issue not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
@@ -445,33 +445,33 @@ export function IssueDetailPage() {
   return (
     <div className="space-y-6">
       {errorMessage && (
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-xs text-[var(--txt-danger-primary)]">
+        <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-xs text-(--txt-danger-primary)">
           {errorMessage}
         </div>
       )}
-      <div className="flex items-center gap-2 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center gap-2 text-sm text-(--txt-tertiary)">
         <Link
           to={baseUrl}
-          className="text-[var(--txt-accent-primary)] hover:underline"
+          className="text-(--txt-accent-primary) hover:underline"
         >
           {project.name}
         </Link>
         <span>/</span>
         <Link
           to={`${baseUrl}/issues`}
-          className="text-[var(--txt-accent-primary)] hover:underline"
+          className="text-(--txt-accent-primary) hover:underline"
         >
           Issues
         </Link>
         <span>/</span>
-        <span className="text-[var(--txt-secondary)]">{displayId}</span>
+        <span className="text-(--txt-secondary)">{displayId}</span>
       </div>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="truncate text-2xl font-semibold text-[var(--txt-primary)]">
+          <h1 className="truncate text-2xl font-semibold text-(--txt-primary)">
             {issue.name}
           </h1>
-          <p className="mt-1 text-xs text-[var(--txt-tertiary)]">
+          <p className="mt-1 text-xs text-(--txt-tertiary)">
             Last edited {new Date(issue.updated_at).toLocaleDateString()}
           </p>
         </div>
@@ -490,17 +490,17 @@ export function IssueDetailPage() {
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="space-y-6 lg:col-span-2">
           <Card>
-            <CardHeader className="text-sm font-medium text-[var(--txt-secondary)]">
+            <CardHeader className="text-sm font-medium text-(--txt-secondary)">
               Description
             </CardHeader>
             <CardContent>
               {descriptionHtml ? (
                 <div
-                  className="prose prose-sm max-w-none text-[var(--txt-primary)]"
+                  className="prose prose-sm max-w-none text-(--txt-primary)"
                   dangerouslySetInnerHTML={{ __html: descriptionHtml }}
                 />
               ) : (
-                <p className="text-sm text-[var(--txt-tertiary)]">
+                <p className="text-sm text-(--txt-tertiary)">
                   Click to add description.
                 </p>
               )}
@@ -509,10 +509,10 @@ export function IssueDetailPage() {
 
           <Card>
             <CardHeader className="flex items-center justify-between">
-              <span className="text-sm font-medium text-[var(--txt-secondary)]">
+              <span className="text-sm font-medium text-(--txt-secondary)">
                 Activity
               </span>
-              <span className="text-xs text-[var(--txt-tertiary)]">
+              <span className="text-xs text-(--txt-tertiary)">
                 Comments {comments.length}
               </span>
             </CardHeader>
@@ -526,12 +526,12 @@ export function IssueDetailPage() {
                     className="mt-0.5 h-7 w-7 text-[10px]"
                   />
                   <div className="min-w-0">
-                    <p className="text-[var(--txt-secondary)]">
-                      <span className="font-medium text-[var(--txt-primary)]">
+                    <p className="text-(--txt-secondary)">
+                      <span className="font-medium text-(--txt-primary)">
                         {getMemberLabel(issue.created_by_id)}
                       </span>{" "}
                       created this work item.
-                      <span className="ml-2 text-xs text-[var(--txt-tertiary)]">
+                      <span className="ml-2 text-xs text-(--txt-tertiary)">
                         {new Date(issue.created_at).toLocaleDateString()}
                       </span>
                     </p>
@@ -539,7 +539,7 @@ export function IssueDetailPage() {
                 </div>
 
                 {comments.length === 0 ? (
-                  <p className="text-sm text-[var(--txt-tertiary)]">
+                  <p className="text-sm text-(--txt-tertiary)">
                     No comments yet.
                   </p>
                 ) : (
@@ -554,16 +554,16 @@ export function IssueDetailPage() {
                             size="sm"
                             className="mt-0.5 h-7 w-7 text-[10px]"
                           />
-                          <div className="min-w-0 flex-1 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] p-3">
+                          <div className="min-w-0 flex-1 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) p-3">
                             <div className="flex items-center justify-between gap-2">
-                              <span className="text-xs font-medium text-[var(--txt-secondary)]">
+                              <span className="text-xs font-medium text-(--txt-secondary)">
                                 {getMemberLabel(c.created_by_id)}
                               </span>
-                              <div className="flex items-center gap-2 text-[11px] text-[var(--txt-tertiary)]">
+                              <div className="flex items-center gap-2 text-[11px] text-(--txt-tertiary)">
                                 <span>{formatRelativeTime(c.created_at)}</span>
                                 <button
                                   type="button"
-                                  className="hover:text-[var(--txt-secondary)]"
+                                  className="hover:text-(--txt-secondary)"
                                   onClick={() => setEditingCommentId(c.id)}
                                   disabled={
                                     updatingCommentId === c.id ||
@@ -574,7 +574,7 @@ export function IssueDetailPage() {
                                 </button>
                                 <button
                                   type="button"
-                                  className="hover:text-[var(--txt-secondary)]"
+                                  className="hover:text-(--txt-secondary)"
                                   onClick={() => void deleteComment(c.id)}
                                   disabled={
                                     deletingCommentId === c.id ||
@@ -602,7 +602,7 @@ export function IssueDetailPage() {
                               </div>
                             ) : (
                               <div
-                                className="mt-1 prose prose-sm max-w-none text-[var(--txt-primary)]"
+                                className="mt-1 prose prose-sm max-w-none text-(--txt-primary)"
                                 dangerouslySetInnerHTML={{ __html: c.comment }}
                               />
                             )}
@@ -623,7 +623,7 @@ export function IssueDetailPage() {
 
           {children.length > 0 && (
             <Card>
-              <CardHeader className="text-sm font-medium text-[var(--txt-secondary)]">
+              <CardHeader className="text-sm font-medium text-(--txt-secondary)">
                 Sub-work items
               </CardHeader>
               <CardContent>
@@ -632,7 +632,7 @@ export function IssueDetailPage() {
                     <li key={ch.id}>
                       <Link
                         to={`${baseUrl}/issues/${ch.id}`}
-                        className="text-sm text-[var(--txt-accent-primary)] hover:underline"
+                        className="text-sm text-(--txt-accent-primary) hover:underline"
                       >
                         {ch.name}
                       </Link>
@@ -646,12 +646,12 @@ export function IssueDetailPage() {
 
         <div className="space-y-4">
           <Card>
-            <CardHeader className="text-sm font-medium text-[var(--txt-secondary)]">
+            <CardHeader className="text-sm font-medium text-(--txt-secondary)">
               Properties
             </CardHeader>
             <CardContent className="space-y-3 pt-4 text-sm">
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">State</span>
+                <span className="text-(--txt-secondary)">State</span>
                 <Dropdown
                   id="state"
                   openId={openDropdown}
@@ -666,17 +666,17 @@ export function IssueDetailPage() {
                     <button
                       key={s.id}
                       type="button"
-                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                       onClick={() => {
                         setOpenDropdown(null);
                         updateIssue({ state_id: s.id });
                       }}
                     >
-                      <span className="truncate text-[var(--txt-primary)]">
+                      <span className="truncate text-(--txt-primary)">
                         {s.name}
                       </span>
                       {issue.state_id === s.id && (
-                        <span className="text-xs text-[var(--txt-tertiary)]">
+                        <span className="text-xs text-(--txt-tertiary)">
                           Selected
                         </span>
                       )}
@@ -686,7 +686,7 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Assignees</span>
+                <span className="text-(--txt-secondary)">Assignees</span>
                 <Dropdown
                   id="assignees"
                   openId={openDropdown}
@@ -700,10 +700,10 @@ export function IssueDetailPage() {
                   }
                   compact
                   align="right"
-                  panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+                  panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
                 >
                   {members.length === 0 ? (
-                    <div className="px-3 py-2 text-sm text-[var(--txt-tertiary)]">
+                    <div className="px-3 py-2 text-sm text-(--txt-tertiary)">
                       No members.
                     </div>
                   ) : (
@@ -713,7 +713,7 @@ export function IssueDetailPage() {
                         <button
                           key={m.id}
                           type="button"
-                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                           onClick={() => {
                             const next = checked
                               ? assigneeIds.filter((x) => x !== m.member_id)
@@ -721,10 +721,10 @@ export function IssueDetailPage() {
                             updateIssue({ assignee_ids: next });
                           }}
                         >
-                          <span className="inline-flex size-4 items-center justify-center rounded border border-[var(--border-subtle)] text-[10px] text-[var(--txt-tertiary)]">
+                          <span className="inline-flex size-4 items-center justify-center rounded border border-(--border-subtle) text-[10px] text-(--txt-tertiary)">
                             {checked ? "✓" : ""}
                           </span>
-                          <span className="truncate text-[var(--txt-primary)]">
+                          <span className="truncate text-(--txt-primary)">
                             {getMemberLabel(m.member_id)}
                           </span>
                         </button>
@@ -735,7 +735,7 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Priority</span>
+                <span className="text-(--txt-secondary)">Priority</span>
                 <Dropdown
                   id="priority"
                   openId={openDropdown}
@@ -752,13 +752,13 @@ export function IssueDetailPage() {
                     <button
                       key={p}
                       type="button"
-                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                       onClick={() => {
                         setOpenDropdown(null);
                         updateIssue({ priority: p });
                       }}
                     >
-                      <span className="truncate text-[var(--txt-primary)]">
+                      <span className="truncate text-(--txt-primary)">
                         {p}
                       </span>
                       <Badge
@@ -773,14 +773,14 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Created by</span>
-                <span className="text-[var(--txt-tertiary)]">
+                <span className="text-(--txt-secondary)">Created by</span>
+                <span className="text-(--txt-tertiary)">
                   {getMemberLabel(issue.created_by_id)}
                 </span>
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Start date</span>
+                <span className="text-(--txt-secondary)">Start date</span>
                 <DatePickerTrigger
                   label="Start date"
                   icon={<IconCalendar />}
@@ -790,7 +790,7 @@ export function IssueDetailPage() {
                 />
               </div>
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Due date</span>
+                <span className="text-(--txt-secondary)">Due date</span>
                 <DatePickerTrigger
                   label="Due date"
                   icon={<IconCalendar />}
@@ -801,7 +801,7 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Modules</span>
+                <span className="text-(--txt-secondary)">Modules</span>
                 <Dropdown
                   id="module"
                   openId={openDropdown}
@@ -814,7 +814,7 @@ export function IssueDetailPage() {
                 >
                   <button
                     type="button"
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                     onClick={() => {
                       setOpenDropdown(null);
                       handleSetModule(null);
@@ -826,7 +826,7 @@ export function IssueDetailPage() {
                     <button
                       key={m.id}
                       type="button"
-                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                       onClick={() => {
                         setOpenDropdown(null);
                         handleSetModule(m.id);
@@ -834,7 +834,7 @@ export function IssueDetailPage() {
                     >
                       <span className="truncate">{m.name}</span>
                       {moduleIds.includes(m.id) && (
-                        <span className="text-xs text-[var(--txt-tertiary)]">
+                        <span className="text-xs text-(--txt-tertiary)">
                           Selected
                         </span>
                       )}
@@ -844,7 +844,7 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Cycle</span>
+                <span className="text-(--txt-secondary)">Cycle</span>
                 <Dropdown
                   id="cycle"
                   openId={openDropdown}
@@ -857,7 +857,7 @@ export function IssueDetailPage() {
                 >
                   <button
                     type="button"
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                     onClick={() => {
                       setOpenDropdown(null);
                       handleSetCycle(null);
@@ -869,7 +869,7 @@ export function IssueDetailPage() {
                     <button
                       key={c.id}
                       type="button"
-                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                       onClick={() => {
                         setOpenDropdown(null);
                         handleSetCycle(c.id);
@@ -877,7 +877,7 @@ export function IssueDetailPage() {
                     >
                       <span className="truncate">{c.name}</span>
                       {cycleIds.includes(c.id) && (
-                        <span className="text-xs text-[var(--txt-tertiary)]">
+                        <span className="text-xs text-(--txt-tertiary)">
                           Selected
                         </span>
                       )}
@@ -887,7 +887,7 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Parent</span>
+                <span className="text-(--txt-secondary)">Parent</span>
                 <Dropdown
                   id="parent"
                   openId={openDropdown}
@@ -899,19 +899,19 @@ export function IssueDetailPage() {
                   }
                   compact
                   align="right"
-                  panelClassName="max-h-72 min-w-[260px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+                  panelClassName="max-h-72 min-w-[260px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
                 >
                   {filteredParentOptions.slice(0, 200).map((pi) => (
                     <button
                       key={pi.id}
                       type="button"
-                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                       onClick={() => {
                         setOpenDropdown(null);
                         updateIssue({ parent_id: pi.id });
                       }}
                     >
-                      <span className="truncate text-[var(--txt-primary)]">
+                      <span className="truncate text-(--txt-primary)">
                         {pi.name}
                       </span>
                     </button>
@@ -920,7 +920,7 @@ export function IssueDetailPage() {
               </div>
 
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--txt-secondary)]">Labels</span>
+                <span className="text-(--txt-secondary)">Labels</span>
                 <Dropdown
                   id="labels"
                   openId={openDropdown}
@@ -934,10 +934,10 @@ export function IssueDetailPage() {
                   }
                   compact
                   align="right"
-                  panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+                  panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
                 >
                   {labels.length === 0 ? (
-                    <div className="px-3 py-2 text-sm text-[var(--txt-tertiary)]">
+                    <div className="px-3 py-2 text-sm text-(--txt-tertiary)">
                       No labels.
                     </div>
                   ) : (
@@ -947,7 +947,7 @@ export function IssueDetailPage() {
                         <button
                           key={l.id}
                           type="button"
-                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                           onClick={() => {
                             const next = checked
                               ? labelIds.filter((x) => x !== l.id)
@@ -955,10 +955,10 @@ export function IssueDetailPage() {
                             updateIssue({ label_ids: next });
                           }}
                         >
-                          <span className="inline-flex size-4 items-center justify-center rounded border border-[var(--border-subtle)] text-[10px] text-[var(--txt-tertiary)]">
+                          <span className="inline-flex size-4 items-center justify-center rounded border border-(--border-subtle) text-[10px] text-(--txt-tertiary)">
                             {checked ? "✓" : ""}
                           </span>
-                          <span className="truncate text-[var(--txt-primary)]">
+                          <span className="truncate text-(--txt-primary)">
                             {l.name}
                           </span>
                         </button>

--- a/ui/src/pages/IssueDetailPage.tsx
+++ b/ui/src/pages/IssueDetailPage.tsx
@@ -758,9 +758,7 @@ export function IssueDetailPage() {
                         updateIssue({ priority: p });
                       }}
                     >
-                      <span className="truncate text-(--txt-primary)">
-                        {p}
-                      </span>
+                      <span className="truncate text-(--txt-primary)">{p}</span>
                       <Badge
                         variant={priorityVariant[p]}
                         className="text-[10px]"

--- a/ui/src/pages/IssueListPage.tsx
+++ b/ui/src/pages/IssueListPage.tsx
@@ -280,9 +280,7 @@ export function IssueListPage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
@@ -308,9 +306,7 @@ export function IssueListPage() {
       <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
         {issues.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-4 px-4 py-12">
-            <p className="text-sm text-(--txt-tertiary)">
-              No work items yet.
-            </p>
+            <p className="text-sm text-(--txt-tertiary)">No work items yet.</p>
             <Button
               size="sm"
               className="gap-1.5"

--- a/ui/src/pages/IssueListPage.tsx
+++ b/ui/src/pages/IssueListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Badge, Avatar, Button } from "../components/ui";
 import { CreateWorkItemModal } from "../components/CreateWorkItemModal";
@@ -274,14 +274,14 @@ export function IssueListPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
@@ -291,11 +291,11 @@ export function IssueListPage() {
     <div className="space-y-4">
       {/* All work items N + plus */}
       <div className="flex items-center justify-between">
-        <h2 className="flex items-center gap-2 text-base font-semibold text-[var(--txt-primary)]">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-(--txt-primary)">
           All work items {issues.length}
           <button
             type="button"
-            className="flex size-7 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+            className="flex size-7 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
             aria-label="Add work item"
             onClick={() => setSearchParams({ create: "1" })}
           >
@@ -305,10 +305,10 @@ export function IssueListPage() {
       </div>
 
       {/* List of work item rows */}
-      <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
+      <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
         {issues.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-4 px-4 py-12">
-            <p className="text-sm text-[var(--txt-tertiary)]">
+            <p className="text-sm text-(--txt-tertiary)">
               No work items yet.
             </p>
             <Button
@@ -321,7 +321,7 @@ export function IssueListPage() {
             </Button>
           </div>
         ) : (
-          <ul className="divide-y divide-[var(--border-subtle)]">
+          <ul className="divide-y divide-(--border-subtle)">
             {issues.map((issue) => {
               const primaryAssigneeId =
                 issue.assignee_ids && issue.assignee_ids.length > 0
@@ -334,17 +334,17 @@ export function IssueListPage() {
                 <li key={issue.id}>
                   <Link
                     to={`${baseUrl}/issues/${issue.id}`}
-                    className="flex min-h-12 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+                    className="flex min-h-12 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
                   >
                     <span className="min-w-0 flex-1 truncate text-sm">
-                      <span className="font-medium text-[var(--txt-accent-primary)]">
+                      <span className="font-medium text-(--txt-accent-primary)">
                         {displayId}
                       </span>
-                      <span className="ml-2 text-[var(--txt-primary)]">
+                      <span className="ml-2 text-(--txt-primary)">
                         {issue.name}
                       </span>
                     </span>
-                    <div className="flex shrink-0 items-center gap-2 text-[var(--txt-icon-tertiary)]">
+                    <div className="flex shrink-0 items-center gap-2 text-(--txt-icon-tertiary)">
                       <span title={getStateName(issue.state_id ?? undefined)}>
                         <Badge
                           variant="neutral"
@@ -411,7 +411,7 @@ export function IssueListPage() {
                       </span>
                       <button
                         type="button"
-                        className="flex size-6 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                        className="flex size-6 items-center justify-center rounded hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                         aria-label="More options"
                         onClick={(e) => {
                           e.preventDefault();
@@ -429,10 +429,10 @@ export function IssueListPage() {
         )}
 
         {issues.length > 0 && (
-          <div className="border-t border-[var(--border-subtle)] px-4 py-2.5">
+          <div className="border-t border-(--border-subtle) px-4 py-2.5">
             <button
               type="button"
-              className="flex items-center gap-1.5 rounded-md border border-dashed border-[var(--border-subtle)] bg-transparent px-3 py-2 text-sm font-medium text-[var(--txt-secondary)] hover:border-[var(--border-strong)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-primary)]"
+              className="flex items-center gap-1.5 rounded-md border border-dashed border-(--border-subtle) bg-transparent px-3 py-2 text-sm font-medium text-(--txt-secondary) hover:border-(--border-strong) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
               onClick={() => setSearchParams({ create: "1" })}
             >
               <IconPlus />

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+﻿import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Button, Input, Card, CardContent } from "../components/ui";
 import { useAuth } from "../contexts/AuthContext";
@@ -40,13 +40,13 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+    <div className="flex min-h-screen items-center justify-center bg-(--bg-canvas) p-4">
       <Card className="w-full max-w-md">
         <CardContent className="p-6">
-          <h1 className="mb-2 text-2xl font-semibold text-[var(--txt-primary)]">
+          <h1 className="mb-2 text-2xl font-semibold text-(--txt-primary)">
             Sign in to Devlane
           </h1>
-          <p className="mb-6 text-sm text-[var(--txt-secondary)]">
+          <p className="mb-6 text-sm text-(--txt-secondary)">
             Enter your email and password to continue.
           </p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">

--- a/ui/src/pages/ModuleDetailPage.tsx
+++ b/ui/src/pages/ModuleDetailPage.tsx
@@ -8,7 +8,6 @@ import { moduleService } from "../services/moduleService";
 import { issueService } from "../services/issueService";
 import { stateService } from "../services/stateService";
 import { labelService } from "../services/labelService";
-import { workspaceService as wsMembers } from "../services/workspaceService";
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -33,7 +32,15 @@ const priorityVariant: Record<
 };
 
 const IconCalendar = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
     <line x1="16" y1="2" x2="16" y2="6" />
     <line x1="8" y1="2" x2="8" y2="6" />
@@ -41,31 +48,70 @@ const IconCalendar = () => (
   </svg>
 );
 const IconUser = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
     <circle cx="12" cy="7" r="4" />
   </svg>
 );
 const IconTag = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <path d="M12 2H2v10l9.29 9.29c.94.94 2.48.94 3.42 0l6.58-6.58c.94-.94.94-2.48 0-3.42L12 2Z" />
   </svg>
 );
 const IconMoreVertical = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden
+  >
     <circle cx="12" cy="5" r="1.5" />
     <circle cx="12" cy="12" r="1.5" />
     <circle cx="12" cy="19" r="1.5" />
   </svg>
 );
 const IconPlus = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
     <path d="M5 12h14" />
     <path d="M12 5v14" />
   </svg>
 );
 const IconModule = () => (
-  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-(--txt-icon-tertiary)" aria-hidden>
+  <svg
+    width="48"
+    height="48"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    className="text-(--txt-icon-tertiary)"
+    aria-hidden
+  >
     <rect width="8" height="8" x="3" y="3" rx="1" />
     <rect width="8" height="8" x="13" y="3" rx="1" />
     <rect width="8" height="8" x="3" y="13" rx="1" />
@@ -140,7 +186,7 @@ export function ModuleDetailPage() {
       issueService.list(workspaceSlug, projectId, { limit: 1000 }),
       stateService.list(workspaceSlug, projectId),
       labelService.list(workspaceSlug, projectId),
-      wsMembers.listMembers(workspaceSlug),
+      workspaceService.listMembers(workspaceSlug),
       projectService.list(workspaceSlug),
     ])
       .then(([w, p, mod, iss, st, lab, mem, proj]) => {
@@ -203,19 +249,28 @@ export function ModuleDetailPage() {
         parent_id: data.parentId || undefined,
       });
       if (created?.id) {
-        await moduleService.addIssue(workspaceSlug, data.projectId, moduleId, created.id);
+        await moduleService.addIssue(
+          workspaceSlug,
+          data.projectId,
+          moduleId,
+          created.id,
+        );
       }
       refetchIssues();
       handleCloseCreate();
     } catch (err) {
-      setCreateError(err instanceof Error ? err.message : "Failed to create work item");
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to create work item",
+      );
     }
   };
 
   const getStateName = (stateId: string | null | undefined) =>
     stateId ? (states.find((s) => s.id === stateId)?.name ?? stateId) : "—";
   const getLabelNames = (labelIds: string[] = []) =>
-    labelIds.map((id) => labels.find((l) => l.id === id)?.name).filter((name): name is string => Boolean(name));
+    labelIds
+      .map((id) => labels.find((l) => l.id === id)?.name)
+      .filter((name): name is string => Boolean(name));
   const getUser = (userId: string | null) => {
     if (!userId) return null;
     const m = members.find((x) => x.member_id === userId);
@@ -237,9 +292,14 @@ export function ModuleDetailPage() {
     return (
       <div className="flex flex-col items-center justify-center gap-4 p-8">
         <p className="text-(--txt-secondary)">Module not found.</p>
-        <Link to={`/${workspace?.slug ?? ""}/projects/${projectId}/modules`} className="text-sm font-medium text-(--brand-default) hover:underline">
-          Back to Modules
-        </Link>
+        {workspace && projectId && (
+          <Link
+            to={`/${workspace.slug}/projects/${projectId}/modules`}
+            className="text-sm font-medium text-(--brand-default) hover:underline"
+          >
+            Back to Modules
+          </Link>
+        )}
       </div>
     );
   }
@@ -248,11 +308,16 @@ export function ModuleDetailPage() {
   const displayId = (issue: IssueApiResponse) =>
     `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`;
 
-  const issuesByState = states.reduce<Record<string, IssueApiResponse[]>>((acc, s) => {
-    acc[s.id] = issues.filter((i) => (i.state_id ?? "") === s.id);
-    return acc;
-  }, {});
-  const ungrouped = issues.filter((i) => !i.state_id || !states.some((s) => s.id === i.state_id));
+  const issuesByState = states.reduce<Record<string, IssueApiResponse[]>>(
+    (acc, s) => {
+      acc[s.id] = issues.filter((i) => (i.state_id ?? "") === s.id);
+      return acc;
+    },
+    {},
+  );
+  const ungrouped = issues.filter(
+    (i) => !i.state_id || !states.some((s) => s.id === i.state_id),
+  );
   if (ungrouped.length > 0) {
     issuesByState[""] = ungrouped;
   }
@@ -264,19 +329,28 @@ export function ModuleDetailPage() {
         <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-(--border-subtle) bg-(--bg-surface-1) px-6 py-16">
           <IconModule />
           <div className="text-center">
-            <h2 className="text-lg font-semibold text-(--txt-primary)">No work items in the module</h2>
+            <h2 className="text-lg font-semibold text-(--txt-primary)">
+              No work items in the module
+            </h2>
             <p className="mt-1 text-sm text-(--txt-secondary)">
-              Create or add work items which you want to accomplish as part of this module.
+              Create or add work items which you want to accomplish as part of
+              this module.
             </p>
           </div>
           <div className="flex flex-wrap items-center justify-center gap-3">
-            <Button size="sm" className="gap-1.5" onClick={() => setSearchParams({ create: "1" })}>
+            <Button
+              size="sm"
+              className="gap-1.5"
+              onClick={() => setSearchParams({ create: "1" })}
+            >
               <IconPlus />
               Create new work items
             </Button>
-            <Button size="sm" variant="secondary" className="gap-1.5" asChild>
-              <Link to={`${baseUrl}/issues`}>Add an existing work item</Link>
-            </Button>
+            <Link to={`${baseUrl}/issues`}>
+              <Button size="sm" variant="secondary" className="gap-1.5">
+                Add an existing work item
+              </Button>
+            </Link>
           </div>
         </div>
       )}
@@ -288,12 +362,20 @@ export function ModuleDetailPage() {
             const stateIssues = issuesByState[state.id] ?? [];
             if (stateIssues.length === 0) return null;
             return (
-              <section key={state.id} className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) overflow-hidden">
+              <section
+                key={state.id}
+                className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) overflow-hidden"
+              >
                 <div className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--bg-layer-2) px-4 py-2">
-                  <span className="flex size-4 shrink-0 items-center justify-center rounded border border-(--border-subtle) border-dashed text-(--txt-icon-tertiary)" aria-hidden>
+                  <span
+                    className="flex size-4 shrink-0 items-center justify-center rounded border border-(--border-subtle) border-dashed text-(--txt-icon-tertiary)"
+                    aria-hidden
+                  >
                     <span className="size-2 rounded-full border border-current border-dashed" />
                   </span>
-                  <span className="text-sm font-medium text-(--txt-primary)">{state.name} {stateIssues.length}</span>
+                  <span className="text-sm font-medium text-(--txt-primary)">
+                    {state.name} {stateIssues.length}
+                  </span>
                 </div>
                 <ul className="divide-y divide-(--border-subtle)">
                   {stateIssues.map((issue) => {
@@ -307,27 +389,61 @@ export function ModuleDetailPage() {
                           className="flex min-h-12 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
                         >
                           <span className="min-w-0 flex-1 truncate text-sm">
-                            <span className="font-medium text-(--txt-accent-primary)">{displayId(issue)}</span>
-                            <span className="ml-2 text-(--txt-primary)">{issue.name}</span>
+                            <span className="font-medium text-(--txt-accent-primary)">
+                              {displayId(issue)}
+                            </span>
+                            <span className="ml-2 text-(--txt-primary)">
+                              {issue.name}
+                            </span>
                           </span>
                           <div className="flex shrink-0 items-center gap-2 text-(--txt-icon-tertiary)">
-                            <Badge variant="neutral" className="text-xs font-medium">
+                            <Badge
+                              variant="neutral"
+                              className="text-xs font-medium"
+                            >
                               {getStateName(issue.state_id ?? undefined)}
                             </Badge>
-                            <Badge variant={priorityVariant[(issue.priority as Priority) ?? "none"]} className="!px-1.5 !py-0 text-[10px]">
+                            <Badge
+                              variant={
+                                priorityVariant[
+                                  (issue.priority as Priority) ?? "none"
+                                ]
+                              }
+                              className="!px-1.5 !py-0 text-[10px]"
+                            >
                               {issue.priority ?? "—"}
                             </Badge>
-                            <span title={formatDate(issue.target_date ?? undefined)} className="flex size-6 items-center justify-center">
+                            <span
+                              title={formatDate(issue.target_date ?? undefined)}
+                              className="flex size-6 items-center justify-center"
+                            >
                               <IconCalendar />
                             </span>
-                            <span title={assignee?.name ?? "Unassigned"} className="flex size-6 items-center justify-center">
+                            <span
+                              title={assignee?.name ?? "Unassigned"}
+                              className="flex size-6 items-center justify-center"
+                            >
                               {assignee ? (
-                                <Avatar name={assignee.name} src={getImageUrl(assignee.avatarUrl) ?? undefined} size="sm" className="h-6 w-6 text-[10px]" />
+                                <Avatar
+                                  name={assignee.name}
+                                  src={
+                                    getImageUrl(assignee.avatarUrl) ?? undefined
+                                  }
+                                  size="sm"
+                                  className="h-6 w-6 text-[10px]"
+                                />
                               ) : (
                                 <IconUser />
                               )}
                             </span>
-                            <span title={labelNames.length ? labelNames.join(", ") : "Labels"} className="flex size-6 items-center justify-center">
+                            <span
+                              title={
+                                labelNames.length
+                                  ? labelNames.join(", ")
+                                  : "Labels"
+                              }
+                              className="flex size-6 items-center justify-center"
+                            >
                               <IconTag />
                             </span>
                             <button
@@ -353,7 +469,9 @@ export function ModuleDetailPage() {
           {(issuesByState[""]?.length ?? 0) > 0 && (
             <section className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) overflow-hidden">
               <div className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--bg-layer-2) px-4 py-2">
-                <span className="text-sm font-medium text-(--txt-primary)">No state {issuesByState[""].length}</span>
+                <span className="text-sm font-medium text-(--txt-primary)">
+                  No state {issuesByState[""].length}
+                </span>
               </div>
               <ul className="divide-y divide-(--border-subtle)">
                 {issuesByState[""].map((issue) => {
@@ -366,16 +484,33 @@ export function ModuleDetailPage() {
                         className="flex min-h-12 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
                       >
                         <span className="min-w-0 flex-1 truncate text-sm">
-                          <span className="font-medium text-(--txt-accent-primary)">{displayId(issue)}</span>
-                          <span className="ml-2 text-(--txt-primary)">{issue.name}</span>
+                          <span className="font-medium text-(--txt-accent-primary)">
+                            {displayId(issue)}
+                          </span>
+                          <span className="ml-2 text-(--txt-primary)">
+                            {issue.name}
+                          </span>
                         </span>
                         <div className="flex shrink-0 items-center gap-2">
                           {assignee ? (
-                            <Avatar name={assignee.name} src={getImageUrl(assignee.avatarUrl) ?? undefined} size="sm" className="h-6 w-6 text-[10px]" />
+                            <Avatar
+                              name={assignee.name}
+                              src={getImageUrl(assignee.avatarUrl) ?? undefined}
+                              size="sm"
+                              className="h-6 w-6 text-[10px]"
+                            />
                           ) : (
                             <IconUser />
                           )}
-                          <button type="button" className="flex size-6 items-center justify-center rounded hover:bg-(--bg-layer-1-hover)" aria-label="More options" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+                          <button
+                            type="button"
+                            className="flex size-6 items-center justify-center rounded hover:bg-(--bg-layer-1-hover)"
+                            aria-label="More options"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                          >
                             <IconMoreVertical />
                           </button>
                         </div>
@@ -391,13 +526,19 @@ export function ModuleDetailPage() {
 
       {issues.length > 0 && (
         <div className="flex flex-wrap items-center justify-center gap-3 border-t border-(--border-subtle) pt-6">
-          <Button size="sm" className="gap-1.5" onClick={() => setSearchParams({ create: "1" })}>
+          <Button
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setSearchParams({ create: "1" })}
+          >
             <IconPlus />
             Create new work items
           </Button>
-          <Button size="sm" variant="secondary" className="gap-1.5" asChild>
-            <Link to={`${baseUrl}/issues`}>Add an existing work item</Link>
-          </Button>
+          <Link to={`${baseUrl}/issues`}>
+            <Button size="sm" variant="secondary" className="gap-1.5">
+              Add an existing work item
+            </Button>
+          </Link>
         </div>
       )}
 

--- a/ui/src/pages/ModuleDetailPage.tsx
+++ b/ui/src/pages/ModuleDetailPage.tsx
@@ -150,7 +150,7 @@ export function ModuleDetailPage() {
 
   useEffect(() => {
     if (createParam && projectId) {
-      setCreateOpen(true);
+      queueMicrotask(() => setCreateOpen(true));
     }
   }, [createParam, projectId]);
 
@@ -174,11 +174,11 @@ export function ModuleDetailPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !moduleId) {
-      setLoading(false);
+      queueMicrotask(() => setLoading(false));
       return;
     }
     let cancelled = false;
-    setLoading(true);
+    queueMicrotask(() => setLoading(true));
     Promise.all([
       workspaceService.getBySlug(workspaceSlug),
       projectService.get(workspaceSlug, projectId),
@@ -409,7 +409,7 @@ export function ModuleDetailPage() {
                                   (issue.priority as Priority) ?? "none"
                                 ]
                               }
-                              className="!px-1.5 !py-0 text-[10px]"
+                              className="px-1.5! py-0! text-[10px]"
                             >
                               {issue.priority ?? "—"}
                             </Badge>

--- a/ui/src/pages/ModuleDetailPage.tsx
+++ b/ui/src/pages/ModuleDetailPage.tsx
@@ -1,0 +1,416 @@
+import { useEffect, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Avatar, Badge, Button } from "../components/ui";
+import { CreateWorkItemModal } from "../components/CreateWorkItemModal";
+import { workspaceService } from "../services/workspaceService";
+import { projectService } from "../services/projectService";
+import { moduleService } from "../services/moduleService";
+import { issueService } from "../services/issueService";
+import { stateService } from "../services/stateService";
+import { labelService } from "../services/labelService";
+import { workspaceService as wsMembers } from "../services/workspaceService";
+import type {
+  WorkspaceApiResponse,
+  ProjectApiResponse,
+  ModuleApiResponse,
+  IssueApiResponse,
+  StateApiResponse,
+  LabelApiResponse,
+  WorkspaceMemberApiResponse,
+} from "../api/types";
+import type { Priority } from "../types";
+import { getImageUrl } from "../lib/utils";
+
+const priorityVariant: Record<
+  Priority,
+  "danger" | "warning" | "default" | "neutral"
+> = {
+  urgent: "danger",
+  high: "danger",
+  medium: "warning",
+  low: "default",
+  none: "neutral",
+};
+
+const IconCalendar = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+  </svg>
+);
+const IconUser = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+const IconTag = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path d="M12 2H2v10l9.29 9.29c.94.94 2.48.94 3.42 0l6.58-6.58c.94-.94.94-2.48 0-3.42L12 2Z" />
+  </svg>
+);
+const IconMoreVertical = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+    <circle cx="12" cy="5" r="1.5" />
+    <circle cx="12" cy="12" r="1.5" />
+    <circle cx="12" cy="19" r="1.5" />
+  </svg>
+);
+const IconPlus = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path d="M5 12h14" />
+    <path d="M12 5v14" />
+  </svg>
+);
+const IconModule = () => (
+  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-(--txt-icon-tertiary)" aria-hidden>
+    <rect width="8" height="8" x="3" y="3" rx="1" />
+    <rect width="8" height="8" x="13" y="3" rx="1" />
+    <rect width="8" height="8" x="3" y="13" rx="1" />
+    <rect width="8" height="8" x="13" y="13" rx="1" />
+  </svg>
+);
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  const day = d.getDate();
+  const month = d.toLocaleString("en-US", { month: "short" });
+  return `${day} ${month}`;
+}
+
+export function ModuleDetailPage() {
+  const { workspaceSlug, projectId, moduleId } = useParams<{
+    workspaceSlug: string;
+    projectId: string;
+    moduleId: string;
+  }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
+  const [project, setProject] = useState<ProjectApiResponse | null>(null);
+  const [module, setModule] = useState<ModuleApiResponse | null>(null);
+  const [issues, setIssues] = useState<IssueApiResponse[]>([]);
+  const [states, setStates] = useState<StateApiResponse[]>([]);
+  const [labels, setLabels] = useState<LabelApiResponse[]>([]);
+  const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
+  const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const createParam = searchParams.get("create") === "1";
+
+  useEffect(() => {
+    if (createParam && projectId) {
+      setCreateOpen(true);
+    }
+  }, [createParam, projectId]);
+
+  const handleCloseCreate = () => {
+    setCreateOpen(false);
+    setCreateError(null);
+    searchParams.delete("create");
+    setSearchParams(searchParams, { replace: true });
+  };
+
+  const refetchIssues = () => {
+    if (!workspaceSlug || !projectId) return;
+    issueService
+      .list(workspaceSlug, projectId, { limit: 1000 })
+      .then((list) => {
+        if (!moduleId) return;
+        setIssues((list ?? []).filter((i) => i.module_ids?.includes(moduleId)));
+      })
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    if (!workspaceSlug || !projectId || !moduleId) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([
+      workspaceService.getBySlug(workspaceSlug),
+      projectService.get(workspaceSlug, projectId),
+      moduleService.get(workspaceSlug, projectId, moduleId),
+      issueService.list(workspaceSlug, projectId, { limit: 1000 }),
+      stateService.list(workspaceSlug, projectId),
+      labelService.list(workspaceSlug, projectId),
+      wsMembers.listMembers(workspaceSlug),
+      projectService.list(workspaceSlug),
+    ])
+      .then(([w, p, mod, iss, st, lab, mem, proj]) => {
+        if (cancelled) return;
+        setWorkspace(w ?? null);
+        setProject(p ?? null);
+        setModule(mod ?? null);
+        setIssues((iss ?? []).filter((i) => i.module_ids?.includes(moduleId)));
+        setStates(st ?? []);
+        setLabels(lab ?? []);
+        setMembers(mem ?? []);
+        setProjects(proj ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWorkspace(null);
+          setProject(null);
+          setModule(null);
+          setIssues([]);
+          setStates([]);
+          setLabels([]);
+          setMembers([]);
+          setProjects([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId, moduleId]);
+
+  const handleCreateSave = async (data: {
+    title: string;
+    description?: string;
+    projectId: string;
+    stateId?: string;
+    priority?: Priority;
+    assigneeIds?: string[];
+    labelIds?: string[];
+    startDate?: string;
+    dueDate?: string;
+    cycleId?: string | null;
+    moduleId?: string | null;
+    parentId?: string | null;
+  }) => {
+    if (!workspaceSlug || !data.title.trim() || !moduleId) return;
+    setCreateError(null);
+    try {
+      const created = await issueService.create(workspaceSlug, data.projectId, {
+        name: data.title.trim(),
+        description: data.description || undefined,
+        state_id: data.stateId || undefined,
+        priority: data.priority || undefined,
+        assignee_ids: data.assigneeIds?.length ? data.assigneeIds : undefined,
+        label_ids: data.labelIds?.length ? data.labelIds : undefined,
+        start_date: data.startDate || undefined,
+        target_date: data.dueDate || undefined,
+        parent_id: data.parentId || undefined,
+      });
+      if (created?.id) {
+        await moduleService.addIssue(workspaceSlug, data.projectId, moduleId, created.id);
+      }
+      refetchIssues();
+      handleCloseCreate();
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Failed to create work item");
+    }
+  };
+
+  const getStateName = (stateId: string | null | undefined) =>
+    stateId ? (states.find((s) => s.id === stateId)?.name ?? stateId) : "—";
+  const getLabelNames = (labelIds: string[] = []) =>
+    labelIds.map((id) => labels.find((l) => l.id === id)?.name).filter((name): name is string => Boolean(name));
+  const getUser = (userId: string | null) => {
+    if (!userId) return null;
+    const m = members.find((x) => x.member_id === userId);
+    const display = m?.member_display_name?.trim();
+    const emailUser = m?.member_email?.split("@")[0]?.trim();
+    const name = display || emailUser || "Member";
+    const avatarUrl = m?.member_avatar ?? null;
+    return { id: userId, name, avatarUrl };
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
+        Loading…
+      </div>
+    );
+  }
+  if (!workspace || !project || !module) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 p-8">
+        <p className="text-(--txt-secondary)">Module not found.</p>
+        <Link to={`/${workspace?.slug ?? ""}/projects/${projectId}/modules`} className="text-sm font-medium text-(--brand-default) hover:underline">
+          Back to Modules
+        </Link>
+      </div>
+    );
+  }
+
+  const baseUrl = `/${workspace.slug}/projects/${project.id}`;
+  const displayId = (issue: IssueApiResponse) =>
+    `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`;
+
+  const issuesByState = states.reduce<Record<string, IssueApiResponse[]>>((acc, s) => {
+    acc[s.id] = issues.filter((i) => (i.state_id ?? "") === s.id);
+    return acc;
+  }, {});
+  const ungrouped = issues.filter((i) => !i.state_id || !states.some((s) => s.id === i.state_id));
+  if (ungrouped.length > 0) {
+    issuesByState[""] = ungrouped;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Empty state */}
+      {issues.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-(--border-subtle) bg-(--bg-surface-1) px-6 py-16">
+          <IconModule />
+          <div className="text-center">
+            <h2 className="text-lg font-semibold text-(--txt-primary)">No work items in the module</h2>
+            <p className="mt-1 text-sm text-(--txt-secondary)">
+              Create or add work items which you want to accomplish as part of this module.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Button size="sm" className="gap-1.5" onClick={() => setSearchParams({ create: "1" })}>
+              <IconPlus />
+              Create new work items
+            </Button>
+            <Button size="sm" variant="secondary" className="gap-1.5" asChild>
+              <Link to={`${baseUrl}/issues`}>Add an existing work item</Link>
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Work items by state */}
+      {issues.length > 0 && (
+        <div className="space-y-6">
+          {states.map((state) => {
+            const stateIssues = issuesByState[state.id] ?? [];
+            if (stateIssues.length === 0) return null;
+            return (
+              <section key={state.id} className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) overflow-hidden">
+                <div className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--bg-layer-2) px-4 py-2">
+                  <span className="flex size-4 shrink-0 items-center justify-center rounded border border-(--border-subtle) border-dashed text-(--txt-icon-tertiary)" aria-hidden>
+                    <span className="size-2 rounded-full border border-current border-dashed" />
+                  </span>
+                  <span className="text-sm font-medium text-(--txt-primary)">{state.name} {stateIssues.length}</span>
+                </div>
+                <ul className="divide-y divide-(--border-subtle)">
+                  {stateIssues.map((issue) => {
+                    const primaryAssigneeId = issue.assignee_ids?.[0] ?? null;
+                    const assignee = getUser(primaryAssigneeId);
+                    const labelNames = getLabelNames(issue.label_ids ?? []);
+                    return (
+                      <li key={issue.id}>
+                        <Link
+                          to={`${baseUrl}/issues/${issue.id}`}
+                          className="flex min-h-12 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
+                        >
+                          <span className="min-w-0 flex-1 truncate text-sm">
+                            <span className="font-medium text-(--txt-accent-primary)">{displayId(issue)}</span>
+                            <span className="ml-2 text-(--txt-primary)">{issue.name}</span>
+                          </span>
+                          <div className="flex shrink-0 items-center gap-2 text-(--txt-icon-tertiary)">
+                            <Badge variant="neutral" className="text-xs font-medium">
+                              {getStateName(issue.state_id ?? undefined)}
+                            </Badge>
+                            <Badge variant={priorityVariant[(issue.priority as Priority) ?? "none"]} className="!px-1.5 !py-0 text-[10px]">
+                              {issue.priority ?? "—"}
+                            </Badge>
+                            <span title={formatDate(issue.target_date ?? undefined)} className="flex size-6 items-center justify-center">
+                              <IconCalendar />
+                            </span>
+                            <span title={assignee?.name ?? "Unassigned"} className="flex size-6 items-center justify-center">
+                              {assignee ? (
+                                <Avatar name={assignee.name} src={getImageUrl(assignee.avatarUrl) ?? undefined} size="sm" className="h-6 w-6 text-[10px]" />
+                              ) : (
+                                <IconUser />
+                              )}
+                            </span>
+                            <span title={labelNames.length ? labelNames.join(", ") : "Labels"} className="flex size-6 items-center justify-center">
+                              <IconTag />
+                            </span>
+                            <button
+                              type="button"
+                              className="flex size-6 items-center justify-center rounded hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
+                              aria-label="More options"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                            >
+                              <IconMoreVertical />
+                            </button>
+                          </div>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+          {(issuesByState[""]?.length ?? 0) > 0 && (
+            <section className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) overflow-hidden">
+              <div className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--bg-layer-2) px-4 py-2">
+                <span className="text-sm font-medium text-(--txt-primary)">No state {issuesByState[""].length}</span>
+              </div>
+              <ul className="divide-y divide-(--border-subtle)">
+                {issuesByState[""].map((issue) => {
+                  const primaryAssigneeId = issue.assignee_ids?.[0] ?? null;
+                  const assignee = getUser(primaryAssigneeId);
+                  return (
+                    <li key={issue.id}>
+                      <Link
+                        to={`${baseUrl}/issues/${issue.id}`}
+                        className="flex min-h-12 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
+                      >
+                        <span className="min-w-0 flex-1 truncate text-sm">
+                          <span className="font-medium text-(--txt-accent-primary)">{displayId(issue)}</span>
+                          <span className="ml-2 text-(--txt-primary)">{issue.name}</span>
+                        </span>
+                        <div className="flex shrink-0 items-center gap-2">
+                          {assignee ? (
+                            <Avatar name={assignee.name} src={getImageUrl(assignee.avatarUrl) ?? undefined} size="sm" className="h-6 w-6 text-[10px]" />
+                          ) : (
+                            <IconUser />
+                          )}
+                          <button type="button" className="flex size-6 items-center justify-center rounded hover:bg-(--bg-layer-1-hover)" aria-label="More options" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+                            <IconMoreVertical />
+                          </button>
+                        </div>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
+
+      {issues.length > 0 && (
+        <div className="flex flex-wrap items-center justify-center gap-3 border-t border-(--border-subtle) pt-6">
+          <Button size="sm" className="gap-1.5" onClick={() => setSearchParams({ create: "1" })}>
+            <IconPlus />
+            Create new work items
+          </Button>
+          <Button size="sm" variant="secondary" className="gap-1.5" asChild>
+            <Link to={`${baseUrl}/issues`}>Add an existing work item</Link>
+          </Button>
+        </div>
+      )}
+
+      <CreateWorkItemModal
+        open={createOpen}
+        onClose={handleCloseCreate}
+        workspaceSlug={workspace.slug}
+        projects={projects}
+        defaultProjectId={project.id}
+        defaultModuleId={moduleId}
+        onSave={handleCreateSave}
+        createError={createError}
+      />
+    </div>
+  );
+}

--- a/ui/src/pages/ModuleDetailPage.tsx
+++ b/ui/src/pages/ModuleDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Avatar, Badge, Button } from "../components/ui";
 import { CreateWorkItemModal } from "../components/CreateWorkItemModal";
+import { AddExistingWorkItemModal } from "../components/AddExistingWorkItemModal";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
 import { moduleService } from "../services/moduleService";
@@ -19,6 +20,7 @@ import type {
 } from "../api/types";
 import type { Priority } from "../types";
 import { getImageUrl } from "../lib/utils";
+import { slugify } from "../lib/slug";
 
 const priorityVariant: Record<
   Priority,
@@ -137,6 +139,7 @@ export function ModuleDetailPage() {
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [module, setModule] = useState<ModuleApiResponse | null>(null);
+  const [resolvedModuleId, setResolvedModuleId] = useState<string | null>(null);
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [labels, setLabels] = useState<LabelApiResponse[]>([]);
@@ -144,6 +147,7 @@ export function ModuleDetailPage() {
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
+  const [addExistingOpen, setAddExistingOpen] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
   const createParam = searchParams.get("create") === "1";
@@ -162,12 +166,13 @@ export function ModuleDetailPage() {
   };
 
   const refetchIssues = () => {
-    if (!workspaceSlug || !projectId) return;
+    if (!workspaceSlug || !projectId || !resolvedModuleId) return;
     issueService
       .list(workspaceSlug, projectId, { limit: 1000 })
       .then((list) => {
-        if (!moduleId) return;
-        setIssues((list ?? []).filter((i) => i.module_ids?.includes(moduleId)));
+        setIssues(
+          (list ?? []).filter((i) => i.module_ids?.includes(resolvedModuleId)),
+        );
       })
       .catch(() => {});
   };
@@ -182,19 +187,27 @@ export function ModuleDetailPage() {
     Promise.all([
       workspaceService.getBySlug(workspaceSlug),
       projectService.get(workspaceSlug, projectId),
-      moduleService.get(workspaceSlug, projectId, moduleId),
+      moduleService.list(workspaceSlug, projectId),
       issueService.list(workspaceSlug, projectId, { limit: 1000 }),
       stateService.list(workspaceSlug, projectId),
       labelService.list(workspaceSlug, projectId),
       workspaceService.listMembers(workspaceSlug),
       projectService.list(workspaceSlug),
     ])
-      .then(([w, p, mod, iss, st, lab, mem, proj]) => {
+      .then(([w, p, mods, iss, st, lab, mem, proj]) => {
         if (cancelled) return;
         setWorkspace(w ?? null);
         setProject(p ?? null);
-        setModule(mod ?? null);
-        setIssues((iss ?? []).filter((i) => i.module_ids?.includes(moduleId)));
+        const key = moduleId.trim().toLowerCase();
+        const found =
+          (mods ?? []).find((x) => x.id === moduleId) ??
+          (mods ?? []).find((x) => slugify(x.name) === key) ??
+          null;
+        setModule(found);
+        setResolvedModuleId(found?.id ?? null);
+        setIssues(
+          (iss ?? []).filter((i) => i.module_ids?.includes(found?.id ?? "")),
+        );
         setStates(st ?? []);
         setLabels(lab ?? []);
         setMembers(mem ?? []);
@@ -205,6 +218,7 @@ export function ModuleDetailPage() {
           setWorkspace(null);
           setProject(null);
           setModule(null);
+          setResolvedModuleId(null);
           setIssues([]);
           setStates([]);
           setLabels([]);
@@ -234,7 +248,7 @@ export function ModuleDetailPage() {
     moduleId?: string | null;
     parentId?: string | null;
   }) => {
-    if (!workspaceSlug || !data.title.trim() || !moduleId) return;
+    if (!workspaceSlug || !data.title.trim() || !resolvedModuleId) return;
     setCreateError(null);
     try {
       const created = await issueService.create(workspaceSlug, data.projectId, {
@@ -252,7 +266,7 @@ export function ModuleDetailPage() {
         await moduleService.addIssue(
           workspaceSlug,
           data.projectId,
-          moduleId,
+          resolvedModuleId,
           created.id,
         );
       }
@@ -346,11 +360,14 @@ export function ModuleDetailPage() {
               <IconPlus />
               Create new work items
             </Button>
-            <Link to={`${baseUrl}/issues`}>
-              <Button size="sm" variant="secondary" className="gap-1.5">
-                Add an existing work item
-              </Button>
-            </Link>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="gap-1.5"
+              onClick={() => setAddExistingOpen(true)}
+            >
+              Add an existing work item
+            </Button>
           </div>
         </div>
       )}
@@ -534,21 +551,33 @@ export function ModuleDetailPage() {
             <IconPlus />
             Create new work items
           </Button>
-          <Link to={`${baseUrl}/issues`}>
-            <Button size="sm" variant="secondary" className="gap-1.5">
-              Add an existing work item
-            </Button>
-          </Link>
+          <Button
+            size="sm"
+            variant="secondary"
+            className="gap-1.5"
+            onClick={() => setAddExistingOpen(true)}
+          >
+            Add an existing work item
+          </Button>
         </div>
       )}
 
+      <AddExistingWorkItemModal
+        open={addExistingOpen}
+        onClose={() => setAddExistingOpen(false)}
+        workspaceSlug={workspace.slug}
+        projectId={project.id}
+        moduleId={resolvedModuleId ?? ""}
+        projectIdentifier={project.identifier ?? project.id.slice(0, 8)}
+        onAdded={refetchIssues}
+      />
       <CreateWorkItemModal
         open={createOpen}
         onClose={handleCloseCreate}
         workspaceSlug={workspace.slug}
         projects={projects}
         defaultProjectId={project.id}
-        defaultModuleId={moduleId}
+        defaultModuleId={resolvedModuleId}
         onSave={handleCreateSave}
         createError={createError}
       />

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -125,7 +125,7 @@ function ModuleProgressCircle({ progress }: { progress: number }) {
           strokeLinecap="round"
         />
       </svg>
-      <span className="absolute text-[10px] font-medium text-[var(--txt-secondary)]">
+      <span className="absolute text-[10px] font-medium text-(--txt-secondary)">
         {progress}%
       </span>
     </div>
@@ -145,10 +145,10 @@ export function ModulesPage() {
 
   const searchQuery = (searchParams.get("search") ?? "").trim().toLowerCase();
   const statusFilter = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
-  const startDateValue =
-    searchParams.get(MODULE_FILTER_PARAM.start_date)?.trim() ?? "";
-  const dueDateValue =
-    searchParams.get(MODULE_FILTER_PARAM.due_date)?.trim() ?? "";
+  const startDateList = parseList(
+    searchParams.get(MODULE_FILTER_PARAM.start_date),
+  );
+  const dueDateList = parseList(searchParams.get(MODULE_FILTER_PARAM.due_date));
   const startAfter =
     searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ?? null;
   const startBefore =
@@ -174,48 +174,41 @@ export function ModulesPage() {
     const toDate = (iso: string) => new Date(iso.slice(0, 10));
     const inRange = (value: Date, min: Date, max: Date) =>
       value.getTime() >= min.getTime() && value.getTime() <= max.getTime();
-    if (startDateValue !== "") {
+    const matchStartPreset = (d: Date, preset: string) => {
+      if (preset === "1_week") return inRange(d, today, addDays(today, 7));
+      if (preset === "2_weeks") return inRange(d, today, addDays(today, 14));
+      if (preset === "1_month") return inRange(d, today, addDays(today, 30));
+      if (preset === "2_months") return inRange(d, today, addDays(today, 60));
+      return false;
+    };
+    if (startDateList.length > 0) {
+      const hasCustomStart = startDateList.includes("custom");
       list = list.filter((m) => {
         const sd = m.start_date?.trim();
         if (!sd) return false;
         const d = toDate(sd);
-        if (
-          startDateValue === "custom" &&
-          startAfter !== null &&
-          startBefore !== null
-        )
-          return inRange(d, toDate(startAfter), toDate(startBefore));
-        if (startDateValue === "1_week")
-          return inRange(d, today, addDays(today, 7));
-        if (startDateValue === "2_weeks")
-          return inRange(d, today, addDays(today, 14));
-        if (startDateValue === "1_month")
-          return inRange(d, today, addDays(today, 30));
-        if (startDateValue === "2_months")
-          return inRange(d, today, addDays(today, 60));
-        return false;
+        if (hasCustomStart)
+          return (
+            startAfter !== null &&
+            startBefore !== null &&
+            inRange(d, toDate(startAfter), toDate(startBefore))
+          );
+        return startDateList.some((p) => matchStartPreset(d, p));
       });
     }
-    if (dueDateValue !== "") {
+    if (dueDateList.length > 0) {
+      const hasCustomDue = dueDateList.includes("custom");
       list = list.filter((m) => {
         const td = m.target_date?.trim();
         if (!td) return false;
         const d = toDate(td);
-        if (
-          dueDateValue === "custom" &&
-          dueAfter !== null &&
-          dueBefore !== null
-        )
-          return inRange(d, toDate(dueAfter), toDate(dueBefore));
-        if (dueDateValue === "1_week")
-          return inRange(d, today, addDays(today, 7));
-        if (dueDateValue === "2_weeks")
-          return inRange(d, today, addDays(today, 14));
-        if (dueDateValue === "1_month")
-          return inRange(d, today, addDays(today, 30));
-        if (dueDateValue === "2_months")
-          return inRange(d, today, addDays(today, 60));
-        return false;
+        if (hasCustomDue)
+          return (
+            dueAfter !== null &&
+            dueBefore !== null &&
+            inRange(d, toDate(dueAfter), toDate(dueBefore))
+          );
+        return dueDateList.some((p) => matchStartPreset(d, p));
       });
     }
     return list;
@@ -223,8 +216,8 @@ export function ModulesPage() {
     modules,
     searchQuery,
     statusFilter,
-    startDateValue,
-    dueDateValue,
+    startDateList,
+    dueDateList,
     startAfter,
     startBefore,
     dueAfter,
@@ -320,14 +313,14 @@ export function ModulesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
@@ -344,24 +337,24 @@ export function ModulesPage() {
           <Link
             key={mod.id}
             to={`${baseUrl}/modules/${mod.id}`}
-            className="flex items-center gap-4 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+            className="flex items-center gap-4 px-4 py-3 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
           >
             <ModuleProgressCircle progress={progress} />
-            <p className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
+            <p className="min-w-0 flex-1 font-medium text-(--txt-primary)">
               {mod.name}
             </p>
             {dateRange !== null && (
-              <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+              <span className="shrink-0 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-[13px] text-(--txt-secondary)">
                 {dateRange}
               </span>
             )}
-            <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+            <span className="shrink-0 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-[13px] text-(--txt-secondary)">
               {mod.status}
             </span>
             <Avatar name={workspace.name} size="sm" className="ml-1" />
             <button
               type="button"
-              className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              className="flex size-8 shrink-0 items-center justify-center rounded text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
               aria-label="Favorite"
               onClick={(e) => {
                 e.preventDefault();
@@ -372,7 +365,7 @@ export function ModulesPage() {
             </button>
             <button
               type="button"
-              className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              className="flex size-8 shrink-0 items-center justify-center rounded text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
               aria-label="More options"
               onClick={(e) => {
                 e.preventDefault();
@@ -396,21 +389,21 @@ export function ModulesPage() {
           <Link
             key={mod.id}
             to={`${baseUrl}/modules/${mod.id}`}
-            className="flex flex-col gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+            className="flex flex-col gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
           >
             <div className="flex items-center justify-between gap-2">
-              <p className="min-w-0 flex-1 truncate font-medium text-[var(--txt-primary)]">
+              <p className="min-w-0 flex-1 truncate font-medium text-(--txt-primary)">
                 {mod.name}
               </p>
               <ModuleProgressCircle progress={progress} />
             </div>
             <div className="mt-1 flex flex-wrap items-center gap-2 text-[13px]">
               {dateRange !== null && (
-                <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[var(--txt-secondary)]">
+                <span className="rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-(--txt-secondary)">
                   {dateRange}
                 </span>
               )}
-              <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[var(--txt-secondary)]">
+              <span className="rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-(--txt-secondary)">
                 {mod.status}
               </span>
             </div>
@@ -434,23 +427,23 @@ export function ModulesPage() {
       });
 
     return (
-      <div className="space-y-3 border-l border-[var(--border-subtle)] pl-4">
-        {withDates.map(({ mod, start, end }) => {
+      <div className="space-y-3 border-l border-(--border-subtle) pl-4">
+        {withDates.map(({ mod }) => {
           const progress = getProgress(mod);
           const dateRange = formatModuleDateRange(mod);
           return (
             <div key={mod.id} className="relative pl-4">
-              <div className="absolute left-0 top-3 h-2 w-2 -translate-x-1/2 rounded-full bg-[var(--brand-default)]" />
+              <div className="absolute left-0 top-3 h-2 w-2 -translate-x-1/2 rounded-full bg-(--brand-default)" />
               <Link
                 to={`${baseUrl}/modules/${mod.id}`}
-                className="flex items-center gap-3 rounded-md px-3 py-2 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex items-center gap-3 rounded-md px-3 py-2 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
               >
                 <ModuleProgressCircle progress={progress} />
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
+                  <p className="truncate text-sm font-medium text-(--txt-primary)">
                     {mod.name}
                   </p>
-                  <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-xs text-(--txt-secondary)">
                     {dateRange ?? "No dates"}
                   </p>
                 </div>
@@ -464,7 +457,7 @@ export function ModulesPage() {
 
   if (filteredModules.length === 0) {
     return (
-      <p className="py-8 text-center text-sm text-[var(--txt-tertiary)]">
+      <p className="py-8 text-center text-sm text-(--txt-tertiary)">
         {searchQuery ? "No modules match your search." : "No modules yet."}
       </p>
     );

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Avatar } from "../components/ui";
+import { MODULE_FILTER_PARAM } from "../components/workspace-views";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
 import { moduleService } from "../services/moduleService";
@@ -9,6 +10,14 @@ import type {
   ProjectApiResponse,
   ModuleApiResponse,
 } from "../api/types";
+
+function parseList(value: string | null): string[] {
+  if (!value?.trim()) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
 /** Zero-pad a number to 2 digits. */
 function pad2(n: number): string {
@@ -135,10 +144,126 @@ export function ModulesPage() {
   const [loading, setLoading] = useState(true);
 
   const searchQuery = (searchParams.get("search") ?? "").trim().toLowerCase();
-  const filteredModules =
-    searchQuery === ""
-      ? modules
-      : modules.filter((m) => m.name.toLowerCase().includes(searchQuery));
+  const statusFilter = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
+  const startDateValue =
+    searchParams.get(MODULE_FILTER_PARAM.start_date)?.trim() ?? "";
+  const dueDateValue =
+    searchParams.get(MODULE_FILTER_PARAM.due_date)?.trim() ?? "";
+  const startAfter =
+    searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ?? null;
+  const startBefore =
+    searchParams.get(MODULE_FILTER_PARAM.start_before)?.trim() ?? null;
+  const dueAfter =
+    searchParams.get(MODULE_FILTER_PARAM.due_after)?.trim() ?? null;
+  const dueBefore =
+    searchParams.get(MODULE_FILTER_PARAM.due_before)?.trim() ?? null;
+
+  const filteredModules = useMemo(() => {
+    let list = modules;
+    if (searchQuery !== "") {
+      list = list.filter((m) => m.name.toLowerCase().includes(searchQuery));
+    }
+    if (statusFilter.length > 0) {
+      const allowed = new Set(statusFilter.map((s) => s.toLowerCase()));
+      list = list.filter((m) => allowed.has((m.status ?? "").toLowerCase()));
+    }
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const addDays = (d: Date, n: number) =>
+      new Date(d.getTime() + n * 24 * 60 * 60 * 1000);
+    const toDate = (iso: string) => new Date(iso.slice(0, 10));
+    const inRange = (value: Date, min: Date, max: Date) =>
+      value.getTime() >= min.getTime() && value.getTime() <= max.getTime();
+    if (startDateValue !== "") {
+      list = list.filter((m) => {
+        const sd = m.start_date?.trim();
+        if (!sd) return false;
+        const d = toDate(sd);
+        if (
+          startDateValue === "custom" &&
+          startAfter !== null &&
+          startBefore !== null
+        )
+          return inRange(d, toDate(startAfter), toDate(startBefore));
+        if (startDateValue === "1_week")
+          return inRange(d, today, addDays(today, 7));
+        if (startDateValue === "2_weeks")
+          return inRange(d, today, addDays(today, 14));
+        if (startDateValue === "1_month")
+          return inRange(d, today, addDays(today, 30));
+        if (startDateValue === "2_months")
+          return inRange(d, today, addDays(today, 60));
+        return false;
+      });
+    }
+    if (dueDateValue !== "") {
+      list = list.filter((m) => {
+        const td = m.target_date?.trim();
+        if (!td) return false;
+        const d = toDate(td);
+        if (
+          dueDateValue === "custom" &&
+          dueAfter !== null &&
+          dueBefore !== null
+        )
+          return inRange(d, toDate(dueAfter), toDate(dueBefore));
+        if (dueDateValue === "1_week")
+          return inRange(d, today, addDays(today, 7));
+        if (dueDateValue === "2_weeks")
+          return inRange(d, today, addDays(today, 14));
+        if (dueDateValue === "1_month")
+          return inRange(d, today, addDays(today, 30));
+        if (dueDateValue === "2_months")
+          return inRange(d, today, addDays(today, 60));
+        return false;
+      });
+    }
+    return list;
+  }, [
+    modules,
+    searchQuery,
+    statusFilter,
+    startDateValue,
+    dueDateValue,
+    startAfter,
+    startBefore,
+    dueAfter,
+    dueBefore,
+  ]);
+
+  const sortBy = searchParams.get("sort") || "progress";
+  const order = searchParams.get("order") || "asc";
+  const sortedModules = [...filteredModules].sort((a, b) => {
+    const getProgress = (mod: ModuleApiResponse) => {
+      const total = mod.issue_count ?? 0;
+      const done = 0;
+      return total === 0 ? 0 : Math.round((done / total) * 100);
+    };
+    let cmp = 0;
+    switch (sortBy) {
+      case "name":
+        cmp = (a.name ?? "").localeCompare(b.name ?? "");
+        break;
+      case "progress":
+        cmp = getProgress(a) - getProgress(b);
+        break;
+      case "work_items":
+        cmp = (a.issue_count ?? 0) - (b.issue_count ?? 0);
+        break;
+      case "due_date":
+        cmp = (a.target_date ?? "").localeCompare(b.target_date ?? "");
+        break;
+      case "created_date":
+        cmp = (a.created_at ?? "").localeCompare(b.created_at ?? "");
+        break;
+      case "manual":
+        cmp = (a.sort_order ?? 0) - (b.sort_order ?? 0);
+        break;
+      default:
+        cmp = getProgress(a) - getProgress(b);
+    }
+    return order === "desc" ? -cmp : cmp;
+  });
 
   useEffect(() => {
     const handler = () => {
@@ -212,7 +337,7 @@ export function ModulesPage() {
 
   const renderListLayout = () => (
     <div className="space-y-2">
-      {filteredModules.map((mod) => {
+      {sortedModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
         return (
@@ -264,7 +389,7 @@ export function ModulesPage() {
 
   const renderGalleryLayout = () => (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {filteredModules.map((mod) => {
+      {sortedModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
         return (
@@ -296,7 +421,7 @@ export function ModulesPage() {
   );
 
   const renderTimelineLayout = () => {
-    const withDates = filteredModules
+    const withDates = sortedModules
       .map((m) => ({
         mod: m,
         start: m.start_date ? new Date(m.start_date) : null,

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -134,6 +134,24 @@ export function ModulesPage() {
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const searchQuery = (searchParams.get("search") ?? "").trim().toLowerCase();
+  const filteredModules =
+    searchQuery === ""
+      ? modules
+      : modules.filter((m) => m.name.toLowerCase().includes(searchQuery));
+
+  useEffect(() => {
+    const handler = () => {
+      if (!workspaceSlug || !projectId) return;
+      moduleService
+        .list(workspaceSlug, projectId)
+        .then((list) => setModules(list ?? []))
+        .catch(() => {});
+    };
+    window.addEventListener("modules-refresh", handler);
+    return () => window.removeEventListener("modules-refresh", handler);
+  }, [workspaceSlug, projectId]);
+
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
@@ -194,7 +212,7 @@ export function ModulesPage() {
 
   const renderListLayout = () => (
     <div className="space-y-2">
-      {modules.map((mod) => {
+      {filteredModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
         return (
@@ -246,7 +264,7 @@ export function ModulesPage() {
 
   const renderGalleryLayout = () => (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {modules.map((mod) => {
+      {filteredModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
         return (
@@ -278,7 +296,7 @@ export function ModulesPage() {
   );
 
   const renderTimelineLayout = () => {
-    const withDates = modules
+    const withDates = filteredModules
       .map((m) => ({
         mod: m,
         start: m.start_date ? new Date(m.start_date) : null,
@@ -319,10 +337,10 @@ export function ModulesPage() {
     );
   };
 
-  if (modules.length === 0) {
+  if (filteredModules.length === 0) {
     return (
       <p className="py-8 text-center text-sm text-[var(--txt-tertiary)]">
-        No modules yet.
+        {searchQuery ? "No modules match your search." : "No modules yet."}
       </p>
     );
   }

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -320,11 +320,11 @@ export function ModulesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
-      setLoading(false);
+      queueMicrotask(() => setLoading(false));
       return;
     }
     let cancelled = false;
-    setLoading(true);
+    queueMicrotask(() => setLoading(true));
     Promise.all([
       workspaceService.getBySlug(workspaceSlug),
       projectService.get(workspaceSlug, projectId),

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -325,6 +325,9 @@ export function ModulesPage() {
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
   const layout =
     (searchParams.get("layout") as "list" | "gallery" | "timeline") || "list";
+  const [timelineTimeframe, setTimelineTimeframe] = useState<
+    "week" | "month" | "quarter"
+  >("week");
 
   const renderListLayout = () => (
     <div className="space-y-2">
@@ -412,43 +415,265 @@ export function ModulesPage() {
   );
 
   const renderTimelineLayout = () => {
-    const withDates = sortedModules
-      .map((m) => ({
-        mod: m,
-        start: m.start_date ? new Date(m.start_date) : null,
-        end: m.target_date ? new Date(m.target_date) : null,
-      }))
-      .sort((a, b) => {
-        const aTime = a.start?.getTime() ?? a.end?.getTime() ?? 0;
-        const bTime = b.start?.getTime() ?? b.end?.getTime() ?? 0;
-        return aTime - bTime;
-      });
+    const DAY_WIDTH = 28;
+    const ROW_HEIGHT = 40;
+    const LEFT_WIDTH = 220;
+    const now = new Date();
+    const todayStart = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    ).getTime();
+
+    const withDates = sortedModules.map((mod) => {
+      const start = mod.start_date ? new Date(mod.start_date) : null;
+      const end = mod.target_date ? new Date(mod.target_date) : null;
+      const startTime = start?.getTime() ?? end?.getTime() ?? todayStart;
+      const endTime = end?.getTime() ?? start?.getTime() ?? todayStart;
+      const durationDays =
+        start && end
+          ? Math.max(
+              0,
+              Math.ceil(
+                (end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000),
+              ) + 1,
+            )
+          : 0;
+      return { mod, start, end, startTime, endTime, durationDays };
+    });
+
+    const rangeStart = Math.min(
+      ...withDates.map((d) => d.startTime),
+      todayStart - 14 * 24 * 60 * 60 * 1000,
+    );
+    const rangeEnd = Math.max(
+      ...withDates.map((d) => d.endTime),
+      todayStart + 60 * 24 * 60 * 60 * 1000,
+    );
+    const totalDays = Math.ceil(
+      (rangeEnd - rangeStart) / (24 * 60 * 60 * 1000),
+    );
+    const days: Date[] = [];
+    for (let i = 0; i < totalDays; i++) {
+      days.push(new Date(rangeStart + i * 24 * 60 * 60 * 1000));
+    }
+
+    const getDayIndex = (t: number) =>
+      Math.floor((t - rangeStart) / (24 * 60 * 60 * 1000));
+    const weekNum = (d: Date) => {
+      return Math.ceil(
+        (d.getDate() + new Date(d.getFullYear(), d.getMonth(), 1).getDay()) / 7,
+      );
+    };
+
+    const monthGroups: { label: string; startIdx: number; span: number }[] = [];
+    let i = 0;
+    while (i < days.length) {
+      const d = days[i];
+      const label = `${MONTH_ABBR[d.getMonth()]} ${d.getFullYear()}`;
+      const startIdx = i;
+      while (
+        i < days.length &&
+        days[i].getMonth() === d.getMonth() &&
+        days[i].getFullYear() === d.getFullYear()
+      )
+        i++;
+      monthGroups.push({ label, startIdx, span: i - startIdx });
+    }
 
     return (
-      <div className="space-y-3 border-l border-(--border-subtle) pl-4">
-        {withDates.map(({ mod }) => {
-          const progress = getProgress(mod);
-          const dateRange = formatModuleDateRange(mod);
-          return (
-            <div key={mod.id} className="relative pl-4">
-              <div className="absolute left-0 top-3 h-2 w-2 -translate-x-1/2 rounded-full bg-(--brand-default)" />
-              <Link
-                to={`${baseUrl}/modules/${mod.id}`}
-                className="flex items-center gap-3 rounded-md px-3 py-2 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
+      <div className="flex flex-col gap-0">
+        <div className="flex items-center justify-between border-b border-(--border-subtle) bg-(--bg-layer-2) px-4 py-2">
+          <span className="text-sm font-medium text-(--txt-secondary)">
+            {sortedModules.length} Module{sortedModules.length !== 1 ? "s" : ""}
+          </span>
+          <div className="flex items-center gap-1">
+            {(["week", "month", "quarter"] as const).map((tf) => (
+              <button
+                key={tf}
+                type="button"
+                onClick={() => setTimelineTimeframe(tf)}
+                className={`rounded px-2.5 py-1.5 text-sm font-medium capitalize ${
+                  timelineTimeframe === tf
+                    ? "bg-(--brand-200) text-(--brand-default)"
+                    : "text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
+                }`}
               >
-                <ModuleProgressCircle progress={progress} />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-(--txt-primary)">
-                    {mod.name}
-                  </p>
-                  <p className="mt-0.5 text-xs text-(--txt-secondary)">
-                    {dateRange ?? "No dates"}
-                  </p>
-                </div>
-              </Link>
+                {tf}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="rounded px-2.5 py-1.5 text-sm font-medium text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary)"
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              className="flex size-8 items-center justify-center rounded text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
+              aria-label="Full screen"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden
+              >
+                <path d="M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div className="flex overflow-x-auto border border-(--border-subtle) bg-(--bg-surface-1)">
+          <div
+            className="shrink-0 border-r border-(--border-subtle) bg-(--bg-layer-2)"
+            style={{ width: LEFT_WIDTH }}
+          >
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="border-b border-(--border-subtle)">
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-(--txt-secondary)">
+                    Modules
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-(--txt-secondary)">
+                    Duration
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {withDates.map(({ mod, durationDays }) => (
+                  <tr
+                    key={mod.id}
+                    className="border-b border-(--border-subtle) last:border-b-0"
+                  >
+                    <td className="px-3 py-2">
+                      <Link
+                        to={`${baseUrl}/modules/${mod.id}`}
+                        className="flex items-center gap-2 text-sm text-(--txt-primary) no-underline hover:text-(--brand-default)"
+                      >
+                        <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
+                          <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            aria-hidden
+                          >
+                            <circle cx="12" cy="12" r="9" />
+                            <path d="M12 6v6l4 2" />
+                          </svg>
+                        </span>
+                        <span className="min-w-0 truncate">{mod.name}</span>
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2 text-sm text-(--txt-secondary)">
+                      {durationDays > 0 ? `${durationDays} days` : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="min-w-0 flex-1 overflow-x-auto">
+            <div
+              style={{
+                width: totalDays * DAY_WIDTH,
+                minHeight: ROW_HEIGHT * (withDates.length + 3),
+              }}
+            >
+              {/* Month row */}
+              <div
+                className="flex border-b border-(--border-subtle) bg-(--bg-layer-2)"
+                style={{ height: 28 }}
+              >
+                {monthGroups.map((g) => (
+                  <div
+                    key={g.startIdx}
+                    className="shrink-0 border-r border-(--border-subtle) px-1 py-1 text-xs font-medium text-(--txt-secondary)"
+                    style={{ width: g.span * DAY_WIDTH }}
+                  >
+                    {g.label}
+                  </div>
+                ))}
+              </div>
+              {/* Week row */}
+              <div
+                className="flex border-b border-(--border-subtle) bg-(--bg-layer-2)"
+                style={{ height: 24 }}
+              >
+                {days
+                  .filter((_, i) => i % 7 === 0)
+                  .map((d, idx) => (
+                    <div
+                      key={idx}
+                      className="shrink-0 border-r border-(--border-subtle) px-0.5 py-0.5 text-[10px] text-(--txt-tertiary)"
+                      style={{ width: 7 * DAY_WIDTH }}
+                    >
+                      Week {weekNum(d)}
+                    </div>
+                  ))}
+              </div>
+              {/* Days row */}
+              <div
+                className="flex border-b border-(--border-subtle) bg-(--bg-layer-2)"
+                style={{ height: 28 }}
+              >
+                {days.map((d, idx) => {
+                  const isToday = d.getTime() === todayStart;
+                  return (
+                    <div
+                      key={idx}
+                      className={`shrink-0 border-r border-(--border-subtle) px-0.5 py-1 text-center text-[11px] ${
+                        isToday
+                          ? "bg-(--brand-200) font-medium text-(--brand-default)"
+                          : "text-(--txt-secondary)"
+                      }`}
+                      style={{ width: DAY_WIDTH }}
+                    >
+                      {d.getDate()}{" "}
+                      {["Su", "M", "Tu", "W", "Th", "F", "Sa"][d.getDay()]}
+                    </div>
+                  );
+                })}
+              </div>
+              {/* Module bars */}
+              {withDates.map(({ mod, startTime, endTime }) => {
+                const startIdx = Math.max(0, getDayIndex(startTime));
+                const endIdx = Math.min(days.length - 1, getDayIndex(endTime));
+                const left = startIdx * DAY_WIDTH;
+                const width = Math.max(
+                  DAY_WIDTH,
+                  (endIdx - startIdx + 1) * DAY_WIDTH,
+                );
+                return (
+                  <div
+                    key={mod.id}
+                    className="flex items-center border-b border-(--border-subtle) last:border-b-0"
+                    style={{ height: ROW_HEIGHT }}
+                  >
+                    <div
+                      className="relative h-6"
+                      style={{ width: totalDays * DAY_WIDTH }}
+                    >
+                      <Link
+                        to={`${baseUrl}/modules/${mod.id}`}
+                        className="absolute top-1/2 -translate-y-1/2 rounded bg-(--brand-200) px-2 py-1 text-xs font-medium text-(--brand-default) no-underline hover:bg-(--brand-default) hover:text-white"
+                        style={{ left, width, minWidth: 40 }}
+                      >
+                        <span className="block truncate">{mod.name}</span>
+                      </Link>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
-          );
-        })}
+          </div>
+        </div>
       </div>
     );
   };

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { Avatar } from "../components/ui";
-import { MODULE_FILTER_PARAM } from "../components/workspace-views";
+import { useModulesFilter } from "../contexts/ModulesFilterContext";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
 import { moduleService } from "../services/moduleService";
@@ -13,14 +13,7 @@ import type {
   WorkspaceMemberApiResponse,
 } from "../api/types";
 import { getImageUrl } from "../lib/utils";
-
-function parseList(value: string | null): string[] {
-  if (!value?.trim()) return [];
-  return value
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
+import { slugify } from "../lib/slug";
 
 /** Zero-pad a number to 2 digits. */
 function pad2(n: number): string {
@@ -169,7 +162,7 @@ export function ModulesPage() {
     workspaceSlug: string;
     projectId: string;
   }>();
-  const [searchParams] = useSearchParams();
+  const filter = useModulesFilter();
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);
@@ -183,22 +176,15 @@ export function ModulesPage() {
     projectId,
   );
 
-  const searchQuery = (searchParams.get("search") ?? "").trim().toLowerCase();
-  const favoritesFilter =
-    searchParams.get(MODULE_FILTER_PARAM.favorites) === "1";
-  const statusFilter = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
-  const startDateList = parseList(
-    searchParams.get(MODULE_FILTER_PARAM.start_date),
-  );
-  const dueDateList = parseList(searchParams.get(MODULE_FILTER_PARAM.due_date));
-  const startAfter =
-    searchParams.get(MODULE_FILTER_PARAM.start_after)?.trim() ?? null;
-  const startBefore =
-    searchParams.get(MODULE_FILTER_PARAM.start_before)?.trim() ?? null;
-  const dueAfter =
-    searchParams.get(MODULE_FILTER_PARAM.due_after)?.trim() ?? null;
-  const dueBefore =
-    searchParams.get(MODULE_FILTER_PARAM.due_before)?.trim() ?? null;
+  const searchQuery = (filter.search ?? "").trim().toLowerCase();
+  const favoritesFilter = filter.favorites;
+  const statusFilter = filter.status;
+  const startDateList = filter.startDateList;
+  const dueDateList = filter.dueDateList;
+  const startAfter = filter.startAfter;
+  const startBefore = filter.startBefore;
+  const dueAfter = filter.dueAfter;
+  const dueBefore = filter.dueBefore;
 
   const filteredModules = useMemo(() => {
     let list = modules;
@@ -272,8 +258,8 @@ export function ModulesPage() {
     dueBefore,
   ]);
 
-  const sortBy = searchParams.get("sort") || "progress";
-  const order = searchParams.get("order") || "asc";
+  const sortBy = filter.sort || "progress";
+  const order = filter.order || "asc";
   const sortedModules = [...filteredModules].sort((a, b) => {
     const getProgress = (mod: ModuleApiResponse) => {
       const total = mod.issue_count ?? 0;
@@ -373,8 +359,10 @@ export function ModulesPage() {
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
-  const layout =
-    (searchParams.get("layout") as "list" | "gallery" | "timeline") || "list";
+
+  const modulePath = (m: ModuleApiResponse) =>
+    `${baseUrl}/modules/${slugify(m.name)}`;
+  const layout = filter.layout;
 
   const getLeadMember = (leadId: string | null | undefined) => {
     if (!leadId) return null;
@@ -399,7 +387,7 @@ export function ModulesPage() {
             className="flex items-center gap-3 border-b border-(--border-subtle) last:border-b-0 px-4 py-3 hover:bg-(--bg-layer-1-hover)"
           >
             <Link
-              to={`${baseUrl}/modules/${mod.id}`}
+              to={modulePath(mod)}
               className="flex min-w-0 flex-1 items-center gap-3 no-underline"
             >
               <ModuleProgressCircle progress={progress} />
@@ -492,7 +480,7 @@ export function ModulesPage() {
         return (
           <Link
             key={mod.id}
-            to={`${baseUrl}/modules/${mod.id}`}
+            to={modulePath(mod)}
             className="flex flex-col gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
           >
             <div className="flex items-center justify-between gap-2">
@@ -654,7 +642,7 @@ export function ModulesPage() {
                   >
                     <td className="px-3 py-2">
                       <Link
-                        to={`${baseUrl}/modules/${mod.id}`}
+                        to={modulePath(mod)}
                         className="flex items-center gap-2 text-sm text-(--txt-primary) no-underline hover:text-(--brand-default)"
                       >
                         <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
@@ -764,7 +752,7 @@ export function ModulesPage() {
                       style={{ width: totalDays * DAY_WIDTH }}
                     >
                       <Link
-                        to={`${baseUrl}/modules/${mod.id}`}
+                        to={modulePath(mod)}
                         className="absolute top-1/2 -translate-y-1/2 rounded bg-(--brand-200) px-2 py-1 text-xs font-medium text-(--brand-default) no-underline hover:bg-(--brand-default) hover:text-white"
                         style={{ left, width, minWidth: 40 }}
                       >

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Avatar } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
@@ -128,6 +128,7 @@ export function ModulesPage() {
     workspaceSlug: string;
     projectId: string;
   }>();
+  const [searchParams] = useSearchParams();
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);
@@ -188,66 +189,145 @@ export function ModulesPage() {
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
+  const layout =
+    (searchParams.get("layout") as "list" | "gallery" | "timeline") || "list";
 
-  return (
+  const renderListLayout = () => (
     <div className="space-y-2">
-      {modules.length === 0 ? (
-        <p className="py-8 text-center text-sm text-[var(--txt-tertiary)]">
-          No modules yet.
-        </p>
-      ) : (
-        modules.map((mod) => {
-          const progress = getProgress(mod);
-          const dateRange = formatModuleDateRange(mod);
-          return (
-            <Link
-              key={mod.id}
-              to={`${baseUrl}/modules/${mod.id}`}
-              className="flex items-center gap-4 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+      {modules.map((mod) => {
+        const progress = getProgress(mod);
+        const dateRange = formatModuleDateRange(mod);
+        return (
+          <Link
+            key={mod.id}
+            to={`${baseUrl}/modules/${mod.id}`}
+            className="flex items-center gap-4 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+          >
+            <ModuleProgressCircle progress={progress} />
+            <p className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
+              {mod.name}
+            </p>
+            {dateRange !== null && (
+              <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+                {dateRange}
+              </span>
+            )}
+            <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+              {mod.status}
+            </span>
+            <Avatar name={workspace.name} size="sm" className="ml-1" />
+            <button
+              type="button"
+              className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              aria-label="Favorite"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
             >
-              <ModuleProgressCircle progress={progress} />
-              <p className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
+              <IconStar />
+            </button>
+            <button
+              type="button"
+              className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              aria-label="More options"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <IconMoreVertical />
+            </button>
+          </Link>
+        );
+      })}
+    </div>
+  );
+
+  const renderGalleryLayout = () => (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {modules.map((mod) => {
+        const progress = getProgress(mod);
+        const dateRange = formatModuleDateRange(mod);
+        return (
+          <Link
+            key={mod.id}
+            to={`${baseUrl}/modules/${mod.id}`}
+            className="flex flex-col gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-4 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <p className="min-w-0 flex-1 truncate font-medium text-[var(--txt-primary)]">
                 {mod.name}
               </p>
+              <ModuleProgressCircle progress={progress} />
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-[13px]">
               {dateRange !== null && (
-                <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+                <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[var(--txt-secondary)]">
                   {dateRange}
                 </span>
               )}
-              <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+              <span className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[var(--txt-secondary)]">
                 {mod.status}
               </span>
-              <Avatar
-                name={workspace.name}
-                size="sm"
-                className="ml-1"
-              />
-              <button
-                type="button"
-                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                aria-label="Favorite"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-              >
-                <IconStar />
-              </button>
-              <button
-                type="button"
-                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                aria-label="More options"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-              >
-                <IconMoreVertical />
-              </button>
-            </Link>
-          );
-        })
-      )}
+            </div>
+          </Link>
+        );
+      })}
     </div>
   );
+
+  const renderTimelineLayout = () => {
+    const withDates = modules
+      .map((m) => ({
+        mod: m,
+        start: m.start_date ? new Date(m.start_date) : null,
+        end: m.target_date ? new Date(m.target_date) : null,
+      }))
+      .sort((a, b) => {
+        const aTime = a.start?.getTime() ?? a.end?.getTime() ?? 0;
+        const bTime = b.start?.getTime() ?? b.end?.getTime() ?? 0;
+        return aTime - bTime;
+      });
+
+    return (
+      <div className="space-y-3 border-l border-[var(--border-subtle)] pl-4">
+        {withDates.map(({ mod, start, end }) => {
+          const progress = getProgress(mod);
+          const dateRange = formatModuleDateRange(mod);
+          return (
+            <div key={mod.id} className="relative pl-4">
+              <div className="absolute left-0 top-3 h-2 w-2 -translate-x-1/2 rounded-full bg-[var(--brand-default)]" />
+              <Link
+                to={`${baseUrl}/modules/${mod.id}`}
+                className="flex items-center gap-3 rounded-md px-3 py-2 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+              >
+                <ModuleProgressCircle progress={progress} />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
+                    {mod.name}
+                  </p>
+                  <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+                    {dateRange ?? "No dates"}
+                  </p>
+                </div>
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  if (modules.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-[var(--txt-tertiary)]">
+        No modules yet.
+      </p>
+    );
+  }
+
+  if (layout === "gallery") return renderGalleryLayout();
+  if (layout === "timeline") return renderTimelineLayout();
+  return renderListLayout();
 }

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -5,11 +5,14 @@ import { MODULE_FILTER_PARAM } from "../components/workspace-views";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
 import { moduleService } from "../services/moduleService";
+import { useModuleFavorites } from "../hooks/useModuleFavorites";
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
   ModuleApiResponse,
+  WorkspaceMemberApiResponse,
 } from "../api/types";
+import { getImageUrl } from "../lib/utils";
 
 function parseList(value: string | null): string[] {
   if (!value?.trim()) return [];
@@ -78,6 +81,35 @@ const IconStar = () => (
     <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
   </svg>
 );
+const IconStarFilled = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
+    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+  </svg>
+);
+const IconCalendar = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
+    <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+  </svg>
+);
 const IconMoreVertical = () => (
   <svg
     width="14"
@@ -141,9 +173,19 @@ export function ModulesPage() {
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);
+  const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
+  const [timelineTimeframe, setTimelineTimeframe] = useState<
+    "week" | "month" | "quarter"
+  >("week");
+  const { favoriteModuleIds, toggleFavorite, isFavorite } = useModuleFavorites(
+    workspaceSlug,
+    projectId,
+  );
 
   const searchQuery = (searchParams.get("search") ?? "").trim().toLowerCase();
+  const favoritesFilter =
+    searchParams.get(MODULE_FILTER_PARAM.favorites) === "1";
   const statusFilter = parseList(searchParams.get(MODULE_FILTER_PARAM.status));
   const startDateList = parseList(
     searchParams.get(MODULE_FILTER_PARAM.start_date),
@@ -162,6 +204,10 @@ export function ModulesPage() {
     let list = modules;
     if (searchQuery !== "") {
       list = list.filter((m) => m.name.toLowerCase().includes(searchQuery));
+    }
+    if (favoritesFilter && favoriteModuleIds.length > 0) {
+      const favSet = new Set(favoriteModuleIds);
+      list = list.filter((m) => favSet.has(m.id));
     }
     if (statusFilter.length > 0) {
       const allowed = new Set(statusFilter.map((s) => s.toLowerCase()));
@@ -215,6 +261,8 @@ export function ModulesPage() {
   }, [
     modules,
     searchQuery,
+    favoritesFilter,
+    favoriteModuleIds,
     statusFilter,
     startDateList,
     dueDateList,
@@ -272,7 +320,6 @@ export function ModulesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }
@@ -282,12 +329,14 @@ export function ModulesPage() {
       workspaceService.getBySlug(workspaceSlug),
       projectService.get(workspaceSlug, projectId),
       moduleService.list(workspaceSlug, projectId),
+      workspaceService.listMembers(workspaceSlug),
     ])
-      .then(([w, p, list]) => {
+      .then(([w, p, list, mem]) => {
         if (!cancelled) {
           setWorkspace(w ?? null);
           setProject(p ?? null);
           setModules(list ?? []);
+          setMembers(mem ?? []);
         }
       })
       .catch(() => {
@@ -295,6 +344,7 @@ export function ModulesPage() {
           setWorkspace(null);
           setProject(null);
           setModules([]);
+          setMembers([]);
         }
       })
       .finally(() => {
@@ -325,44 +375,97 @@ export function ModulesPage() {
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
   const layout =
     (searchParams.get("layout") as "list" | "gallery" | "timeline") || "list";
-  const [timelineTimeframe, setTimelineTimeframe] = useState<
-    "week" | "month" | "quarter"
-  >("week");
+
+  const getLeadMember = (leadId: string | null | undefined) => {
+    if (!leadId) return null;
+    const m = members.find((x) => x.member_id === leadId);
+    const name =
+      m?.member_display_name?.trim() ??
+      m?.member_email?.split("@")[0] ??
+      leadId.slice(0, 8);
+    return { name, avatarUrl: m?.member_avatar ?? null };
+  };
 
   const renderListLayout = () => (
-    <div className="space-y-2">
+    <div className="space-y-0 rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
       {sortedModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
+        const lead = getLeadMember(mod.lead_id ?? null);
+        const fav = isFavorite(mod.id);
         return (
-          <Link
+          <div
             key={mod.id}
-            to={`${baseUrl}/modules/${mod.id}`}
-            className="flex items-center gap-4 px-4 py-3 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
+            className="flex items-center gap-3 border-b border-(--border-subtle) last:border-b-0 px-4 py-3 hover:bg-(--bg-layer-1-hover)"
           >
-            <ModuleProgressCircle progress={progress} />
-            <p className="min-w-0 flex-1 font-medium text-(--txt-primary)">
-              {mod.name}
-            </p>
-            {dateRange !== null && (
-              <span className="shrink-0 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-[13px] text-(--txt-secondary)">
-                {dateRange}
+            <Link
+              to={`${baseUrl}/modules/${mod.id}`}
+              className="flex min-w-0 flex-1 items-center gap-3 no-underline"
+            >
+              <ModuleProgressCircle progress={progress} />
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-(--txt-primary)">{mod.name}</p>
+                <div className="mt-0.5 flex items-center gap-2 text-[13px]">
+                  {dateRange !== null ? (
+                    <span className="flex items-center gap-1.5 text-(--txt-secondary)">
+                      <IconCalendar />
+                      {dateRange}
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1.5 text-(--txt-placeholder)">
+                      <IconCalendar />
+                      Start date → End date
+                    </span>
+                  )}
+                </div>
+              </div>
+              <span className="shrink-0 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-[13px] font-medium capitalize text-(--txt-secondary)">
+                {mod.status}
+              </span>
+            </Link>
+            {lead ? (
+              <Avatar
+                name={lead.name}
+                src={getImageUrl(lead.avatarUrl) ?? undefined}
+                size="sm"
+                className="h-8 w-8 shrink-0 text-xs"
+              />
+            ) : (
+              <span
+                className="flex size-8 shrink-0 items-center justify-center rounded border border-(--border-subtle) border-dashed text-(--txt-icon-tertiary)"
+                aria-hidden
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  aria-hidden
+                >
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
               </span>
             )}
-            <span className="shrink-0 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-[13px] text-(--txt-secondary)">
-              {mod.status}
-            </span>
-            <Avatar name={workspace.name} size="sm" className="ml-1" />
             <button
               type="button"
               className="flex size-8 shrink-0 items-center justify-center rounded text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
-              aria-label="Favorite"
+              aria-label={fav ? "Remove from favorites" : "Add to favorites"}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                toggleFavorite(mod.id);
               }}
             >
-              <IconStar />
+              {fav ? (
+                <span className="text-amber-500">
+                  <IconStarFilled />
+                </span>
+              ) : (
+                <IconStar />
+              )}
             </button>
             <button
               type="button"
@@ -375,7 +478,7 @@ export function ModulesPage() {
             >
               <IconMoreVertical />
             </button>
-          </Link>
+          </div>
         );
       })}
     </div>
@@ -681,7 +784,11 @@ export function ModulesPage() {
   if (filteredModules.length === 0) {
     return (
       <p className="py-8 text-center text-sm text-(--txt-tertiary)">
-        {searchQuery ? "No modules match your search." : "No modules yet."}
+        {favoritesFilter
+          ? "No favorite modules. Star modules to add them here."
+          : searchQuery
+            ? "No modules match your search."
+            : "No modules yet."}
       </p>
     );
   }

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -319,9 +319,7 @@ export function ModulesPage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -9,49 +9,26 @@ import type {
   ModuleApiResponse,
 } from "../api/types";
 
-const IconSearch = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden
-  >
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-4.3-4.3" />
-  </svg>
-);
-const IconFilter = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden
-  >
-    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
-  </svg>
-);
-const IconCalendar = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden
-  >
-    <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-    <line x1="16" y1="2" x2="16" y2="6" />
-    <line x1="8" y1="2" x2="8" y2="6" />
-    <line x1="3" y1="10" x2="21" y2="10" />
-  </svg>
-);
+/** Format ISO date to "Mon DD, YYYY" */
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** Format module date range from API (start_date, target_date). Returns null if neither set. */
+function formatModuleDateRange(mod: ModuleApiResponse): string | null {
+  const start = mod.start_date?.trim();
+  const end = mod.target_date?.trim();
+  if (start && end) return `${formatDate(start)} - ${formatDate(end)}`;
+  if (start) return `From ${formatDate(start)}`;
+  if (end) return `Until ${formatDate(end)}`;
+  return null;
+}
+
 const IconUser = () => (
   <svg
     width="14"
@@ -92,33 +69,47 @@ const IconMoreVertical = () => (
     <circle cx="12" cy="19" r="1.5" />
   </svg>
 );
-const IconChevronDown = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden
-  >
-    <path d="m6 9 6 6 6-6" />
-  </svg>
-);
-const IconLuggage = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden
-  >
-    <path d="M6 20h12a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z" />
-    <path d="M8 8V6a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-  </svg>
-);
+
+/** Circular progress indicator (0–100). */
+function ModuleProgressCircle({ progress }: { progress: number }) {
+  const r = 18;
+  const c = 2 * Math.PI * r;
+  const stroke = Math.max(0, Math.min(100, progress)) / 100;
+  return (
+    <div className="relative flex size-10 shrink-0 items-center justify-center">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        className="-rotate-90"
+        aria-hidden
+      >
+        <circle
+          cx="20"
+          cy="20"
+          r={r}
+          fill="none"
+          stroke="var(--border-subtle)"
+          strokeWidth="3"
+        />
+        <circle
+          cx="20"
+          cy="20"
+          r={r}
+          fill="none"
+          stroke="var(--brand-default)"
+          strokeWidth="3"
+          strokeDasharray={c}
+          strokeDashoffset={c - stroke * c}
+          strokeLinecap="round"
+        />
+      </svg>
+      <span className="absolute text-[10px] font-medium text-[var(--txt-secondary)]">
+        {progress}%
+      </span>
+    </div>
+  );
+}
 
 export function ModulesPage() {
   const { workspaceSlug, projectId } = useParams<{
@@ -132,7 +123,6 @@ export function ModulesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }
@@ -165,11 +155,8 @@ export function ModulesPage() {
     };
   }, [workspaceSlug, projectId]);
 
-  const getIssueCount = (moduleId: string) =>
-    modules.find((m) => m.id === moduleId)?.issue_count ?? 0;
-  const getTotalIssues = (moduleId: string) => getIssueCount(moduleId);
-  const getProgress = (moduleId: string) => {
-    const total = getTotalIssues(moduleId);
+  const getProgress = (mod: ModuleApiResponse) => {
+    const total = mod.issue_count ?? 0;
     const done = 0;
     return total === 0 ? 0 : Math.round((done / total) * 100);
   };
@@ -190,170 +177,70 @@ export function ModulesPage() {
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
 
   return (
-    <div className="space-y-4">
-      {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
-          aria-label="Search"
-        >
-          <IconSearch />
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
-        >
-          ↑ Name <IconChevronDown />
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
-        >
-          <IconFilter /> Filters <IconChevronDown />
-        </button>
-        <button
-          type="button"
-          className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--brand-default)] hover:bg-[var(--bg-layer-2-hover)]"
-          aria-label="List view"
-          title="List view"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <line x1="8" y1="6" x2="21" y2="6" />
-            <line x1="8" y1="12" x2="21" y2="12" />
-            <line x1="8" y1="18" x2="21" y2="18" />
-            <line x1="3" y1="6" x2="3.01" y2="6" />
-            <line x1="3" y1="12" x2="3.01" y2="12" />
-            <line x1="3" y1="18" x2="3.01" y2="18" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          className="flex size-8 items-center justify-center rounded-md border border-transparent text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
-          aria-label="Grid view"
-          title="Grid view"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <rect width="7" height="7" x="3" y="3" rx="1" />
-            <rect width="7" height="7" x="14" y="3" rx="1" />
-            <rect width="7" height="7" x="14" y="14" rx="1" />
-            <rect width="7" height="7" x="3" y="14" rx="1" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
-        >
-          <IconCalendar /> Start date → End date
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
-        >
-          <IconLuggage /> Backlog
-        </button>
-        <button
-          type="button"
-          className="flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
-          aria-label="Assignees"
-        >
-          <IconUser />
-        </button>
-        <button
-          type="button"
-          className="flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
-          aria-label="Favorite"
-        >
-          <IconStar />
-        </button>
-        <button
-          type="button"
-          className="flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2)] hover:text-[var(--txt-icon-secondary)]"
-          aria-label="More"
-        >
-          <IconMoreVertical />
-        </button>
-      </div>
-
-      {/* Module list */}
-      <div className="space-y-2">
-        {modules.length === 0 ? (
-          <p className="py-8 text-center text-sm text-[var(--txt-tertiary)]">
-            No modules yet.
-          </p>
-        ) : (
-          modules.map((mod) => {
-            const progress = getProgress(mod.id);
-            return (
-              <Link
-                key={mod.id}
-                to={`${baseUrl}/modules/${mod.id}`}
-                className="flex items-center gap-4 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+    <div className="space-y-2">
+      {modules.length === 0 ? (
+        <p className="py-8 text-center text-sm text-[var(--txt-tertiary)]">
+          No modules yet.
+        </p>
+      ) : (
+        modules.map((mod) => {
+          const progress = getProgress(mod);
+          const dateRange = formatModuleDateRange(mod);
+          return (
+            <Link
+              key={mod.id}
+              to={`${baseUrl}/modules/${mod.id}`}
+              className="flex items-center gap-4 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+            >
+              <ModuleProgressCircle progress={progress} />
+              <p className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
+                {mod.name}
+              </p>
+              {dateRange !== null && (
+                <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+                  {dateRange}
+                </span>
+              )}
+              <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
+                {mod.status}
+              </span>
+              <button
+                type="button"
+                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                aria-label="Assignees"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
               >
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-sm font-medium text-[var(--txt-secondary)]">
-                  {progress}%
-                </div>
-                <div className="min-w-0 flex-1 border-l border-[var(--border-subtle)] pl-4">
-                  <p className="font-medium text-[var(--txt-primary)]">
-                    {mod.name}
-                  </p>
-                </div>
-                <div className="flex shrink-0 items-center gap-1 text-[var(--txt-icon-tertiary)]">
-                  <span
-                    className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                    title="Start date → End date"
-                  >
-                    <IconCalendar />
-                  </span>
-                  <span
-                    className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                    title="Backlog"
-                  >
-                    <IconLuggage />
-                  </span>
-                  <span
-                    className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                    title="Assignees"
-                  >
-                    <IconUser />
-                  </span>
-                  <span
-                    className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                    title="Favorite"
-                  >
-                    <IconStar />
-                  </span>
-                  <button
-                    type="button"
-                    className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                    aria-label="More options"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                  >
-                    <IconMoreVertical />
-                  </button>
-                </div>
-              </Link>
-            );
-          })
-        )}
-      </div>
+                <IconUser />
+              </button>
+              <button
+                type="button"
+                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                aria-label="Favorite"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
+                <IconStar />
+              </button>
+              <button
+                type="button"
+                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                aria-label="More options"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
+                <IconMoreVertical />
+              </button>
+            </Link>
+          );
+        })
+      )}
     </div>
   );
 }

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { Avatar } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
 import { moduleService } from "../services/moduleService";
@@ -15,18 +16,20 @@ function pad2(n: number): string {
 }
 
 const MONTH_ABBR = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
 ];
 
-/**
- * Format module date range in compact form matching the Plane design:
- *  - Same month+year: "Mar 03 - 27, 2026"
- *  - Same year:       "Mar 03 - Apr 12, 2026"
- *  - Different year:  "Dec 20, 2025 - Jan 05, 2026"
- *  - Single date:     "Mar 03, 2026"
- *  Returns null when neither date is set.
- */
 function formatModuleDateRange(mod: ModuleApiResponse): string | null {
   const startRaw = mod.start_date?.trim();
   const endRaw = mod.target_date?.trim();
@@ -53,23 +56,6 @@ function formatModuleDateRange(mod: ModuleApiResponse): string | null {
   return `${MONTH_ABBR[single.m]} ${pad2(single.d)}, ${single.y}`;
 }
 
-const IconSave = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden
-  >
-    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
-    <polyline points="17 21 17 13 7 13 7 21" />
-    <polyline points="7 3 7 8 15 8" />
-  </svg>
-);
 const IconStar = () => (
   <svg
     width="14"
@@ -97,7 +83,6 @@ const IconMoreVertical = () => (
   </svg>
 );
 
-/** Circular progress indicator (0–100). */
 function ModuleProgressCircle({ progress }: { progress: number }) {
   const r = 18;
   const c = 2 * Math.PI * r;
@@ -150,6 +135,7 @@ export function ModulesPage() {
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug/project (kept for future use)
       setLoading(false);
       return;
     }
@@ -217,7 +203,7 @@ export function ModulesPage() {
             <Link
               key={mod.id}
               to={`${baseUrl}/modules/${mod.id}`}
-              className="flex items-center gap-4 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex items-center gap-4 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
             >
               <ModuleProgressCircle progress={progress} />
               <p className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
@@ -231,17 +217,11 @@ export function ModulesPage() {
               <span className="shrink-0 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1 text-[13px] text-[var(--txt-secondary)]">
                 {mod.status}
               </span>
-              <button
-                type="button"
-                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                aria-label="Save"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-              >
-                <IconSave />
-              </button>
+              <Avatar
+                name={workspace.name}
+                size="sm"
+                className="ml-1"
+              />
               <button
                 type="button"
                 className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -9,27 +9,51 @@ import type {
   ModuleApiResponse,
 } from "../api/types";
 
-/** Format ISO date to "Mon DD, YYYY" */
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+/** Zero-pad a number to 2 digits. */
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
 }
 
-/** Format module date range from API (start_date, target_date). Returns null if neither set. */
+const MONTH_ABBR = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * Format module date range in compact form matching the Plane design:
+ *  - Same month+year: "Mar 03 - 27, 2026"
+ *  - Same year:       "Mar 03 - Apr 12, 2026"
+ *  - Different year:  "Dec 20, 2025 - Jan 05, 2026"
+ *  - Single date:     "Mar 03, 2026"
+ *  Returns null when neither date is set.
+ */
 function formatModuleDateRange(mod: ModuleApiResponse): string | null {
-  const start = mod.start_date?.trim();
-  const end = mod.target_date?.trim();
-  if (start && end) return `${formatDate(start)} - ${formatDate(end)}`;
-  if (start) return `From ${formatDate(start)}`;
-  if (end) return `Until ${formatDate(end)}`;
-  return null;
+  const startRaw = mod.start_date?.trim();
+  const endRaw = mod.target_date?.trim();
+  if (!startRaw && !endRaw) return null;
+
+  const parse = (iso: string) => {
+    const d = new Date(iso);
+    return { m: d.getMonth(), d: d.getDate(), y: d.getFullYear() };
+  };
+
+  if (startRaw && endRaw) {
+    const s = parse(startRaw);
+    const e = parse(endRaw);
+    if (s.y === e.y && s.m === e.m) {
+      return `${MONTH_ABBR[s.m]} ${pad2(s.d)} - ${pad2(e.d)}, ${s.y}`;
+    }
+    if (s.y === e.y) {
+      return `${MONTH_ABBR[s.m]} ${pad2(s.d)} - ${MONTH_ABBR[e.m]} ${pad2(e.d)}, ${s.y}`;
+    }
+    return `${MONTH_ABBR[s.m]} ${pad2(s.d)}, ${s.y} - ${MONTH_ABBR[e.m]} ${pad2(e.d)}, ${e.y}`;
+  }
+
+  const single = parse((startRaw ?? endRaw)!);
+  return `${MONTH_ABBR[single.m]} ${pad2(single.d)}, ${single.y}`;
 }
 
-const IconUser = () => (
+const IconSave = () => (
   <svg
     width="14"
     height="14"
@@ -37,10 +61,13 @@ const IconUser = () => (
     fill="none"
     stroke="currentColor"
     strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     aria-hidden
   >
-    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-    <circle cx="12" cy="7" r="4" />
+    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+    <polyline points="17 21 17 13 7 13 7 21" />
+    <polyline points="7 3 7 8 15 8" />
   </svg>
 );
 const IconStar = () => (
@@ -207,13 +234,13 @@ export function ModulesPage() {
               <button
                 type="button"
                 className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
-                aria-label="Assignees"
+                aria-label="Save"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
                 }}
               >
-                <IconUser />
+                <IconSave />
               </button>
               <button
                 type="button"

--- a/ui/src/pages/NotificationsPage.tsx
+++ b/ui/src/pages/NotificationsPage.tsx
@@ -164,9 +164,7 @@ export function NotificationsPage() {
   }
   if (!workspace) {
     return (
-      <div className="p-4 text-(--txt-secondary)">
-        Workspace not found.
-      </div>
+      <div className="p-4 text-(--txt-secondary)">Workspace not found.</div>
     );
   }
 

--- a/ui/src/pages/NotificationsPage.tsx
+++ b/ui/src/pages/NotificationsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+﻿import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { Avatar, Button, Card, CardContent } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
@@ -157,14 +157,14 @@ export function NotificationsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="p-4 text-[var(--txt-secondary)]">
+      <div className="p-4 text-(--txt-secondary)">
         Workspace not found.
       </div>
     );
@@ -175,10 +175,10 @@ export function NotificationsPage() {
   return (
     <div className="flex h-full min-h-0 w-full">
       <div
-        className="flex shrink-0 flex-col border-r border-[var(--border-subtle)] bg-[var(--bg-canvas)]"
+        className="flex shrink-0 flex-col border-r border-(--border-subtle) bg-(--bg-canvas)"
         style={{ width: listWidth }}
       >
-        <div className="shrink-0 border-b border-[var(--border-subtle)] px-4">
+        <div className="shrink-0 border-b border-(--border-subtle) px-4">
           <div className="flex items-center justify-between gap-2">
             <div className="flex gap-1">
               <button
@@ -186,8 +186,8 @@ export function NotificationsPage() {
                 onClick={() => setInboxTab("all")}
                 className={`border-b-2 px-4 py-2.5 text-sm font-medium ${
                   inboxTab === "all"
-                    ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-                    : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+                    ? "border-(--brand-default) text-(--txt-primary)"
+                    : "border-transparent text-(--txt-secondary) hover:text-(--txt-primary)"
                 }`}
               >
                 All
@@ -197,8 +197,8 @@ export function NotificationsPage() {
                 onClick={() => setInboxTab("mentions")}
                 className={`border-b-2 px-4 py-2.5 text-sm font-medium ${
                   inboxTab === "mentions"
-                    ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-                    : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+                    ? "border-(--brand-default) text-(--txt-primary)"
+                    : "border-transparent text-(--txt-secondary) hover:text-(--txt-primary)"
                 }`}
               >
                 Mentions
@@ -221,11 +221,11 @@ export function NotificationsPage() {
 
         <div className="min-h-0 flex-1 overflow-y-auto">
           {items.length === 0 ? (
-            <div className="p-4 text-sm text-[var(--txt-tertiary)]">
+            <div className="p-4 text-sm text-(--txt-tertiary)">
               No notifications.
             </div>
           ) : (
-            <ul className="divide-y divide-[var(--border-subtle)]">
+            <ul className="divide-y divide-(--border-subtle)">
               {items.map((item) => {
                 const actorName = item.actorUserId
                   ? item.actorUserId.slice(0, 8)
@@ -242,30 +242,30 @@ export function NotificationsPage() {
                       onClick={() => setSelectedId(item.id)}
                       className={`flex w-full gap-3 px-4 py-3 text-left transition-colors ${
                         isSelected
-                          ? "bg-[var(--bg-layer-1)]"
-                          : "hover:bg-[var(--bg-layer-1-hover)]"
+                          ? "bg-(--bg-layer-1)"
+                          : "hover:bg-(--bg-layer-1-hover)"
                       }`}
                     >
                       <Avatar name={actorName} size="md" className="shrink-0" />
                       <div className="min-w-0 flex-1">
-                        <p className="text-sm text-[var(--txt-primary)]">
+                        <p className="text-sm text-(--txt-primary)">
                           <span className="font-medium">{actorName}</span>{" "}
-                          <span className="text-[var(--txt-secondary)]">
+                          <span className="text-(--txt-secondary)">
                             {item.type}
                           </span>{" "}
                           <span className="font-semibold">{item.title}</span>
                         </p>
-                        <p className="mt-0.5 truncate text-sm text-[var(--txt-secondary)]">
+                        <p className="mt-0.5 truncate text-sm text-(--txt-secondary)">
                           {project ? (project.identifier ?? project.name) : "—"}
                           -{issueRef}
                         </p>
                       </div>
-                      <span className="shrink-0 text-right text-xs text-[var(--txt-tertiary)]">
+                      <span className="shrink-0 text-right text-xs text-(--txt-tertiary)">
                         <span className="block">
                           {formatTimeAgo(item.createdAt)}
                         </span>
                         {!item.readAt && (
-                          <span className="mt-1 inline-block rounded bg-[var(--brand-200)] px-2 py-0.5 text-[10px] font-medium text-[var(--brand-default)]">
+                          <span className="mt-1 inline-block rounded bg-(--brand-200) px-2 py-0.5 text-[10px] font-medium text-(--brand-default)">
                             New
                           </span>
                         )}
@@ -279,19 +279,19 @@ export function NotificationsPage() {
         </div>
       </div>
 
-      <div className="min-w-0 flex-1 bg-[var(--bg-canvas)]">
+      <div className="min-w-0 flex-1 bg-(--bg-canvas)">
         {!selectedItem ? (
-          <div className="flex h-full items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+          <div className="flex h-full items-center justify-center p-8 text-sm text-(--txt-tertiary)">
             Select a notification to see details.
           </div>
         ) : (
-          <div className="h-full overflow-y-auto px-[var(--padding-page)] py-6">
+          <div className="h-full overflow-y-auto px-(--padding-page) py-6">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0">
-                <h2 className="truncate text-lg font-semibold text-[var(--txt-primary)]">
+                <h2 className="truncate text-lg font-semibold text-(--txt-primary)">
                   {selectedItem.title}
                 </h2>
-                <p className="mt-1 text-sm text-[var(--txt-secondary)]">
+                <p className="mt-1 text-sm text-(--txt-secondary)">
                   {formatTimeAgo(selectedItem.createdAt)}
                 </p>
               </div>
@@ -319,20 +319,20 @@ export function NotificationsPage() {
             <div className="mt-6 grid gap-4 sm:grid-cols-2">
               <Card variant="outlined">
                 <CardContent className="space-y-1">
-                  <p className="text-xs font-medium uppercase tracking-wide text-[var(--txt-tertiary)]">
+                  <p className="text-xs font-medium uppercase tracking-wide text-(--txt-tertiary)">
                     Project
                   </p>
-                  <p className="text-sm text-[var(--txt-primary)]">
+                  <p className="text-sm text-(--txt-primary)">
                     {selectedProject?.name ?? "—"}
                   </p>
                 </CardContent>
               </Card>
               <Card variant="outlined">
                 <CardContent className="space-y-1">
-                  <p className="text-xs font-medium uppercase tracking-wide text-[var(--txt-tertiary)]">
+                  <p className="text-xs font-medium uppercase tracking-wide text-(--txt-tertiary)">
                     Issue
                   </p>
-                  <p className="text-sm text-[var(--txt-primary)]">
+                  <p className="text-sm text-(--txt-primary)">
                     {selectedIssue?.name ?? "—"}
                   </p>
                 </CardContent>
@@ -341,10 +341,10 @@ export function NotificationsPage() {
 
             <Card variant="outlined" className="mt-4">
               <CardContent>
-                <p className="text-xs font-medium uppercase tracking-wide text-[var(--txt-tertiary)]">
+                <p className="text-xs font-medium uppercase tracking-wide text-(--txt-tertiary)">
                   Message
                 </p>
-                <pre className="mt-2 whitespace-pre-wrap break-words rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3 text-xs text-[var(--txt-secondary)]">
+                <pre className="mt-2 whitespace-pre-wrap break-words rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3 text-xs text-(--txt-secondary)">
                   {selectedItem.message
                     ? JSON.stringify(selectedItem.message, null, 2)
                     : "—"}

--- a/ui/src/pages/PagesPage.tsx
+++ b/ui/src/pages/PagesPage.tsx
@@ -209,9 +209,7 @@ export function PagesPage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;

--- a/ui/src/pages/PagesPage.tsx
+++ b/ui/src/pages/PagesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Avatar } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
@@ -117,7 +117,7 @@ const IconAlertTriangle = () => (
     fill="none"
     stroke="currentColor"
     strokeWidth="2"
-    className="shrink-0 text-[var(--warning-default)]"
+    className="shrink-0 text-(--warning-default)"
     aria-hidden
   >
     <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
@@ -203,14 +203,14 @@ export function PagesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
@@ -219,7 +219,7 @@ export function PagesPage() {
   return (
     <div className="space-y-4">
       {/* Tabs: Public | Private | Archived */}
-      <div className="flex gap-1 border-b border-[var(--border-subtle)]">
+      <div className="flex gap-1 border-b border-(--border-subtle)">
         {(["public", "private", "archived"] as const).map((t) => (
           <button
             key={t}
@@ -227,8 +227,8 @@ export function PagesPage() {
             onClick={() => setTab(t)}
             className={`border-b-2 px-4 py-2.5 text-sm font-medium capitalize ${
               tab === t
-                ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-                : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+                ? "border-(--brand-default) text-(--txt-primary)"
+                : "border-transparent text-(--txt-secondary) hover:text-(--txt-primary)"
             }`}
           >
             {t === "public"
@@ -244,7 +244,7 @@ export function PagesPage() {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <button
           type="button"
-          className="flex size-8 items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-2-hover)]"
+          className="flex size-8 items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-2-hover)"
           aria-label="Search"
         >
           <IconSearch />
@@ -252,13 +252,13 @@ export function PagesPage() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconCalendar /> Date modified <IconChevronDown />
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             <IconFilter /> Filters <IconChevronDown />
           </button>
@@ -266,13 +266,13 @@ export function PagesPage() {
       </div>
 
       {/* Page list */}
-      <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
+      <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
         {filteredPages.length === 0 ? (
-          <p className="px-4 py-8 text-center text-sm text-[var(--txt-tertiary)]">
+          <p className="px-4 py-8 text-center text-sm text-(--txt-tertiary)">
             No {tab} pages yet.
           </p>
         ) : (
-          <ul className="divide-y divide-[var(--border-subtle)]">
+          <ul className="divide-y divide-(--border-subtle)">
             {filteredPages.map((page) => {
               const updatedBy = getUser(
                 page.updated_by_id ?? page.owned_by_id ?? null,
@@ -281,12 +281,12 @@ export function PagesPage() {
                 <li key={page.id}>
                   <Link
                     to={`${baseUrl}/pages/${page.id}`}
-                    className="flex items-center gap-3 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+                    className="flex items-center gap-3 px-4 py-3 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
                   >
                     {page.archived_at ? (
                       <IconAlertTriangle />
                     ) : (
-                      <span className="flex size-9 shrink-0 items-center justify-center rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)]">
+                      <span className="flex size-9 shrink-0 items-center justify-center rounded border border-(--border-subtle) bg-(--bg-layer-2) text-(--txt-icon-tertiary)">
                         <svg
                           width="18"
                           height="18"
@@ -300,10 +300,10 @@ export function PagesPage() {
                         </svg>
                       </span>
                     )}
-                    <span className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
+                    <span className="min-w-0 flex-1 font-medium text-(--txt-primary)">
                       {page.title ?? page.name}
                     </span>
-                    <div className="flex shrink-0 items-center gap-2 text-[var(--txt-icon-tertiary)]">
+                    <div className="flex shrink-0 items-center gap-2 text-(--txt-icon-tertiary)">
                       {updatedBy && (
                         <Avatar
                           name={updatedBy.name}
@@ -313,26 +313,26 @@ export function PagesPage() {
                         />
                       )}
                       <span
-                        className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                        className="flex size-8 items-center justify-center rounded hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                         title="Visibility"
                       >
                         <IconGlobe />
                       </span>
                       <span
-                        className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                        className="flex size-8 items-center justify-center rounded hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                         title="Info"
                       >
                         <IconInfo />
                       </span>
                       <span
-                        className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                        className="flex size-8 items-center justify-center rounded hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                         title="Favorite"
                       >
                         <IconStar />
                       </span>
                       <button
                         type="button"
-                        className="flex size-8 items-center justify-center rounded hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                        className="flex size-8 items-center justify-center rounded hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                         aria-label="More options"
                         onClick={(e) => {
                           e.preventDefault();

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from "react-router-dom";
+﻿import { useParams, Link } from "react-router-dom";
 import { useState, useMemo, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { Avatar, Card, CardContent } from "../components/ui";
@@ -265,14 +265,14 @@ export function ProfilePage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="p-4 text-[var(--txt-secondary)]">
+      <div className="p-4 text-(--txt-secondary)">
         Workspace not found.
       </div>
     );
@@ -292,7 +292,7 @@ export function ProfilePage() {
       {/* Main content */}
       <div className="min-w-0 flex-1 space-y-6 pb-8">
         {/* Tabs */}
-        <div className="border-b border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
+        <div className="border-b border-(--border-subtle) bg-(--bg-surface-1)">
           <div className="flex gap-1">
             {tabs.map((tab) => (
               <button
@@ -301,8 +301,8 @@ export function ProfilePage() {
                 onClick={() => setActiveTab(tab.id)}
                 className={`border-b-2 px-4 py-2.5 text-sm font-medium transition-colors ${
                   activeTab === tab.id
-                    ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-                    : "border-transparent text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                    ? "border-(--brand-default) text-(--txt-primary)"
+                    : "border-transparent text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                 }`}
               >
                 {tab.label}
@@ -315,21 +315,21 @@ export function ProfilePage() {
           <>
             {/* Overview */}
             <section>
-              <h2 className="mb-3 text-sm font-semibold text-[var(--txt-primary)]">
+              <h2 className="mb-3 text-sm font-semibold text-(--txt-primary)">
                 Overview
               </h2>
               <div className="grid gap-4 sm:grid-cols-3">
                 <button
                   type="button"
                   onClick={() => setActiveTab("created")}
-                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
+                  className="w-full cursor-pointer rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) text-left transition-colors hover:bg-(--bg-layer-1-hover) focus:outline-none"
                 >
                   <Card
                     variant="outlined"
                     className="border-0 bg-transparent shadow-none"
                   >
                     <CardContent className="flex items-center gap-3 p-4">
-                      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--bg-layer-1)] text-[var(--txt-icon-secondary)]">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-(--bg-layer-1) text-(--txt-icon-secondary)">
                         <svg
                           width="20"
                           height="20"
@@ -345,10 +345,10 @@ export function ProfilePage() {
                         </svg>
                       </span>
                       <div>
-                        <p className="text-2xl font-semibold text-[var(--txt-primary)]">
+                        <p className="text-2xl font-semibold text-(--txt-primary)">
                           {issuesCreated.length}
                         </p>
-                        <p className="text-sm text-[var(--txt-secondary)]">
+                        <p className="text-sm text-(--txt-secondary)">
                           Work items created
                         </p>
                       </div>
@@ -358,14 +358,14 @@ export function ProfilePage() {
                 <button
                   type="button"
                   onClick={() => setActiveTab("assigned")}
-                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
+                  className="w-full cursor-pointer rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) text-left transition-colors hover:bg-(--bg-layer-1-hover) focus:outline-none"
                 >
                   <Card
                     variant="outlined"
                     className="border-0 bg-transparent shadow-none"
                   >
                     <CardContent className="flex items-center gap-3 p-4">
-                      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--bg-layer-1)] text-[var(--txt-icon-secondary)]">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-(--bg-layer-1) text-(--txt-icon-secondary)">
                         <svg
                           width="20"
                           height="20"
@@ -381,10 +381,10 @@ export function ProfilePage() {
                         </svg>
                       </span>
                       <div>
-                        <p className="text-2xl font-semibold text-[var(--txt-primary)]">
+                        <p className="text-2xl font-semibold text-(--txt-primary)">
                           {issuesAssigned.length}
                         </p>
-                        <p className="text-sm text-[var(--txt-secondary)]">
+                        <p className="text-sm text-(--txt-secondary)">
                           Work items assigned
                         </p>
                       </div>
@@ -394,14 +394,14 @@ export function ProfilePage() {
                 <button
                   type="button"
                   onClick={() => setActiveTab("subscribed")}
-                  className="w-full cursor-pointer rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-left transition-colors hover:bg-[var(--bg-layer-1-hover)] focus:outline-none"
+                  className="w-full cursor-pointer rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) text-left transition-colors hover:bg-(--bg-layer-1-hover) focus:outline-none"
                 >
                   <Card
                     variant="outlined"
                     className="border-0 bg-transparent shadow-none"
                   >
                     <CardContent className="flex items-center gap-3 p-4">
-                      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--bg-layer-1)] text-[var(--txt-icon-secondary)]">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-(--bg-layer-1) text-(--txt-icon-secondary)">
                         <svg
                           width="20"
                           height="20"
@@ -415,10 +415,10 @@ export function ProfilePage() {
                         </svg>
                       </span>
                       <div>
-                        <p className="text-2xl font-semibold text-[var(--txt-primary)]">
+                        <p className="text-2xl font-semibold text-(--txt-primary)">
                           {issuesSubscribed}
                         </p>
-                        <p className="text-sm text-[var(--txt-secondary)]">
+                        <p className="text-sm text-(--txt-secondary)">
                           Work items subscribed
                         </p>
                       </div>
@@ -430,7 +430,7 @@ export function ProfilePage() {
 
             {/* Workload */}
             <section>
-              <h2 className="mb-3 text-sm font-semibold text-[var(--txt-primary)]">
+              <h2 className="mb-3 text-sm font-semibold text-(--txt-primary)">
                 Workload
               </h2>
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
@@ -443,7 +443,7 @@ export function ProfilePage() {
                     <Card
                       key={cat.id}
                       variant="outlined"
-                      className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+                      className="border border-(--border-subtle) bg-(--bg-surface-1)"
                     >
                       <CardContent className="flex items-center gap-3 p-4">
                         <span
@@ -452,10 +452,10 @@ export function ProfilePage() {
                           aria-hidden
                         />
                         <div>
-                          <p className="text-2xl font-semibold text-[var(--txt-primary)]">
+                          <p className="text-2xl font-semibold text-(--txt-primary)">
                             {count}
                           </p>
-                          <p className="text-sm text-[var(--txt-secondary)]">
+                          <p className="text-sm text-(--txt-secondary)">
                             {cat.label}
                           </p>
                         </div>
@@ -469,12 +469,12 @@ export function ProfilePage() {
             {/* Charts */}
             <div className="grid gap-6 lg:grid-cols-2">
               <section>
-                <h2 className="mb-3 text-sm font-semibold text-[var(--txt-primary)]">
+                <h2 className="mb-3 text-sm font-semibold text-(--txt-primary)">
                   Work items by Priority
                 </h2>
                 <Card
                   variant="outlined"
-                  className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+                  className="border border-(--border-subtle) bg-(--bg-surface-1)"
                 >
                   <CardContent className="p-4">
                     <div className="flex flex-col gap-2">
@@ -499,11 +499,11 @@ export function ProfilePage() {
                                   : "#94a3b8";
                         return (
                           <div key={p} className="flex items-center gap-3">
-                            <span className="w-16 shrink-0 capitalize text-sm text-[var(--txt-secondary)]">
+                            <span className="w-16 shrink-0 capitalize text-sm text-(--txt-secondary)">
                               {p}
                             </span>
                             <div className="min-w-0 flex-1">
-                              <div className="h-6 overflow-hidden rounded bg-[var(--bg-layer-1)]">
+                              <div className="h-6 overflow-hidden rounded bg-(--bg-layer-1)">
                                 <div
                                   className="h-full rounded"
                                   style={{
@@ -515,7 +515,7 @@ export function ProfilePage() {
                                 />
                               </div>
                             </div>
-                            <span className="w-6 text-right text-sm text-[var(--txt-secondary)]">
+                            <span className="w-6 text-right text-sm text-(--txt-secondary)">
                               {count}
                             </span>
                           </div>
@@ -526,12 +526,12 @@ export function ProfilePage() {
                 </Card>
               </section>
               <section>
-                <h2 className="mb-3 text-sm font-semibold text-[var(--txt-primary)]">
+                <h2 className="mb-3 text-sm font-semibold text-(--txt-primary)">
                   Work items by state
                 </h2>
                 <Card
                   variant="outlined"
-                  className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+                  className="border border-(--border-subtle) bg-(--bg-surface-1)"
                 >
                   <CardContent className="flex flex-wrap items-center gap-6 p-4">
                     <div className="relative h-32 w-32 shrink-0">
@@ -547,10 +547,10 @@ export function ProfilePage() {
                             className="h-3 w-3 shrink-0 rounded-sm"
                             style={{ backgroundColor: item.color }}
                           />
-                          <span className="text-[var(--txt-secondary)]">
+                          <span className="text-(--txt-secondary)">
                             {item.label}
                           </span>
-                          <span className="text-[var(--txt-primary)]">
+                          <span className="text-(--txt-primary)">
                             ({item.count})
                           </span>
                         </div>
@@ -563,17 +563,17 @@ export function ProfilePage() {
 
             {/* Recent activity */}
             <section>
-              <h2 className="mb-3 text-sm font-semibold text-[var(--txt-primary)]">
+              <h2 className="mb-3 text-sm font-semibold text-(--txt-primary)">
                 Recent activity
               </h2>
               <Card
                 variant="outlined"
-                className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+                className="border border-(--border-subtle) bg-(--bg-surface-1)"
               >
                 <CardContent className="p-0">
-                  <ul className="divide-y divide-[var(--border-subtle)]">
+                  <ul className="divide-y divide-(--border-subtle)">
                     {recentActivity.length === 0 ? (
-                      <li className="px-4 py-6 text-center text-sm text-[var(--txt-tertiary)]">
+                      <li className="px-4 py-6 text-center text-sm text-(--txt-tertiary)">
                         No recent activity
                       </li>
                     ) : (
@@ -596,7 +596,7 @@ export function ProfilePage() {
                           text = (
                             <>
                               You added a new label{" "}
-                              <span className="rounded bg-[var(--bg-warning-subtle)] px-1.5 py-0.5 text-[var(--txt-warning-primary)]">
+                              <span className="rounded bg-(--bg-warning-subtle) px-1.5 py-0.5 text-(--txt-warning-primary)">
                                 {act.labelName}
                               </span>{" "}
                               to {issueRef} {issueTitle}{" "}
@@ -640,7 +640,7 @@ export function ProfilePage() {
                               size="sm"
                               className="shrink-0"
                             />
-                            <p className="min-w-0 text-sm text-[var(--txt-secondary)]">
+                            <p className="min-w-0 text-sm text-(--txt-secondary)">
                               {text}
                             </p>
                           </li>
@@ -699,10 +699,10 @@ export function ProfilePage() {
       <aside className="hidden w-72 shrink-0 lg:flex lg:flex-col">
         <Card
           variant="outlined"
-          className="flex min-h-0 flex-1 flex-col overflow-hidden border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden border border-(--border-subtle) bg-(--bg-surface-1)"
         >
           <div
-            className="relative h-20 shrink-0 bg-gradient-to-br from-[var(--brand-default)] to-[#0ea5e9]"
+            className="relative h-20 shrink-0 bg-gradient-to-br from-(--brand-default) to-[#0ea5e9]"
             style={
               getImageUrl(profileUser?.coverImageUrl)
                 ? {
@@ -743,20 +743,20 @@ export function ProfilePage() {
                 className="h-14 w-14"
               />
             </div>
-            <h3 className="text-center text-base font-semibold text-[var(--txt-primary)] shrink-0">
+            <h3 className="text-center text-base font-semibold text-(--txt-primary) shrink-0">
               {profileUser?.name ?? "—"}
             </h3>
-            <p className="text-center text-sm text-[var(--txt-tertiary)] shrink-0">
+            <p className="text-center text-sm text-(--txt-tertiary) shrink-0">
               ({profileUser?.email?.split("@")[0] ?? "user"})
             </p>
-            <p className="mt-2 text-center text-xs text-[var(--txt-secondary)] shrink-0">
+            <p className="mt-2 text-center text-xs text-(--txt-secondary) shrink-0">
               Joined on {formatJoinedDate(joinedAt)}
             </p>
-            <p className="text-center text-xs text-[var(--txt-secondary)] shrink-0">
+            <p className="text-center text-xs text-(--txt-secondary) shrink-0">
               Timezone 23:10 UTC
             </p>
             <div className="mt-4 flex min-h-0 flex-1 flex-col pt-4">
-              <p className="mb-2 shrink-0 text-xs font-medium uppercase tracking-wide text-[var(--txt-tertiary)]">
+              <p className="mb-2 shrink-0 text-xs font-medium uppercase tracking-wide text-(--txt-tertiary)">
                 Projects
               </p>
               <ul className="min-h-0 flex-1 overflow-auto">
@@ -773,7 +773,7 @@ export function ProfilePage() {
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="2"
-                      className="shrink-0 text-[var(--txt-icon-tertiary)]"
+                      className="shrink-0 text-(--txt-icon-tertiary)"
                     >
                       <path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2" />
                       <path d="M15 18h2" />
@@ -787,7 +787,7 @@ export function ProfilePage() {
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="2"
-                      className="shrink-0 text-[var(--txt-icon-tertiary)]"
+                      className="shrink-0 text-(--txt-icon-tertiary)"
                     >
                       <rect width="16" height="20" x="4" y="2" rx="2" ry="2" />
                       <path d="M9 22v-4h6v4" />
@@ -807,7 +807,7 @@ export function ProfilePage() {
                       key={p.id}
                       className={
                         index > 0
-                          ? "border-t border-[var(--border-subtle)]"
+                          ? "border-t border-(--border-subtle)"
                           : undefined
                       }
                     >
@@ -815,7 +815,7 @@ export function ProfilePage() {
                         <button
                           type="button"
                           onClick={() => toggleProjectExpanded(p.id)}
-                          className="flex w-full items-center justify-between gap-2 py-1.5 pr-1 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                          className="flex w-full items-center justify-between gap-2 py-1.5 pr-1 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                         >
                           <span className="flex min-w-0 items-center gap-2">
                             {projectIcon}
@@ -828,11 +828,11 @@ export function ProfilePage() {
                             </Link>
                           </span>
                           {p.progress > 0 ? (
-                            <span className="shrink-0 rounded px-1.5 py-0.5 text-xs text-[var(--txt-secondary)] bg-[var(--bg-layer-2)]">
+                            <span className="shrink-0 rounded px-1.5 py-0.5 text-xs text-(--txt-secondary) bg-(--bg-layer-2)">
                               {p.progress}%
                             </span>
                           ) : (
-                            <span className="shrink-0 rounded px-1.5 py-0.5 text-xs text-[var(--txt-danger-primary)] bg-[var(--bg-danger-subtle)]">
+                            <span className="shrink-0 rounded px-1.5 py-0.5 text-xs text-(--txt-danger-primary) bg-(--bg-danger-subtle)">
                               0%
                             </span>
                           )}
@@ -843,14 +843,14 @@ export function ProfilePage() {
                             fill="none"
                             stroke="currentColor"
                             strokeWidth="2"
-                            className={`shrink-0 text-[var(--txt-icon-tertiary)] transition-transform ${expanded ? "rotate-0" : "-rotate-90"}`}
+                            className={`shrink-0 text-(--txt-icon-tertiary) transition-transform ${expanded ? "rotate-0" : "-rotate-90"}`}
                           >
                             <path d="m6 9 6 6 6-6" />
                           </svg>
                         </button>
                         {expanded && (
                           <div className="ml-6 mr-1 pb-3">
-                            <div className="mb-2 flex h-2 w-full overflow-hidden rounded-full bg-[var(--bg-layer-1)]">
+                            <div className="mb-2 flex h-2 w-full overflow-hidden rounded-full bg-(--bg-layer-1)">
                               {total > 0 ? (
                                 states.map((s) => (
                                   <span
@@ -865,7 +865,7 @@ export function ProfilePage() {
                                   />
                                 ))
                               ) : (
-                                <span className="h-full w-full bg-[var(--bg-layer-2)]" />
+                                <span className="h-full w-full bg-(--bg-layer-2)" />
                               )}
                             </div>
                             <ul className="space-y-1">
@@ -881,10 +881,10 @@ export function ProfilePage() {
                                     }}
                                     aria-hidden
                                   />
-                                  <span className="text-[var(--txt-secondary)]">
+                                  <span className="text-(--txt-secondary)">
                                     {s.name}
                                   </span>
-                                  <span className="text-[var(--txt-primary)]">
+                                  <span className="text-(--txt-primary)">
                                     — {s.count} Work item
                                     {s.count === 1 ? "" : "s"}
                                   </span>
@@ -957,14 +957,14 @@ function WorkItemsList({
 
   return (
     <div className="space-y-0">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--border-subtle)] pb-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-(--border-subtle) pb-3">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-[var(--txt-primary)]">
+          <span className="text-sm font-medium text-(--txt-primary)">
             All work items {issues.length}
           </span>
           <button
             type="button"
-            className="rounded p-1.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+            className="rounded p-1.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
             aria-label="Refresh"
           >
             <svg
@@ -985,7 +985,7 @@ function WorkItemsList({
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+            className="flex size-8 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover)"
             aria-label="List view"
           >
             <svg
@@ -1006,7 +1006,7 @@ function WorkItemsList({
           </button>
           <button
             type="button"
-            className="flex size-8 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+            className="flex size-8 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover)"
             aria-label="Chart view"
           >
             <svg
@@ -1024,7 +1024,7 @@ function WorkItemsList({
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-sm text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-sm text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             Filters
             <svg
@@ -1040,7 +1040,7 @@ function WorkItemsList({
           </button>
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-sm text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-2-hover)]"
+            className="flex items-center gap-1.5 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-sm text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
           >
             Display
             <svg
@@ -1058,15 +1058,15 @@ function WorkItemsList({
       </div>
       <Card
         variant="outlined"
-        className="overflow-hidden border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+        className="overflow-hidden border border-(--border-subtle) bg-(--bg-surface-1)"
       >
         <CardContent className="p-0">
           {issues.length === 0 ? (
-            <div className="py-12 text-center text-sm text-[var(--txt-tertiary)]">
+            <div className="py-12 text-center text-sm text-(--txt-tertiary)">
               No work items
             </div>
           ) : (
-            <ul className="divide-y divide-[var(--border-subtle)]">
+            <ul className="divide-y divide-(--border-subtle)">
               {issues.map((issue) => {
                 const apiIssue = issue as {
                   id: string;
@@ -1092,16 +1092,16 @@ function WorkItemsList({
                   <li key={issue.id}>
                     <Link
                       to={issueUrl}
-                      className="flex flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+                      className="flex flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-(--bg-layer-1-hover)"
                     >
-                      <span className="min-w-0 flex-1 font-medium text-[var(--txt-primary)]">
+                      <span className="min-w-0 flex-1 font-medium text-(--txt-primary)">
                         {issueRef} {apiIssue.name}
                       </span>
-                      <span className="flex shrink-0 items-center gap-2 text-sm text-[var(--txt-secondary)]">
-                        <span className="flex h-4 w-4 items-center justify-center rounded-full border-2 border-[var(--border-strong)]" />
+                      <span className="flex shrink-0 items-center gap-2 text-sm text-(--txt-secondary)">
+                        <span className="flex h-4 w-4 items-center justify-center rounded-full border-2 border-(--border-strong)" />
                         {stateName}
                       </span>
-                      <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                      <span className="shrink-0 text-(--txt-icon-tertiary)">
                         <svg
                           width="16"
                           height="16"
@@ -1115,7 +1115,7 @@ function WorkItemsList({
                           <line x1="6" y1="20" x2="6" y2="14" />
                         </svg>
                       </span>
-                      <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                      <span className="shrink-0 text-(--txt-icon-tertiary)">
                         <svg
                           width="16"
                           height="16"
@@ -1128,7 +1128,7 @@ function WorkItemsList({
                           <path d="M21 3v5h-5" />
                         </svg>
                       </span>
-                      <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+                      <span className="shrink-0 text-(--txt-icon-tertiary)">
                         <svg
                           width="16"
                           height="16"
@@ -1159,17 +1159,17 @@ function WorkItemsList({
                         />
                       )}
                       {cycle && (
-                        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-0.5 text-xs text-[var(--txt-secondary)]">
-                          <span className="h-1.5 w-1.5 rounded-full bg-[var(--brand-default)]" />
+                        <span className="inline-flex items-center gap-1 rounded-full border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-0.5 text-xs text-(--txt-secondary)">
+                          <span className="h-1.5 w-1.5 rounded-full bg-(--brand-default)" />
                           {cycle.name}
                         </span>
                       )}
                       {labelNames.map((name) => (
                         <span
                           key={name}
-                          className="inline-flex items-center gap-1 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-warning-subtle)] px-2 py-0.5 text-xs text-[var(--txt-warning-primary)]"
+                          className="inline-flex items-center gap-1 rounded-full border border-(--border-subtle) bg-(--bg-warning-subtle) px-2 py-0.5 text-xs text-(--txt-warning-primary)"
                         >
-                          <span className="h-1.5 w-1.5 rounded-full bg-[var(--txt-warning-primary)]" />
+                          <span className="h-1.5 w-1.5 rounded-full bg-(--txt-warning-primary)" />
                           {name}
                         </span>
                       ))}
@@ -1179,7 +1179,7 @@ function WorkItemsList({
                           e.preventDefault();
                           e.stopPropagation();
                         }}
-                        className="shrink-0 rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)]"
+                        className="shrink-0 rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover)"
                         aria-label="More options"
                       >
                         <svg
@@ -1235,24 +1235,24 @@ function ActivityTab({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-sm font-semibold text-[var(--txt-primary)]">
+        <h2 className="text-sm font-semibold text-(--txt-primary)">
           Recent activity
         </h2>
         <button
           type="button"
-          className="rounded-md bg-[var(--brand-default)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+          className="rounded-md bg-(--brand-default) px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
         >
           Download today&apos;s activity
         </button>
       </div>
       <Card
         variant="outlined"
-        className="border border-[var(--border-subtle)] bg-[var(--bg-surface-1)]"
+        className="border border-(--border-subtle) bg-(--bg-surface-1)"
       >
         <CardContent className="p-0">
-          <ul className="divide-y divide-[var(--border-subtle)]">
+          <ul className="divide-y divide-(--border-subtle)">
             {activities.length === 0 ? (
-              <li className="px-4 py-8 text-center text-sm text-[var(--txt-tertiary)]">
+              <li className="px-4 py-8 text-center text-sm text-(--txt-tertiary)">
                 No recent activity
               </li>
             ) : (
@@ -1298,7 +1298,7 @@ function ActivityTab({
                   text = (
                     <>
                       You added a new label{" "}
-                      <span className="inline-flex rounded bg-[var(--bg-warning-subtle)] px-1.5 py-0.5 text-[var(--txt-warning-primary)]">
+                      <span className="inline-flex rounded bg-(--bg-warning-subtle) px-1.5 py-0.5 text-(--txt-warning-primary)">
                         {act.labelName}
                       </span>{" "}
                       to{" "}
@@ -1371,10 +1371,10 @@ function ActivityTab({
                 }
                 return (
                   <li key={act.id} className="flex gap-3 px-4 py-3">
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-1)] text-[var(--txt-icon-tertiary)]">
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-1) text-(--txt-icon-tertiary)">
                       {icon}
                     </span>
-                    <p className="min-w-0 text-sm text-[var(--txt-secondary)]">
+                    <p className="min-w-0 text-sm text-(--txt-secondary)">
                       {text}
                     </p>
                   </li>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -272,9 +272,7 @@ export function ProfilePage() {
   }
   if (!workspace) {
     return (
-      <div className="p-4 text-(--txt-secondary)">
-        Workspace not found.
-      </div>
+      <div className="p-4 text-(--txt-secondary)">Workspace not found.</div>
     );
   }
 

--- a/ui/src/pages/ProjectHomePage.tsx
+++ b/ui/src/pages/ProjectHomePage.tsx
@@ -82,9 +82,7 @@ export function ProjectHomePage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;

--- a/ui/src/pages/ProjectHomePage.tsx
+++ b/ui/src/pages/ProjectHomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Card, CardContent, Badge, Button } from "../components/ui";
 import { workspaceService } from "../services/workspaceService";
@@ -76,14 +76,14 @@ export function ProjectHomePage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
@@ -92,18 +92,18 @@ export function ProjectHomePage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-2xl font-semibold text-(--txt-primary)">
           {project.name}
         </h1>
         {project.description && (
-          <p className="mt-1 text-sm text-[var(--txt-secondary)]">
+          <p className="mt-1 text-sm text-(--txt-secondary)">
             {project.description}
           </p>
         )}
       </div>
       <section>
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-medium text-[var(--txt-secondary)]">
+          <h2 className="text-lg font-medium text-(--txt-secondary)">
             Recent issues
           </h2>
           <div className="flex items-center gap-2">
@@ -121,14 +121,14 @@ export function ProjectHomePage() {
         </div>
         <Card>
           <CardContent className="p-0">
-            <ul className="divide-y divide-[var(--border-subtle)]">
+            <ul className="divide-y divide-(--border-subtle)">
               {issues.slice(0, 5).map((issue) => (
                 <li key={issue.id}>
                   <Link
                     to={`${baseUrl}/issues/${issue.id}`}
-                    className="flex items-center justify-between gap-4 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+                    className="flex items-center justify-between gap-4 px-4 py-3 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
                   >
-                    <span className="font-medium text-[var(--txt-primary)]">
+                    <span className="font-medium text-(--txt-primary)">
                       {issue.name}
                     </span>
                     <Badge variant="neutral">
@@ -139,7 +139,7 @@ export function ProjectHomePage() {
               ))}
             </ul>
             {issues.length === 0 && (
-              <p className="px-4 py-6 text-sm text-[var(--txt-tertiary)]">
+              <p className="px-4 py-6 text-sm text-(--txt-tertiary)">
                 No issues yet.
               </p>
             )}

--- a/ui/src/pages/ProjectsListPage.tsx
+++ b/ui/src/pages/ProjectsListPage.tsx
@@ -201,9 +201,7 @@ export function ProjectsListPage() {
     );
   }
   if (!workspace) {
-    return (
-      <div className="text-(--txt-secondary)">Workspace not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Workspace not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}`;

--- a/ui/src/pages/ProjectsListPage.tsx
+++ b/ui/src/pages/ProjectsListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Avatar } from "../components/ui";
 import { CreateProjectModal } from "../components/CreateProjectModal";
@@ -195,14 +195,14 @@ export function ProjectsListPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="text-[var(--txt-secondary)]">Workspace not found.</div>
+      <div className="text-(--txt-secondary)">Workspace not found.</div>
     );
   }
 
@@ -238,7 +238,7 @@ export function ProjectsListPage() {
           return (
             <div
               key={project.id}
-              className="overflow-hidden rounded-xl bg-[var(--bg-surface-1)] shadow-sm"
+              className="overflow-hidden rounded-xl bg-(--bg-surface-1) shadow-sm"
             >
               <Link
                 to={`${baseUrl}/projects/${project.id}/issues`}
@@ -294,7 +294,7 @@ export function ProjectsListPage() {
                 </div>
                 {/* Description */}
                 <div className="px-4 py-3">
-                  <p className="line-clamp-2 text-sm text-[var(--txt-secondary)]">
+                  <p className="line-clamp-2 text-sm text-(--txt-secondary)">
                     {project.description || "No description"}
                   </p>
                 </div>
@@ -306,7 +306,7 @@ export function ProjectsListPage() {
                   className="flex min-w-0 flex-1 -space-x-2 no-underline"
                 >
                   {visibleMembers.length === 0 ? (
-                    <span className="text-xs text-[var(--txt-tertiary)]">
+                    <span className="text-xs text-(--txt-tertiary)">
                       No members
                     </span>
                   ) : (
@@ -317,12 +317,12 @@ export function ProjectsListPage() {
                           name={user.name}
                           src={user.avatarUrl}
                           size="sm"
-                          className="h-7 w-7 border-2 border-[var(--bg-surface-1)] text-[10px]"
+                          className="h-7 w-7 border-2 border-(--bg-surface-1) text-[10px]"
                         />
                       ))}
                       {extraCount > 0 && (
                         <span
-                          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 border-[var(--bg-surface-1)] bg-[var(--bg-layer-2)] text-[10px] font-medium text-[var(--txt-secondary)]"
+                          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 border-(--bg-surface-1) bg-(--bg-layer-2) text-[10px] font-medium text-(--txt-secondary)"
                           title={`${extraCount} more`}
                         >
                           +{extraCount}
@@ -333,7 +333,7 @@ export function ProjectsListPage() {
                 </Link>
                 <Link
                   to={`${baseUrl}/settings/projects/${project.id}`}
-                  className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                  className="flex size-8 shrink-0 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                   aria-label="Project settings"
                 >
                   <IconSettings />
@@ -344,7 +344,7 @@ export function ProjectsListPage() {
         })}
       </div>
       {projects.length === 0 && (
-        <p className="text-sm text-[var(--txt-tertiary)]">No projects yet.</p>
+        <p className="text-sm text-(--txt-tertiary)">No projects yet.</p>
       )}
     </div>
   );

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+﻿import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Link,
   useLocation,
@@ -1225,14 +1225,14 @@ export function SettingsPage() {
     : projectMembers;
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="px-[var(--padding-page)] py-8 text-[var(--txt-secondary)]">
+      <div className="px-(--padding-page) py-8 text-(--txt-secondary)">
         Workspace not found.
       </div>
     );
@@ -1273,15 +1273,15 @@ export function SettingsPage() {
   const projectsSettingsUrl = `/${workspace.slug}/settings/projects${projects.length ? `/${projects[0].id}` : ""}`;
 
   return (
-    <div className="min-h-0 flex-1 px-[var(--padding-page)] pb-8">
+    <div className="min-h-0 flex-1 px-(--padding-page) pb-8">
       {/* Main tabs: Account | Workspace | Projects */}
-      <div className="flex gap-1 border-b border-[var(--border-subtle)]">
+      <div className="flex gap-1 border-b border-(--border-subtle)">
         <Link
           to={accountSettingsUrl}
           className={`border-b-2 px-4 py-2.5 text-sm font-medium ${
             isAccountTab
-              ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-              : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+              ? "border-(--brand-default) text-(--txt-primary)"
+              : "border-transparent text-(--txt-secondary) hover:text-(--txt-primary)"
           }`}
         >
           Account
@@ -1290,8 +1290,8 @@ export function SettingsPage() {
           to={baseSettingsUrl}
           className={`border-b-2 px-4 py-2.5 text-sm font-medium ${
             !isAccountTab && !isProjectsTab
-              ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-              : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+              ? "border-(--brand-default) text-(--txt-primary)"
+              : "border-transparent text-(--txt-secondary) hover:text-(--txt-primary)"
           }`}
         >
           Workspace
@@ -1300,8 +1300,8 @@ export function SettingsPage() {
           to={projectsSettingsUrl}
           className={`border-b-2 px-4 py-2.5 text-sm font-medium ${
             isProjectsTab
-              ? "border-[var(--brand-default)] text-[var(--txt-primary)]"
-              : "border-transparent text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+              ? "border-(--brand-default) text-(--txt-primary)"
+              : "border-transparent text-(--txt-secondary) hover:text-(--txt-primary)"
           }`}
         >
           Projects
@@ -1321,16 +1321,16 @@ export function SettingsPage() {
                   size="sm"
                 />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
+                  <p className="truncate text-sm font-medium text-(--txt-primary)">
                     {displayName || user?.name}
                   </p>
-                  <p className="truncate text-xs text-[var(--txt-tertiary)]">
+                  <p className="truncate text-xs text-(--txt-tertiary)">
                     {user?.email}
                   </p>
                 </div>
               </div>
               <nav className="space-y-0.5">
-                <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-[var(--txt-tertiary)]">
+                <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-(--txt-tertiary)">
                   Your Profile
                 </p>
                 {ACCOUNT_SECTIONS_PROFILE.map(({ id, label, icon }) => (
@@ -1340,17 +1340,17 @@ export function SettingsPage() {
                     onClick={() => setAccountSection(id)}
                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors ${
                       accountSection === id
-                        ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                        : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                        ? "bg-(--brand-200) text-(--txt-primary)"
+                        : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-[var(--txt-icon-secondary)]">
+                    <span className="text-(--txt-icon-secondary)">
                       {icon}
                     </span>
                     {label}
                   </button>
                 ))}
-                <p className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-[var(--txt-tertiary)]">
+                <p className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-(--txt-tertiary)">
                   Developer
                 </p>
                 {ACCOUNT_SECTIONS_DEVELOPER.map(({ id, label, icon }) => (
@@ -1360,11 +1360,11 @@ export function SettingsPage() {
                     onClick={() => setAccountSection(id)}
                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors ${
                       accountSection === id
-                        ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                        : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                        ? "bg-(--brand-200) text-(--txt-primary)"
+                        : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-[var(--txt-icon-secondary)]">
+                    <span className="text-(--txt-icon-secondary)">
                       {icon}
                     </span>
                     {label}
@@ -1381,14 +1381,14 @@ export function SettingsPage() {
                   size="sm"
                 />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
+                  <p className="truncate text-sm font-medium text-(--txt-primary)">
                     {workspace.name}
                   </p>
-                  <p className="text-xs text-[var(--txt-tertiary)]">Admin</p>
+                  <p className="text-xs text-(--txt-tertiary)">Admin</p>
                 </div>
               </div>
               <nav className="space-y-0.5">
-                <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-[var(--txt-tertiary)]">
+                <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-(--txt-tertiary)">
                   Projects
                 </p>
                 {projects.map((proj) => {
@@ -1400,11 +1400,11 @@ export function SettingsPage() {
                         onClick={() => setProjectId(proj.id)}
                         className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors ${
                           isSelected
-                            ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                            : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                            ? "bg-(--brand-200) text-(--txt-primary)"
+                            : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                         }`}
                       >
-                        <span className="text-[var(--txt-icon-secondary)] flex shrink-0 items-center justify-center">
+                        <span className="text-(--txt-icon-secondary) flex shrink-0 items-center justify-center">
                           <ProjectIconDisplay
                             emoji={proj.emoji}
                             icon_prop={proj.icon_prop}
@@ -1412,12 +1412,12 @@ export function SettingsPage() {
                           />
                         </span>
                         <span className="min-w-0 truncate">{proj.name}</span>
-                        <span className="ml-auto shrink-0 text-xs text-[var(--txt-tertiary)]">
+                        <span className="ml-auto shrink-0 text-xs text-(--txt-tertiary)">
                           Admin
                         </span>
                       </button>
                       {isSelected && (
-                        <div className="ml-4 space-y-0.5 border-l border-[var(--border-subtle)] pl-2">
+                        <div className="ml-4 space-y-0.5 border-l border-(--border-subtle) pl-2">
                           {PROJECT_SECTIONS.map(({ id, label, icon }) => (
                             <button
                               key={id}
@@ -1425,11 +1425,11 @@ export function SettingsPage() {
                               onClick={() => setProjectSection(proj.id, id)}
                               className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm font-medium transition-colors ${
                                 projectSection === id
-                                  ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                                  : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                                  ? "bg-(--brand-200) text-(--txt-primary)"
+                                  : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                               }`}
                             >
-                              <span className="text-[var(--txt-icon-secondary)]">
+                              <span className="text-(--txt-icon-secondary)">
                                 {icon}
                               </span>
                               {label}
@@ -1451,14 +1451,14 @@ export function SettingsPage() {
                   size="sm"
                 />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-[var(--txt-primary)]">
+                  <p className="truncate text-sm font-medium text-(--txt-primary)">
                     {workspace.name}
                   </p>
-                  <p className="text-xs text-[var(--txt-tertiary)]">Admin</p>
+                  <p className="text-xs text-(--txt-tertiary)">Admin</p>
                 </div>
               </div>
               <nav className="space-y-0.5">
-                <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-[var(--txt-tertiary)]">
+                <p className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-(--txt-tertiary)">
                   Administration
                 </p>
                 {WORKSPACE_SECTIONS.slice(0, 4).map(({ id, label, icon }) => (
@@ -1468,17 +1468,17 @@ export function SettingsPage() {
                     onClick={() => setSection(id)}
                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors ${
                       section === id
-                        ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                        : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                        ? "bg-(--brand-200) text-(--txt-primary)"
+                        : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-[var(--txt-icon-secondary)]">
+                    <span className="text-(--txt-icon-secondary)">
                       {icon}
                     </span>
                     {label}
                   </button>
                 ))}
-                <p className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-[var(--txt-tertiary)]">
+                <p className="mb-2 mt-4 px-2 text-xs font-medium uppercase tracking-wider text-(--txt-tertiary)">
                   Developer
                 </p>
                 {WORKSPACE_SECTIONS.slice(4).map(({ id, label, icon }) => (
@@ -1488,11 +1488,11 @@ export function SettingsPage() {
                     onClick={() => setSection(id)}
                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors ${
                       section === id
-                        ? "bg-[var(--brand-200)] text-[var(--txt-primary)]"
-                        : "text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-primary)]"
+                        ? "bg-(--brand-200) text-(--txt-primary)"
+                        : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-[var(--txt-icon-secondary)]">
+                    <span className="text-(--txt-icon-secondary)">
                       {icon}
                     </span>
                     {label}
@@ -1507,10 +1507,10 @@ export function SettingsPage() {
         <main className="min-w-0 flex-1">
           {isAccountTab && accountSection === "profile" && (
             <div className="space-y-6">
-              <div className="relative h-48 rounded-[var(--radius-md)]">
+              <div className="relative h-48 rounded-(--radius-md)">
                 {/* Cover background (clipped to rounded corners; no overflow on outer so avatar can overlap) */}
                 <div
-                  className="absolute inset-0 overflow-hidden rounded-[var(--radius-md)] bg-[var(--bg-layer-2)]"
+                  className="absolute inset-0 overflow-hidden rounded-(--radius-md) bg-(--bg-layer-2)"
                   style={
                     getImageUrl(user?.coverImageUrl)
                       ? {
@@ -1522,7 +1522,7 @@ export function SettingsPage() {
                   }
                 >
                   {!getImageUrl(user?.coverImageUrl) && (
-                    <div className="absolute inset-0 bg-gradient-to-br from-[var(--neutral-800)] to-[var(--neutral-1000)]" />
+                    <div className="absolute inset-0 bg-gradient-to-br from-(--neutral-800) to-(--neutral-1000)" />
                   )}
                 </div>
                 <Button
@@ -1537,7 +1537,7 @@ export function SettingsPage() {
                   <button
                     type="button"
                     onClick={() => setAccountAvatarModalOpen(true)}
-                    className="block h-24 w-20 overflow-hidden rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--brand-default)]"
+                    className="block h-24 w-20 overflow-hidden rounded-xl focus:outline-none focus:ring-2 focus:ring-(--brand-default)"
                     aria-label="Change profile picture"
                   >
                     {getImageUrl(user?.avatarUrl) ? (
@@ -1547,7 +1547,7 @@ export function SettingsPage() {
                         className="h-full w-full object-cover"
                       />
                     ) : (
-                      <span className="flex h-full w-full items-center justify-center bg-[var(--bg-accent-primary)] text-sm font-medium text-[var(--txt-on-color)]">
+                      <span className="flex h-full w-full items-center justify-center bg-(--bg-accent-primary) text-sm font-medium text-(--txt-on-color)">
                         {(user?.name ?? "")
                           .split(/\s+/)
                           .map((p) => p[0])
@@ -1560,65 +1560,65 @@ export function SettingsPage() {
                 </div>
               </div>
               <div className="pt-10">
-                <h2 className="text-lg font-semibold text-[var(--txt-primary)]">
+                <h2 className="text-lg font-semibold text-(--txt-primary)">
                   {firstName} {lastName}
                 </h2>
-                <p className="text-sm text-[var(--txt-tertiary)]">
+                <p className="text-sm text-(--txt-tertiary)">
                   {user?.email}
                 </p>
               </div>
               <div className="grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     First name{" "}
-                    <span className="text-[var(--txt-danger-primary)]">*</span>
+                    <span className="text-(--txt-danger-primary)">*</span>
                   </label>
                   <input
                     type="text"
                     value={firstName}
                     onChange={(e) => setFirstName(e.target.value)}
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Last name
                   </label>
                   <input
                     type="text"
                     value={lastName}
                     onChange={(e) => setLastName(e.target.value)}
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Display name{" "}
-                    <span className="text-[var(--txt-danger-primary)]">*</span>
+                    <span className="text-(--txt-danger-primary)">*</span>
                   </label>
                   <input
                     type="text"
                     value={displayName}
                     onChange={(e) => setDisplayName(e.target.value)}
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="sm:col-span-2">
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Email{" "}
-                    <span className="text-[var(--txt-danger-primary)]">*</span>
+                    <span className="text-(--txt-danger-primary)">*</span>
                   </label>
                   <input
                     type="email"
                     value={profileEmail}
                     readOnly
                     disabled
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-2 text-sm text-[var(--txt-tertiary)] cursor-not-allowed"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-2 text-sm text-(--txt-tertiary) cursor-not-allowed"
                   />
                 </div>
               </div>
               {profileError && (
-                <p className="text-sm text-[var(--txt-danger-primary)]">
+                <p className="text-sm text-(--txt-danger-primary)">
                   {profileError}
                 </p>
               )}
@@ -1655,31 +1655,31 @@ export function SettingsPage() {
               </Button>
               <Card
                 variant="outlined"
-                className="border-[var(--border-subtle)]"
+                className="border-(--border-subtle)"
               >
                 <button
                   type="button"
                   onClick={() => setDeactivateOpen(!deactivateOpen)}
                   className="flex w-full items-center justify-between px-4 py-3 text-left"
                 >
-                  <span className="text-sm font-medium text-[var(--txt-danger-primary)]">
+                  <span className="text-sm font-medium text-(--txt-danger-primary)">
                     Deactivate account
                   </span>
                   <span
-                    className={`text-[var(--txt-icon-tertiary)] transition-transform ${deactivateOpen ? "rotate-180" : ""}`}
+                    className={`text-(--txt-icon-tertiary) transition-transform ${deactivateOpen ? "rotate-180" : ""}`}
                   >
                     <IconChevronDown />
                   </span>
                 </button>
                 {deactivateOpen && (
-                  <CardContent className="border-t border-[var(--border-subtle)] pt-3">
-                    <p className="text-sm text-[var(--txt-secondary)]">
+                  <CardContent className="border-t border-(--border-subtle) pt-3">
+                    <p className="text-sm text-(--txt-secondary)">
                       This action cannot be undone. Your account will be
                       deactivated.
                     </p>
                     <Button
                       variant="secondary"
-                      className="mt-3 text-[var(--txt-danger-primary)]"
+                      className="mt-3 text-(--txt-danger-primary)"
                     >
                       Deactivate account
                     </Button>
@@ -1720,19 +1720,19 @@ export function SettingsPage() {
           {isAccountTab && accountSection === "preferences" && (
             <div className="space-y-8">
               <div>
-                <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                <h2 className="text-base font-semibold text-(--txt-primary)">
                   Preferences
                 </h2>
-                <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                <p className="mt-0.5 text-sm text-(--txt-secondary)">
                   Customize your app experience the way you work
                 </p>
               </div>
               <div className="space-y-6">
                 <div>
-                  <label className="block text-sm font-medium text-[var(--txt-primary)]">
+                  <label className="block text-sm font-medium text-(--txt-primary)">
                     Theme
                   </label>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Select or customize your interface color scheme.
                   </p>
                   <div className="relative mt-2 max-w-xs">
@@ -1741,49 +1741,49 @@ export function SettingsPage() {
                       onChange={(e) =>
                         setTheme(e.target.value as "light" | "dark" | "system")
                       }
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <option value="light">Light</option>
                       <option value="dark">Dark</option>
                       <option value="system">System</option>
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-[var(--txt-primary)]">
+                  <label className="block text-sm font-medium text-(--txt-primary)">
                     First day of the week
                   </label>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     This will change how all calendars in your app look.
                   </p>
                   <div className="relative mt-2 max-w-xs">
                     <select
                       value={firstDayOfWeek}
                       onChange={(e) => setFirstDayOfWeek(e.target.value)}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <option value="sunday">Sunday</option>
                       <option value="monday">Monday</option>
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
                 </div>
               </div>
               <div>
-                <h3 className="text-sm font-semibold text-[var(--txt-primary)]">
+                <h3 className="text-sm font-semibold text-(--txt-primary)">
                   Language & Time
                 </h3>
                 <div className="mt-4 space-y-6">
                   <div>
-                    <label className="block text-sm font-medium text-[var(--txt-primary)]">
+                    <label className="block text-sm font-medium text-(--txt-primary)">
                       Timezone
                     </label>
-                    <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                    <p className="mt-0.5 text-sm text-(--txt-secondary)">
                       Current timezone setting.
                     </p>
                     <div
@@ -1793,20 +1793,20 @@ export function SettingsPage() {
                       <button
                         type="button"
                         onClick={() => setTimezoneDropdownOpen((o) => !o)}
-                        className="flex w-full items-center justify-between rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                        className="flex w-full items-center justify-between rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                       >
                         <span className="truncate">
                           {timezoneOptions.find((o) => o.value === timezone)
                             ?.label ?? timezone}
                         </span>
-                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                           <IconChevronDown />
                         </span>
                       </button>
                       {timezoneDropdownOpen && (
-                        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-lg">
-                          <div className="border-b border-[var(--border-subtle)] p-2">
-                            <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2 py-1.5">
+                        <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-hidden rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) shadow-lg">
+                          <div className="border-b border-(--border-subtle) p-2">
+                            <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2 py-1.5">
                               <IconSearch />
                               <input
                                 type="text"
@@ -1815,7 +1815,7 @@ export function SettingsPage() {
                                   setTimezoneSearch(e.target.value)
                                 }
                                 placeholder="Search"
-                                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] outline-none placeholder:text-[var(--txt-placeholder)]"
+                                className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) outline-none placeholder:text-(--txt-placeholder)"
                               />
                             </div>
                           </div>
@@ -1829,7 +1829,7 @@ export function SettingsPage() {
                                   setTimezoneDropdownOpen(false);
                                   setTimezoneSearch("");
                                 }}
-                                className={`w-full rounded-[var(--radius-md)] px-2 py-1.5 text-left text-sm ${o.value === timezone ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]" : "text-[var(--txt-primary)] hover:bg-[var(--bg-layer-transparent-hover)]"}`}
+                                className={`w-full rounded-(--radius-md) px-2 py-1.5 text-left text-sm ${o.value === timezone ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)" : "text-(--txt-primary) hover:bg-(--bg-layer-transparent-hover)"}`}
                               >
                                 {o.label}
                               </button>
@@ -1840,21 +1840,21 @@ export function SettingsPage() {
                     </div>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-[var(--txt-primary)]">
+                    <label className="block text-sm font-medium text-(--txt-primary)">
                       Language
                     </label>
-                    <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                    <p className="mt-0.5 text-sm text-(--txt-secondary)">
                       Choose the language used in the user interface.
                     </p>
                     <div className="relative mt-2 max-w-xs">
                       <select
                         value={language}
                         onChange={(e) => setLanguage(e.target.value)}
-                        className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                        className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                       >
                         <option value="en">English</option>
                       </select>
-                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                         <IconChevronDown />
                       </span>
                     </div>
@@ -1880,10 +1880,10 @@ export function SettingsPage() {
           {isAccountTab && accountSection === "notifications" && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                <h2 className="text-base font-semibold text-(--txt-primary)">
                   Email notifications
                 </h2>
-                <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                <p className="mt-0.5 text-sm text-(--txt-secondary)">
                   Stay in the loop on Work items you are subscribed to. Enable
                   this to get notified.
                 </p>
@@ -1933,13 +1933,13 @@ export function SettingsPage() {
                 ].map(({ id, label, desc, value, set, key }) => (
                   <div
                     key={id}
-                    className="flex items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3"
+                    className="flex items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3"
                   >
                     <div>
-                      <p className="text-sm font-medium text-[var(--txt-primary)]">
+                      <p className="text-sm font-medium text-(--txt-primary)">
                         {label}
                       </p>
-                      <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                      <p className="mt-0.5 text-sm text-(--txt-secondary)">
                         {desc}
                       </p>
                     </div>
@@ -1959,7 +1959,7 @@ export function SettingsPage() {
                           set(value);
                         }
                       }}
-                      className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${value ? "bg-[var(--brand-default)]" : "bg-[var(--neutral-400)]"}`}
+                      className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${value ? "bg-(--brand-default)" : "bg-(--neutral-400)"}`}
                     >
                       <span
                         className={`absolute top-1 left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${value ? "translate-x-4" : "translate-x-0"}`}
@@ -1973,12 +1973,12 @@ export function SettingsPage() {
 
           {isAccountTab && accountSection === "security" && (
             <div className="space-y-6">
-              <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+              <h2 className="text-base font-semibold text-(--txt-primary)">
                 Change password
               </h2>
               <div className="max-w-md space-y-4">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Current password
                   </label>
                   <div className="relative">
@@ -1987,12 +1987,12 @@ export function SettingsPage() {
                       value={currentPassword}
                       onChange={(e) => setCurrentPassword(e.target.value)}
                       placeholder="Old password"
-                      className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-9 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                     />
                     <button
                       type="button"
                       onClick={() => setShowCurrentPass(!showCurrentPass)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary) hover:text-(--txt-secondary)"
                       aria-label={
                         showCurrentPass ? "Hide password" : "Show password"
                       }
@@ -2002,7 +2002,7 @@ export function SettingsPage() {
                   </div>
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     New password
                   </label>
                   <div className="relative">
@@ -2011,12 +2011,12 @@ export function SettingsPage() {
                       value={newPassword}
                       onChange={(e) => setNewPassword(e.target.value)}
                       placeholder="Enter new password"
-                      className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-9 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                     />
                     <button
                       type="button"
                       onClick={() => setShowNewPass(!showNewPass)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary) hover:text-(--txt-secondary)"
                       aria-label={
                         showNewPass ? "Hide password" : "Show password"
                       }
@@ -2026,7 +2026,7 @@ export function SettingsPage() {
                   </div>
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Confirm password
                   </label>
                   <div className="relative">
@@ -2035,12 +2035,12 @@ export function SettingsPage() {
                       value={confirmPassword}
                       onChange={(e) => setConfirmPassword(e.target.value)}
                       placeholder="Confirm password"
-                      className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-9 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-9 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                     />
                     <button
                       type="button"
                       onClick={() => setShowConfirmPass(!showConfirmPass)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)] hover:text-[var(--txt-secondary)]"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary) hover:text-(--txt-secondary)"
                       aria-label={
                         showConfirmPass ? "Hide password" : "Show password"
                       }
@@ -2051,7 +2051,7 @@ export function SettingsPage() {
                 </div>
               </div>
               {changePasswordError && (
-                <p className="text-sm text-[var(--txt-danger-primary)]">
+                <p className="text-sm text-(--txt-danger-primary)">
                   {changePasswordError}
                 </p>
               )}
@@ -2110,22 +2110,22 @@ export function SettingsPage() {
           {isAccountTab && accountSection === "activity" && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                <h2 className="text-base font-semibold text-(--txt-primary)">
                   Activity
                 </h2>
-                <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                <p className="mt-0.5 text-sm text-(--txt-secondary)">
                   Track your recent actions and changes across all projects and
                   work items.
                 </p>
               </div>
               {activityLoading ? (
-                <div className="py-10 text-center text-sm text-[var(--txt-tertiary)]">
+                <div className="py-10 text-center text-sm text-(--txt-tertiary)">
                   Loading activity…
                 </div>
               ) : activityList.length === 0 ? (
                 <Card variant="outlined">
                   <CardContent className="py-10 text-center">
-                    <p className="text-sm text-[var(--txt-tertiary)]">
+                    <p className="text-sm text-(--txt-tertiary)">
                       No activity yet.
                     </p>
                   </CardContent>
@@ -2135,9 +2135,9 @@ export function SettingsPage() {
                   {activityList.map((a) => (
                     <div
                       key={a.id}
-                      className="flex gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3"
+                      className="flex gap-3 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3"
                     >
-                      <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-2)] text-[var(--txt-icon-tertiary)]">
+                      <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-2) text-(--txt-icon-tertiary)">
                         {a.type === "comment" ? (
                           <IconMessageCircle />
                         ) : (
@@ -2145,18 +2145,18 @@ export function SettingsPage() {
                         )}
                       </span>
                       <div className="min-w-0 flex-1">
-                        <p className="text-sm text-[var(--txt-secondary)]">
+                        <p className="text-sm text-(--txt-secondary)">
                           You commented {formatRelativeTime(a.created_at)}
                         </p>
                         {a.description && (
-                          <p className="mt-1 text-sm font-medium text-[var(--txt-primary)]">
+                          <p className="mt-1 text-sm font-medium text-(--txt-primary)">
                             {a.description}
                           </p>
                         )}
                         {a.issue_id && a.issue_name && workspaceSlug && (
                           <Link
                             to={`/${workspaceSlug}/projects/${a.project_id}/issues/${a.issue_id}`}
-                            className="mt-1 inline-block text-sm text-[var(--txt-accent-primary)] hover:underline"
+                            className="mt-1 inline-block text-sm text-(--txt-accent-primary) hover:underline"
                           >
                             {a.issue_name}
                           </Link>
@@ -2173,10 +2173,10 @@ export function SettingsPage() {
             <div className="space-y-6">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     Personal Access Tokens
                   </h2>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Generate secure API tokens to integrate your data with
                     external systems and applications.
                   </p>
@@ -2195,13 +2195,13 @@ export function SettingsPage() {
                 </Button>
               </div>
               {tokensLoading ? (
-                <div className="py-10 text-center text-sm text-[var(--txt-tertiary)]">
+                <div className="py-10 text-center text-sm text-(--txt-tertiary)">
                   Loading tokens…
                 </div>
               ) : tokensList.length === 0 ? (
                 <Card variant="outlined">
                   <CardContent className="py-10 text-center">
-                    <p className="text-sm text-[var(--txt-tertiary)]">
+                    <p className="text-sm text-(--txt-tertiary)">
                       No tokens yet.
                     </p>
                   </CardContent>
@@ -2211,25 +2211,25 @@ export function SettingsPage() {
                   {tokensList.map((t) => (
                     <div
                       key={t.id}
-                      className="flex items-center justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3"
+                      className="flex items-center justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3"
                     >
                       <div>
-                        <p className="text-sm font-medium text-[var(--txt-primary)]">
+                        <p className="text-sm font-medium text-(--txt-primary)">
                           {t.label}
                         </p>
                         {t.description && (
-                          <p className="text-xs text-[var(--txt-tertiary)]">
+                          <p className="text-xs text-(--txt-tertiary)">
                             {t.description}
                           </p>
                         )}
-                        <p className="mt-0.5 text-xs text-[var(--txt-placeholder)]">
+                        <p className="mt-0.5 text-xs text-(--txt-placeholder)">
                           Created {formatRelativeTime(t.created_at)}
                         </p>
                       </div>
                       <Button
                         variant="secondary"
                         size="sm"
-                        className="text-[var(--txt-danger-primary)]"
+                        className="text-(--txt-danger-primary)"
                         disabled={revokingId === t.id}
                         onClick={async () => {
                           setRevokingId(t.id);
@@ -2260,10 +2260,10 @@ export function SettingsPage() {
               >
                 {createdTokenValue ? (
                   <div className="space-y-4">
-                    <p className="text-sm text-[var(--txt-secondary)]">
+                    <p className="text-sm text-(--txt-secondary)">
                       Copy this token now; it will not be shown again.
                     </p>
-                    <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-2 font-mono text-sm text-[var(--txt-primary)] break-all">
+                    <div className="rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-2 font-mono text-sm text-(--txt-primary) break-all">
                       {createdTokenValue}
                     </div>
                     <div className="flex justify-end">
@@ -2280,7 +2280,7 @@ export function SettingsPage() {
                 ) : (
                   <div className="space-y-4">
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                      <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                         Title
                       </label>
                       <input
@@ -2290,11 +2290,11 @@ export function SettingsPage() {
                           setTokenForm((f) => ({ ...f, label: e.target.value }))
                         }
                         placeholder="Title"
-                        className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                        className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                       />
                     </div>
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                      <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                         Description
                       </label>
                       <textarea
@@ -2307,11 +2307,11 @@ export function SettingsPage() {
                         }
                         placeholder="Description"
                         rows={2}
-                        className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                        className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                       />
                     </div>
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                      <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                         Expiration
                       </label>
                       <div className="relative max-w-xs">
@@ -2323,7 +2323,7 @@ export function SettingsPage() {
                               expiresIn: e.target.value,
                             }))
                           }
-                          className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                          className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                         >
                           <option value="">Never expires</option>
                           <option value="7d">1 week</option>
@@ -2331,7 +2331,7 @@ export function SettingsPage() {
                           <option value="90d">3 months</option>
                           <option value="365d">1 year</option>
                         </select>
-                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                           <IconChevronDown />
                         </span>
                       </div>
@@ -2372,9 +2372,9 @@ export function SettingsPage() {
 
           {isProjectsTab && selectedProject && projectSection === "general" && (
             <div className="space-y-6">
-              <div className="relative h-48 rounded-[var(--radius-md)]">
+              <div className="relative h-48 rounded-(--radius-md)">
                 <div
-                  className="absolute inset-0 overflow-hidden rounded-[var(--radius-md)] bg-[var(--bg-layer-2)]"
+                  className="absolute inset-0 overflow-hidden rounded-(--radius-md) bg-(--bg-layer-2)"
                   style={
                     getImageUrl(selectedProject?.cover_image)
                       ? {
@@ -2386,7 +2386,7 @@ export function SettingsPage() {
                   }
                 >
                   {!getImageUrl(selectedProject?.cover_image) && (
-                    <div className="absolute inset-0 bg-gradient-to-br from-[var(--neutral-800)] to-[var(--neutral-1000)]" />
+                    <div className="absolute inset-0 bg-gradient-to-br from-(--neutral-800) to-(--neutral-1000)" />
                   )}
                 </div>
                 <Button
@@ -2422,18 +2422,18 @@ export function SettingsPage() {
               </div>
               <div className="pt-10 grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="sm:col-span-2">
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Project name
                   </label>
                   <input
                     type="text"
                     value={projectName || selectedProject.name}
                     onChange={(e) => setProjectName(e.target.value)}
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div className="sm:col-span-2">
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Description
                   </label>
                   <textarea
@@ -2443,11 +2443,11 @@ export function SettingsPage() {
                     onChange={(e) => setProjectDescription(e.target.value)}
                     rows={3}
                     placeholder="Description..."
-                    className="w-full resize-y rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full resize-y rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Project ID
                   </label>
                   <div className="flex items-center gap-1.5">
@@ -2455,10 +2455,10 @@ export function SettingsPage() {
                       type="text"
                       readOnly
                       value={selectedProject.identifier}
-                      className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-2 text-sm text-[var(--txt-tertiary)]"
+                      className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-2 text-sm text-(--txt-tertiary)"
                     />
                     <span
-                      className="text-[var(--txt-icon-tertiary)]"
+                      className="text-(--txt-icon-tertiary)"
                       title="Project identifier"
                     >
                       <IconInfo />
@@ -2490,7 +2490,7 @@ export function SettingsPage() {
                   }}
                 />
                 <div className="sm:col-span-2">
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Project Timezone
                   </label>
                   <div
@@ -2500,21 +2500,21 @@ export function SettingsPage() {
                     <button
                       type="button"
                       onClick={() => setProjectTimezoneDropdownOpen((o) => !o)}
-                      className="flex w-full items-center justify-between rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="flex w-full items-center justify-between rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <span className="truncate">
                         {timezoneOptions.find(
                           (o) => o.value === projectTimezone,
                         )?.label ?? projectTimezone}
                       </span>
-                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                         <IconChevronDown />
                       </span>
                     </button>
                     {projectTimezoneDropdownOpen && (
-                      <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] shadow-lg">
-                        <div className="border-b border-[var(--border-subtle)] p-2">
-                          <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2 py-1.5">
+                      <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-hidden rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) shadow-lg">
+                        <div className="border-b border-(--border-subtle) p-2">
+                          <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2 py-1.5">
                             <IconSearch />
                             <input
                               type="text"
@@ -2523,7 +2523,7 @@ export function SettingsPage() {
                                 setProjectTimezoneSearch(e.target.value)
                               }
                               placeholder="Search"
-                              className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] outline-none placeholder:text-[var(--txt-placeholder)]"
+                              className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) outline-none placeholder:text-(--txt-placeholder)"
                             />
                           </div>
                         </div>
@@ -2537,7 +2537,7 @@ export function SettingsPage() {
                                 setProjectTimezoneDropdownOpen(false);
                                 setProjectTimezoneSearch("");
                               }}
-                              className={`w-full rounded-[var(--radius-md)] px-2 py-1.5 text-left text-sm ${o.value === projectTimezone ? "bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]" : "text-[var(--txt-primary)] hover:bg-[var(--bg-layer-transparent-hover)]"}`}
+                              className={`w-full rounded-(--radius-md) px-2 py-1.5 text-left text-sm ${o.value === projectTimezone ? "bg-(--bg-accent-subtle) text-(--txt-accent-primary)" : "text-(--txt-primary) hover:bg-(--bg-layer-transparent-hover)"}`}
                             >
                               {o.label}
                             </button>
@@ -2549,7 +2549,7 @@ export function SettingsPage() {
                 </div>
               </div>
               {projectUpdateError && (
-                <p className="text-sm text-[var(--txt-danger-primary)]">
+                <p className="text-sm text-(--txt-danger-primary)">
                   {projectUpdateError}
                 </p>
               )}
@@ -2593,7 +2593,7 @@ export function SettingsPage() {
                 {projectUpdateLoading ? "Updating…" : "Update project"}
               </Button>
               {selectedProject?.created_at && (
-                <p className="text-sm text-[var(--txt-tertiary)]">
+                <p className="text-sm text-(--txt-tertiary)">
                   Created on{" "}
                   {new Date(selectedProject.created_at).toLocaleDateString(
                     "en-US",
@@ -2657,16 +2657,16 @@ export function SettingsPage() {
 
           {isProjectsTab && selectedProject && projectSection === "members" && (
             <div className="space-y-6">
-              <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+              <h2 className="text-base font-semibold text-(--txt-primary)">
                 Members
               </h2>
               <div className="space-y-6">
-                <div className="flex flex-wrap items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3">
+                <div className="flex flex-wrap items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
                   <div>
-                    <p className="text-sm font-medium text-[var(--txt-primary)]">
+                    <p className="text-sm font-medium text-(--txt-primary)">
                       Project Lead
                     </p>
-                    <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                    <p className="mt-0.5 text-sm text-(--txt-secondary)">
                       Select the project lead for the project.
                     </p>
                   </div>
@@ -2693,7 +2693,7 @@ export function SettingsPage() {
                           setProjectLeadId(previous);
                         }
                       }}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <option value="">Select</option>
                       {workspaceMembers.map((m) => (
@@ -2702,17 +2702,17 @@ export function SettingsPage() {
                         </option>
                       ))}
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
                 </div>
-                <div className="flex flex-wrap items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3">
+                <div className="flex flex-wrap items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
                   <div>
-                    <p className="text-sm font-medium text-[var(--txt-primary)]">
+                    <p className="text-sm font-medium text-(--txt-primary)">
                       Default Assignee
                     </p>
-                    <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                    <p className="mt-0.5 text-sm text-(--txt-secondary)">
                       Select the default assignee for the project.
                     </p>
                   </div>
@@ -2740,7 +2740,7 @@ export function SettingsPage() {
                           setDefaultAssigneeId(previous);
                         }
                       }}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <option value="none">None</option>
                       {workspaceMembers.map((m) => (
@@ -2749,17 +2749,17 @@ export function SettingsPage() {
                         </option>
                       ))}
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
                 </div>
-                <div className="flex flex-wrap items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3">
+                <div className="flex flex-wrap items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
                   <div>
-                    <p className="text-sm font-medium text-[var(--txt-primary)]">
+                    <p className="text-sm font-medium text-(--txt-primary)">
                       Guest access
                     </p>
-                    <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                    <p className="mt-0.5 text-sm text-(--txt-secondary)">
                       This will allow guests to have view access to all the
                       project work items.
                     </p>
@@ -2785,7 +2785,7 @@ export function SettingsPage() {
                         setGuestAccess(guestAccess);
                       }
                     }}
-                    className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${guestAccess ? "bg-[var(--brand-default)]" : "bg-[var(--neutral-400)]"}`}
+                    className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${guestAccess ? "bg-(--brand-default)" : "bg-(--neutral-400)"}`}
                   >
                     <span
                       className={`absolute top-1 left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${guestAccess ? "translate-x-4" : "translate-x-0"}`}
@@ -2794,12 +2794,12 @@ export function SettingsPage() {
                 </div>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-4">
-                <h3 className="text-sm font-semibold text-[var(--txt-primary)]">
+                <h3 className="text-sm font-semibold text-(--txt-primary)">
                   Members
                 </h3>
                 <div className="flex items-center gap-2">
-                  <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1.5">
-                    <span className="text-[var(--txt-icon-tertiary)]">
+                  <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1.5">
+                    <span className="text-(--txt-icon-tertiary)">
                       <IconSearch />
                     </span>
                     <input
@@ -2807,7 +2807,7 @@ export function SettingsPage() {
                       value={projectMembersSearch}
                       onChange={(e) => setProjectMembersSearch(e.target.value)}
                       placeholder="Search"
-                      className="w-32 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                      className="w-32 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                     />
                   </div>
                   <Button
@@ -2826,17 +2826,17 @@ export function SettingsPage() {
                 <div className="overflow-x-auto">
                   <table className="w-full text-left text-sm">
                     <thead>
-                      <tr className="border-b border-[var(--border-subtle)]">
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                      <tr className="border-b border-(--border-subtle)">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Full name
                         </th>
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Display name
                         </th>
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Account type
                         </th>
-                        <th className="py-3 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 font-medium text-(--txt-secondary)">
                           Joining date
                         </th>
                       </tr>
@@ -2850,12 +2850,12 @@ export function SettingsPage() {
                                 name={memberLabel(m.member_id)}
                                 size="sm"
                               />
-                              <span className="text-[var(--txt-primary)]">
+                              <span className="text-(--txt-primary)">
                                 {memberLabel(m.member_id)}
                               </span>
                             </div>
                           </td>
-                          <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                          <td className="py-3 pr-4 text-(--txt-secondary)">
                             {memberLabel(m.member_id)}
                           </td>
                           <td className="py-3 pr-4">
@@ -2890,17 +2890,17 @@ export function SettingsPage() {
                                     // could toast
                                   }
                                 }}
-                                className="w-full appearance-none rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1.5 pl-2.5 pr-7 text-sm capitalize text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                                className="w-full appearance-none rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1.5 pl-2.5 pr-7 text-sm capitalize text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                               >
                                 <option value="member">Member</option>
                                 <option value="admin">Admin</option>
                               </select>
-                              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                                 <IconChevronDown />
                               </span>
                             </div>
                           </td>
-                          <td className="py-3 text-[var(--txt-secondary)]">
+                          <td className="py-3 text-(--txt-secondary)">
                             {m.created_at
                               ? new Date(m.created_at).toLocaleDateString(
                                   "en-US",
@@ -2920,19 +2920,19 @@ export function SettingsPage() {
               </Card>
               {pendingProjectInvites.length > 0 && (
                 <div className="mt-6">
-                  <h3 className="text-sm font-semibold text-[var(--txt-primary)] mb-2">
+                  <h3 className="text-sm font-semibold text-(--txt-primary) mb-2">
                     Pending invites
                   </h3>
                   <div className="space-y-2">
                     {pendingProjectInvites.map((inv) => (
                       <div
                         key={inv.id}
-                        className="flex items-center justify-between gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3"
+                        className="flex items-center justify-between gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
                       >
-                        <span className="text-sm text-[var(--txt-primary)]">
+                        <span className="text-sm text-(--txt-primary)">
                           {inv.email}
                         </span>
-                        <span className="rounded-full bg-[var(--bg-warning-subtle)] px-2.5 py-0.5 text-xs font-medium text-[var(--txt-warning-primary)]">
+                        <span className="rounded-full bg-(--bg-warning-subtle) px-2.5 py-0.5 text-xs font-medium text-(--txt-warning-primary)">
                           Pending
                         </span>
                         <Button
@@ -2971,10 +2971,10 @@ export function SettingsPage() {
             projectSection === "features" && (
               <div className="space-y-8">
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     Projects and work items
                   </h2>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Toggle these on or off this project.
                   </p>
                 </div>
@@ -3023,10 +3023,10 @@ export function SettingsPage() {
                   ].map(({ id, label, desc, value, set, key }) => (
                     <div
                       key={id}
-                      className="flex items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3"
+                      className="flex items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3"
                     >
                       <div className="flex items-start gap-3">
-                        <span className="text-[var(--txt-icon-tertiary)]">
+                        <span className="text-(--txt-icon-tertiary)">
                           {id === "cycles" && <IconClock />}
                           {id === "modules" && <IconGrid />}
                           {id === "views" && <IconLayers />}
@@ -3034,10 +3034,10 @@ export function SettingsPage() {
                           {id === "intake" && <IconInbox />}
                         </span>
                         <div>
-                          <p className="text-sm font-medium text-[var(--txt-primary)]">
+                          <p className="text-sm font-medium text-(--txt-primary)">
                             {label}
                           </p>
-                          <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                          <p className="mt-0.5 text-sm text-(--txt-secondary)">
                             {desc}
                           </p>
                         </div>
@@ -3065,7 +3065,7 @@ export function SettingsPage() {
                             set(value);
                           }
                         }}
-                        className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${value ? "bg-[var(--brand-default)]" : "bg-[var(--neutral-400)]"}`}
+                        className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${value ? "bg-(--brand-default)" : "bg-(--neutral-400)"}`}
                       >
                         <span
                           className={`absolute top-1 left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${value ? "translate-x-4" : "translate-x-0"}`}
@@ -3075,23 +3075,23 @@ export function SettingsPage() {
                   ))}
                 </div>
                 <div>
-                  <h3 className="text-sm font-semibold text-[var(--txt-primary)]">
+                  <h3 className="text-sm font-semibold text-(--txt-primary)">
                     Work management
                   </h3>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Manage your work and projects with ease.
                   </p>
                 </div>
-                <div className="flex items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3">
+                <div className="flex items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
                   <div className="flex items-start gap-3">
-                    <span className="text-[var(--txt-icon-tertiary)]">
+                    <span className="text-(--txt-icon-tertiary)">
                       <IconClock />
                     </span>
                     <div>
-                      <p className="text-sm font-medium text-[var(--txt-primary)]">
+                      <p className="text-sm font-medium text-(--txt-primary)">
                         Time Tracking
                       </p>
-                      <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                      <p className="mt-0.5 text-sm text-(--txt-secondary)">
                         Log time spent on work items and projects.
                       </p>
                     </div>
@@ -3117,7 +3117,7 @@ export function SettingsPage() {
                         setFeatureTimeTracking(featureTimeTracking);
                       }
                     }}
-                    className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${featureTimeTracking ? "bg-[var(--brand-default)]" : "bg-[var(--neutral-400)]"}`}
+                    className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${featureTimeTracking ? "bg-(--brand-default)" : "bg-(--neutral-400)"}`}
                   >
                     <span
                       className={`absolute top-1 left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${featureTimeTracking ? "translate-x-4" : "translate-x-0"}`}
@@ -3131,10 +3131,10 @@ export function SettingsPage() {
             <div className="space-y-6">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     States
                   </h2>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Define and customize workflow states to track the progress
                     of your work items.
                   </p>
@@ -3177,12 +3177,12 @@ export function SettingsPage() {
                     const states = byGroup[group] ?? [];
                     return (
                       <div key={group}>
-                        <h3 className="text-sm font-medium text-[var(--txt-secondary)] mb-2 capitalize">
+                        <h3 className="text-sm font-medium text-(--txt-secondary) mb-2 capitalize">
                           {group}
                         </h3>
                         <div className="space-y-2">
                           {states.length === 0 ? (
-                            <p className="text-sm text-[var(--txt-tertiary)] py-2">
+                            <p className="text-sm text-(--txt-tertiary) py-2">
                               No states in this group.
                             </p>
                           ) : (
@@ -3200,7 +3200,7 @@ export function SettingsPage() {
                                         st.color ?? "var(--border-subtle)",
                                     }}
                                   />
-                                  <span className="text-sm font-medium text-[var(--txt-primary)]">
+                                  <span className="text-sm font-medium text-(--txt-primary)">
                                     {st.name}
                                   </span>
                                 </div>
@@ -3225,7 +3225,7 @@ export function SettingsPage() {
                                   <Button
                                     size="sm"
                                     variant="secondary"
-                                    className="text-[var(--txt-danger-primary)]"
+                                    className="text-(--txt-danger-primary)"
                                     onClick={async () => {
                                       if (!workspaceSlug || !selectedProjectId)
                                         return;
@@ -3264,10 +3264,10 @@ export function SettingsPage() {
             <div className="space-y-6">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     Labels
                   </h2>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Create custom labels to categorize and organize your work
                     items.
                   </p>
@@ -3300,7 +3300,7 @@ export function SettingsPage() {
                             label.color ?? "var(--border-subtle)",
                         }}
                       />
-                      <span className="text-sm font-medium capitalize text-[var(--txt-primary)]">
+                      <span className="text-sm font-medium capitalize text-(--txt-primary)">
                         {label.name}
                       </span>
                     </div>
@@ -3320,7 +3320,7 @@ export function SettingsPage() {
                       <Button
                         size="sm"
                         variant="secondary"
-                        className="text-[var(--txt-danger-primary)]"
+                        className="text-(--txt-danger-primary)"
                         onClick={async () => {
                           if (!workspaceSlug || !selectedProjectId) return;
                           try {
@@ -3353,14 +3353,14 @@ export function SettingsPage() {
             projectSection === "estimates" && (
               <div className="space-y-6">
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     Estimates
                   </h2>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Set up estimation systems to track and communicate the
                     effort required for each work item.
                   </p>
-                  <p className="mt-2 text-sm text-[var(--txt-tertiary)]">
+                  <p className="mt-2 text-sm text-(--txt-tertiary)">
                     Estimate systems will be available when the API is
                     connected.
                   </p>
@@ -3371,28 +3371,28 @@ export function SettingsPage() {
                   </Button>
                 </div>
                 <Card variant="outlined" className="p-4">
-                  <p className="text-sm font-medium text-[var(--txt-primary)] mb-3">
+                  <p className="text-sm font-medium text-(--txt-primary) mb-3">
                     New Estimate
                   </p>
                   <div className="space-y-3">
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                      <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                         T-Shirt sizes
                       </label>
                       <input
                         type="text"
                         defaultValue="T-Shirt sizes"
-                        className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                        className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                       />
                     </div>
                     <div>
-                      <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                      <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                         Description
                       </label>
                       <textarea
                         rows={2}
                         placeholder="Description..."
-                        className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                        className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
                       />
                     </div>
                     <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
@@ -3402,16 +3402,16 @@ export function SettingsPage() {
                             key={v}
                             type="text"
                             defaultValue={v}
-                            className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                            className="rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                           />
                         ),
                       )}
                     </div>
                     <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
-                      <label className="flex items-center gap-2 text-sm text-[var(--txt-secondary)]">
+                      <label className="flex items-center gap-2 text-sm text-(--txt-secondary)">
                         <input
                           type="checkbox"
-                          className="rounded border-[var(--border-subtle)]"
+                          className="rounded border-(--border-subtle)"
                         />
                         Create more
                       </label>
@@ -3437,25 +3437,25 @@ export function SettingsPage() {
             projectSection === "automations" && (
               <div className="space-y-6">
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     Automations
                   </h2>
-                  <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                  <p className="mt-0.5 text-sm text-(--txt-secondary)">
                     Configure automated actions to streamline your project
                     management workflow and reduce manual tasks.
                   </p>
                 </div>
                 <div className="space-y-3">
-                  <div className="flex items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3">
+                  <div className="flex items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
                     <div className="flex items-start gap-3">
-                      <span className="text-[var(--txt-icon-tertiary)]">
+                      <span className="text-(--txt-icon-tertiary)">
                         <IconArchive />
                       </span>
                       <div>
-                        <p className="text-sm font-medium text-[var(--txt-primary)]">
+                        <p className="text-sm font-medium text-(--txt-primary)">
                           Auto-archive closed work items
                         </p>
-                        <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                        <p className="mt-0.5 text-sm text-(--txt-secondary)">
                           Devlane will auto archive work items that have been
                           completed or canceled.
                         </p>
@@ -3466,23 +3466,23 @@ export function SettingsPage() {
                       role="switch"
                       aria-checked={autoArchive}
                       onClick={() => setAutoArchive(!autoArchive)}
-                      className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${autoArchive ? "bg-[var(--brand-default)]" : "bg-[var(--neutral-400)]"}`}
+                      className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${autoArchive ? "bg-(--brand-default)" : "bg-(--neutral-400)"}`}
                     >
                       <span
                         className={`absolute top-1 left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${autoArchive ? "translate-x-4" : "translate-x-0"}`}
                       />
                     </button>
                   </div>
-                  <div className="flex items-start justify-between gap-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-4 py-3">
+                  <div className="flex items-start justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
                     <div className="flex items-start gap-3">
-                      <span className="text-[var(--txt-icon-tertiary)]">
+                      <span className="text-(--txt-icon-tertiary)">
                         <IconTrash />
                       </span>
                       <div>
-                        <p className="text-sm font-medium text-[var(--txt-primary)]">
+                        <p className="text-sm font-medium text-(--txt-primary)">
                           Auto-close work items
                         </p>
-                        <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                        <p className="mt-0.5 text-sm text-(--txt-secondary)">
                           Devlane will automatically close work items that
                           haven&apos;t been completed or canceled.
                         </p>
@@ -3493,7 +3493,7 @@ export function SettingsPage() {
                       role="switch"
                       aria-checked={autoClose}
                       onClick={() => setAutoClose(!autoClose)}
-                      className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${autoClose ? "bg-[var(--brand-default)]" : "bg-[var(--neutral-400)]"}`}
+                      className={`relative h-6 w-10 shrink-0 rounded-full transition-colors ${autoClose ? "bg-(--brand-default)" : "bg-(--neutral-400)"}`}
                     >
                       <span
                         className={`absolute top-1 left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${autoClose ? "translate-x-4" : "translate-x-0"}`}
@@ -3507,7 +3507,7 @@ export function SettingsPage() {
           {!isAccountTab && !isProjectsTab && section === "general" && (
             <div className="space-y-8">
               <div className="flex items-start gap-4">
-                <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-[var(--bg-layer-2)] text-lg font-semibold text-[var(--txt-secondary)]">
+                <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-(--bg-layer-2) text-lg font-semibold text-(--txt-secondary)">
                   {workspace?.logo && getImageUrl(workspace.logo) ? (
                     <img
                       src={getImageUrl(workspace.logo)!}
@@ -3519,16 +3519,16 @@ export function SettingsPage() {
                   )}
                 </div>
                 <div>
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     {workspaceDisplayName}
                   </h2>
-                  <p className="text-sm text-[var(--txt-tertiary)]">
+                  <p className="text-sm text-(--txt-tertiary)">
                     {workspaceUrl}
                   </p>
                   <button
                     type="button"
                     onClick={() => setWorkspaceLogoModalOpen(true)}
-                    className="mt-1 flex items-center gap-1 text-sm font-medium text-[var(--txt-accent-primary)] hover:underline"
+                    className="mt-1 flex items-center gap-1 text-sm font-medium text-(--txt-accent-primary) hover:underline"
                   >
                     <IconPencil />
                     Edit logo
@@ -3537,25 +3537,25 @@ export function SettingsPage() {
               </div>
               <div className="grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-3">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Workspace name
                   </label>
                   <input
                     type="text"
                     value={workspaceName || workspace.name}
                     onChange={(e) => setWorkspaceName(e.target.value)}
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Company size
                   </label>
                   <div className="relative">
                     <select
                       value={companySize}
                       onChange={(e) => setCompanySize(e.target.value)}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       {COMPANY_SIZES.map((s) => (
                         <option key={s} value={s}>
@@ -3563,25 +3563,25 @@ export function SettingsPage() {
                         </option>
                       ))}
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Workspace URL
                   </label>
                   <input
                     type="text"
                     readOnly
                     value={workspaceUrl}
-                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-3 py-2 text-sm text-[var(--txt-tertiary)]"
+                    className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-3 py-2 text-sm text-(--txt-tertiary)"
                   />
                 </div>
               </div>
               {generalUpdateError && (
-                <p className="text-sm text-[var(--txt-danger-primary)]">
+                <p className="text-sm text-(--txt-danger-primary)">
                   {generalUpdateError}
                 </p>
               )}
@@ -3611,31 +3611,31 @@ export function SettingsPage() {
               </Button>
               <Card
                 variant="outlined"
-                className="border-[var(--border-subtle)]"
+                className="border-(--border-subtle)"
               >
                 <button
                   type="button"
                   onClick={() => setDeleteWorkspaceOpen(!deleteWorkspaceOpen)}
                   className="flex w-full items-center justify-between px-4 py-3 text-left"
                 >
-                  <span className="text-sm font-medium text-[var(--txt-danger-primary)]">
+                  <span className="text-sm font-medium text-(--txt-danger-primary)">
                     Delete this workspace
                   </span>
                   <span
-                    className={`text-[var(--txt-icon-tertiary)] transition-transform ${deleteWorkspaceOpen ? "rotate-180" : ""}`}
+                    className={`text-(--txt-icon-tertiary) transition-transform ${deleteWorkspaceOpen ? "rotate-180" : ""}`}
                   >
                     <IconChevronDown />
                   </span>
                 </button>
                 {deleteWorkspaceOpen && (
-                  <CardContent className="border-t border-[var(--border-subtle)] pt-3">
-                    <p className="text-sm text-[var(--txt-secondary)]">
+                  <CardContent className="border-t border-(--border-subtle) pt-3">
+                    <p className="text-sm text-(--txt-secondary)">
                       This action cannot be undone. All projects and data in
                       this workspace will be permanently removed.
                     </p>
                     <Button
                       variant="secondary"
-                      className="mt-3 text-[var(--txt-danger-primary)]"
+                      className="mt-3 text-(--txt-danger-primary)"
                     >
                       Delete workspace
                     </Button>
@@ -3667,16 +3667,16 @@ export function SettingsPage() {
             <div className="space-y-6">
               <div className="flex flex-wrap items-center justify-between gap-4">
                 <div className="flex items-center gap-2">
-                  <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                  <h2 className="text-base font-semibold text-(--txt-primary)">
                     Members
                   </h2>
-                  <span className="rounded-full bg-[var(--brand-200)] px-2 py-0.5 text-xs font-medium text-[var(--txt-primary)]">
+                  <span className="rounded-full bg-(--brand-200) px-2 py-0.5 text-xs font-medium text-(--txt-primary)">
                     {workspaceMembers.length}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1.5">
-                    <span className="text-[var(--txt-icon-tertiary)]">
+                  <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1.5">
+                    <span className="text-(--txt-icon-tertiary)">
                       <IconSearch />
                     </span>
                     <input
@@ -3684,7 +3684,7 @@ export function SettingsPage() {
                       value={membersSearch}
                       onChange={(e) => setMembersSearch(e.target.value)}
                       placeholder="Search..."
-                      className="w-40 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                      className="w-40 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                     />
                   </div>
                   <Button
@@ -3704,23 +3704,23 @@ export function SettingsPage() {
                 <div className="overflow-x-auto">
                   <table className="w-full text-left text-sm">
                     <thead>
-                      <tr className="border-b border-[var(--border-subtle)]">
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                      <tr className="border-b border-(--border-subtle)">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Full name
                         </th>
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Display name
                         </th>
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Email address
                         </th>
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Account type
                         </th>
-                        <th className="py-3 pr-4 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 pr-4 font-medium text-(--txt-secondary)">
                           Authentication
                         </th>
-                        <th className="py-3 font-medium text-[var(--txt-secondary)]">
+                        <th className="py-3 font-medium text-(--txt-secondary)">
                           Joining date
                         </th>
                       </tr>
@@ -3734,16 +3734,16 @@ export function SettingsPage() {
                                 name={memberLabel(m.member_id)}
                                 size="sm"
                               />
-                              <span className="text-[var(--txt-primary)]">
+                              <span className="text-(--txt-primary)">
                                 {memberLabel(m.member_id)}
                               </span>
                             </div>
                           </td>
-                          <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                          <td className="py-3 pr-4 text-(--txt-secondary)">
                             {m.member_display_name?.trim() ||
                               memberLabel(m.member_id)}
                           </td>
-                          <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                          <td className="py-3 pr-4 text-(--txt-secondary)">
                             {m.member_email ?? "—"}
                           </td>
                           <td className="py-3 pr-4">
@@ -3771,20 +3771,20 @@ export function SettingsPage() {
                                     // could toast or set per-row error
                                   }
                                 }}
-                                className="w-full appearance-none rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1.5 pl-2.5 pr-7 text-sm capitalize text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                                className="w-full appearance-none rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1.5 pl-2.5 pr-7 text-sm capitalize text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                               >
                                 <option value="member">Member</option>
                                 <option value="admin">Admin</option>
                               </select>
-                              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                                 <IconChevronDown />
                               </span>
                             </div>
                           </td>
-                          <td className="py-3 pr-4 text-[var(--txt-secondary)]">
+                          <td className="py-3 pr-4 text-(--txt-secondary)">
                             Email
                           </td>
-                          <td className="py-3 text-[var(--txt-secondary)]">
+                          <td className="py-3 text-(--txt-secondary)">
                             {m.created_at
                               ? new Date(m.created_at).toLocaleDateString(
                                   "en-US",
@@ -3806,13 +3806,13 @@ export function SettingsPage() {
                 <button
                   type="button"
                   onClick={() => setPendingInvitesExpanded((e) => !e)}
-                  className="flex w-full items-center gap-2 rounded-md py-2 text-left text-sm font-semibold text-[var(--txt-primary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                  className="flex w-full items-center gap-2 rounded-md py-2 text-left text-sm font-semibold text-(--txt-primary) hover:bg-(--bg-layer-transparent-hover)"
                 >
                   Pending invites
-                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--brand-200)] px-2 py-0.5 text-xs font-medium text-[var(--brand-default)]">
+                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-(--brand-200) px-2 py-0.5 text-xs font-medium text-(--brand-default)">
                     {pendingInvites.length}
                   </span>
-                  <span className="ml-auto flex size-5 items-center justify-center text-[var(--txt-icon-tertiary)]">
+                  <span className="ml-auto flex size-5 items-center justify-center text-(--txt-icon-tertiary)">
                     {pendingInvitesExpanded ? (
                       <IconChevronUp />
                     ) : (
@@ -3823,7 +3823,7 @@ export function SettingsPage() {
                 {pendingInvitesExpanded && (
                   <div className="mt-2 space-y-2">
                     {pendingInvites.length === 0 ? (
-                      <p className="py-4 text-sm text-[var(--txt-tertiary)]">
+                      <p className="py-4 text-sm text-(--txt-tertiary)">
                         No pending invites.
                       </p>
                     ) : (
@@ -3832,26 +3832,26 @@ export function SettingsPage() {
                         return (
                           <div
                             key={inv.id}
-                            className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-3"
+                            className="flex items-center gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
                           >
-                            <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--bg-layer-2)] text-sm font-medium text-[var(--txt-secondary)]">
+                            <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-(--bg-layer-2) text-sm font-medium text-(--txt-secondary)">
                               {initial}
                             </div>
-                            <span className="min-w-0 flex-1 truncate text-sm text-[var(--txt-primary)]">
+                            <span className="min-w-0 flex-1 truncate text-sm text-(--txt-primary)">
                               {inv.email}
                             </span>
-                            <span className="shrink-0 rounded-full bg-[var(--bg-warning-subtle)] px-2.5 py-0.5 text-xs font-medium text-[var(--txt-warning-primary)]">
+                            <span className="shrink-0 rounded-full bg-(--bg-warning-subtle) px-2.5 py-0.5 text-xs font-medium text-(--txt-warning-primary)">
                               Pending
                             </span>
                             <div className="relative shrink-0 min-w-[100px]">
                               <select
                                 defaultValue={roleLabel(inv.role)}
-                                className="w-full appearance-none rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1.5 pl-2.5 pr-7 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                                className="w-full appearance-none rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1.5 pl-2.5 pr-7 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                               >
                                 <option value="member">Member</option>
                                 <option value="admin">Admin</option>
                               </select>
-                              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                                 <IconChevronDown />
                               </span>
                             </div>
@@ -3865,7 +3865,7 @@ export function SettingsPage() {
                             >
                               <button
                                 type="button"
-                                className="flex size-8 shrink-0 items-center justify-center rounded-md text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                                className="flex size-8 shrink-0 items-center justify-center rounded-md text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                                 aria-label="More options"
                                 aria-expanded={pendingInviteMenuId === inv.id}
                                 onClick={(e) => {
@@ -3879,14 +3879,14 @@ export function SettingsPage() {
                               </button>
                               {pendingInviteMenuId === inv.id && (
                                 <div
-                                  className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-lg"
+                                  className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-lg"
                                   role="menu"
                                   onClick={(e) => e.stopPropagation()}
                                 >
                                   <button
                                     type="button"
                                     role="menuitem"
-                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
                                     onClick={async () => {
                                       setPendingInviteMenuId(null);
                                       const url = `${window.location.origin}/invite?token=${inv.token}`;
@@ -3905,7 +3905,7 @@ export function SettingsPage() {
                                   <button
                                     type="button"
                                     role="menuitem"
-                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--txt-destructive)] hover:bg-[var(--bg-destructive-subtle)]"
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-(--txt-destructive) hover:bg-(--bg-destructive-subtle)"
                                     onClick={async () => {
                                       setPendingInviteMenuId(null);
                                       if (!workspaceSlug) return;
@@ -3943,7 +3943,7 @@ export function SettingsPage() {
           {!isAccountTab && !isProjectsTab && section === "billing" && (
             <Card variant="outlined">
               <CardContent className="py-10 text-center">
-                <p className="text-sm text-[var(--txt-secondary)]">
+                <p className="text-sm text-(--txt-secondary)">
                   Billing & Plans settings will be available when the API is
                   connected.
                 </p>
@@ -3954,24 +3954,24 @@ export function SettingsPage() {
           {!isAccountTab && !isProjectsTab && section === "exports" && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+                <h2 className="text-base font-semibold text-(--txt-primary)">
                   Exports
                 </h2>
-                <p className="mt-1 text-sm text-[var(--txt-secondary)]">
+                <p className="mt-1 text-sm text-(--txt-secondary)">
                   Export your project data in various formats and access your
                   export history with download links.
                 </p>
               </div>
               <div className="flex flex-wrap items-end gap-4">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Exporting project
                   </label>
                   <div className="relative min-w-[200px]">
                     <select
                       value={exportProjectValue}
                       onChange={(e) => setExportProjectValue(e.target.value)}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <option value="all">All projects</option>
                       {projects.map((p) => (
@@ -3980,26 +3980,26 @@ export function SettingsPage() {
                         </option>
                       ))}
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+                  <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                     Format
                   </label>
                   <div className="relative min-w-[120px]">
                     <select
                       value={exportFormat}
                       onChange={(e) => setExportFormat(e.target.value)}
-                      className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                      className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                     >
                       <option value="csv">CSV</option>
                       <option value="json">JSON</option>
                       <option value="xlsx">Excel</option>
                     </select>
-                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                    <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                       <IconChevronDown />
                     </span>
                   </div>
@@ -4010,32 +4010,32 @@ export function SettingsPage() {
               </div>
               <div>
                 <div className="mb-2 flex items-center justify-between">
-                  <h3 className="text-sm font-semibold text-[var(--txt-primary)]">
+                  <h3 className="text-sm font-semibold text-(--txt-primary)">
                     Previous exports
                   </h3>
                   <button
                     type="button"
-                    className="flex items-center gap-1 text-sm font-medium text-[var(--txt-secondary)] hover:text-[var(--txt-primary)]"
+                    className="flex items-center gap-1 text-sm font-medium text-(--txt-secondary) hover:text-(--txt-primary)"
                   >
                     <IconRefresh />
                     Refresh status
                   </button>
                 </div>
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-[var(--txt-tertiary)]">
+                  <span className="text-sm text-(--txt-tertiary)">
                     ← Prev
                   </span>
-                  <span className="text-sm text-[var(--txt-tertiary)]">
+                  <span className="text-sm text-(--txt-tertiary)">
                     Next →
                   </span>
                 </div>
                 <Card variant="outlined" className="mt-2">
                   <CardContent className="flex flex-col items-center justify-center py-12">
                     <IconCog />
-                    <p className="mt-2 text-sm font-medium text-[var(--txt-secondary)]">
+                    <p className="mt-2 text-sm font-medium text-(--txt-secondary)">
                       No exports yet
                     </p>
-                    <p className="mt-0.5 text-sm text-[var(--txt-tertiary)]">
+                    <p className="mt-0.5 text-sm text-(--txt-tertiary)">
                       Anytime you export, you will also have a copy here for
                       reference.
                     </p>
@@ -4048,7 +4048,7 @@ export function SettingsPage() {
           {!isAccountTab && !isProjectsTab && section === "webhooks" && (
             <Card variant="outlined">
               <CardContent className="py-10 text-center">
-                <p className="text-sm text-[var(--txt-secondary)]">
+                <p className="text-sm text-(--txt-secondary)">
                   Webhooks settings will be available when the API is connected.
                 </p>
               </CardContent>
@@ -4178,14 +4178,14 @@ export function SettingsPage() {
         }
       >
         <div>
-          <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
             Projects
           </label>
           <div className="relative">
             <select
               value={exportProjectValue}
               onChange={(e) => setExportProjectValue(e.target.value)}
-              className="w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 pr-8 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+              className="w-full appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 pr-8 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
             >
               <option value="all">All projects</option>
               {projects.map((p) => (
@@ -4194,12 +4194,12 @@ export function SettingsPage() {
                 </option>
               ))}
             </select>
-            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
               <IconChevronDown />
             </span>
           </div>
           {exportFormat === "xlsx" && (
-            <p className="mt-2 text-sm text-[var(--txt-tertiary)]">
+            <p className="mt-2 text-sm text-(--txt-tertiary)">
               Excel export will download as CSV for now.
             </p>
           )}
@@ -4288,7 +4288,7 @@ export function SettingsPage() {
           </>
         }
       >
-        <p className="mb-4 text-sm text-[var(--txt-secondary)]">
+        <p className="mb-4 text-sm text-(--txt-secondary)">
           {inviteTarget === "project"
             ? "Invite people to this project."
             : "Invite people to collaborate on your workspace."}
@@ -4307,7 +4307,7 @@ export function SettingsPage() {
                   )
                 }
                 placeholder="name@company.com"
-                className="min-w-[200px] flex-1 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                className="min-w-[200px] flex-1 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
               />
               <div className="relative min-w-[100px]">
                 <select
@@ -4321,12 +4321,12 @@ export function SettingsPage() {
                       ),
                     )
                   }
-                  className="w-full appearance-none rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-2.5 pr-7 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                  className="w-full appearance-none rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-2.5 pr-7 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
                 >
                   <option value="member">Member</option>
                   <option value="admin">Admin</option>
                 </select>
-                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
                   <IconChevronDown />
                 </span>
               </div>
@@ -4340,7 +4340,7 @@ export function SettingsPage() {
                 { id: Date.now(), email: "", role: "member" as const },
               ])
             }
-            className="flex items-center gap-1.5 text-sm font-medium text-[var(--txt-accent-primary)] hover:underline"
+            className="flex items-center gap-1.5 text-sm font-medium text-(--txt-accent-primary) hover:underline"
           >
             <IconPlus />
             Add more
@@ -4417,19 +4417,19 @@ export function SettingsPage() {
       >
         <div className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+            <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
               Name
             </label>
             <input
               type="text"
               value={projectStateName}
               onChange={(e) => setProjectStateName(e.target.value)}
-              className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+              className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
               placeholder="e.g. In Progress"
             />
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+            <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
               Color
             </label>
             <div className="flex items-center gap-2">
@@ -4437,25 +4437,25 @@ export function SettingsPage() {
                 type="color"
                 value={projectStateColor}
                 onChange={(e) => setProjectStateColor(e.target.value)}
-                className="h-9 w-14 cursor-pointer rounded border border-[var(--border-subtle)]"
+                className="h-9 w-14 cursor-pointer rounded border border-(--border-subtle)"
               />
               <input
                 type="text"
                 value={projectStateColor}
                 onChange={(e) => setProjectStateColor(e.target.value)}
-                className="flex-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                className="flex-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
               />
             </div>
           </div>
           {!projectStateEdit && (
             <div>
-              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+              <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                 Group
               </label>
               <select
                 value={projectStateGroup}
                 onChange={(e) => setProjectStateGroup(e.target.value)}
-                className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
               >
                 <option value="backlog">Backlog</option>
                 <option value="unstarted">Unstarted</option>
@@ -4536,19 +4536,19 @@ export function SettingsPage() {
       >
         <div className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+            <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
               Name
             </label>
             <input
               type="text"
               value={projectLabelName}
               onChange={(e) => setProjectLabelName(e.target.value)}
-              className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+              className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
               placeholder="e.g. Bug"
             />
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+            <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
               Color
             </label>
             <div className="flex items-center gap-2">
@@ -4556,13 +4556,13 @@ export function SettingsPage() {
                 type="color"
                 value={projectLabelColor}
                 onChange={(e) => setProjectLabelColor(e.target.value)}
-                className="h-9 w-14 cursor-pointer rounded border border-[var(--border-subtle)]"
+                className="h-9 w-14 cursor-pointer rounded border border-(--border-subtle)"
               />
               <input
                 type="text"
                 value={projectLabelColor}
                 onChange={(e) => setProjectLabelColor(e.target.value)}
-                className="flex-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] focus:outline-none focus:border-[var(--border-strong)]"
+                className="flex-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
               />
             </div>
           </div>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1344,9 +1344,7 @@ export function SettingsPage() {
                         : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-(--txt-icon-secondary)">
-                      {icon}
-                    </span>
+                    <span className="text-(--txt-icon-secondary)">{icon}</span>
                     {label}
                   </button>
                 ))}
@@ -1364,9 +1362,7 @@ export function SettingsPage() {
                         : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-(--txt-icon-secondary)">
-                      {icon}
-                    </span>
+                    <span className="text-(--txt-icon-secondary)">{icon}</span>
                     {label}
                   </button>
                 ))}
@@ -1472,9 +1468,7 @@ export function SettingsPage() {
                         : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-(--txt-icon-secondary)">
-                      {icon}
-                    </span>
+                    <span className="text-(--txt-icon-secondary)">{icon}</span>
                     {label}
                   </button>
                 ))}
@@ -1492,9 +1486,7 @@ export function SettingsPage() {
                         : "text-(--txt-secondary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-primary)"
                     }`}
                   >
-                    <span className="text-(--txt-icon-secondary)">
-                      {icon}
-                    </span>
+                    <span className="text-(--txt-icon-secondary)">{icon}</span>
                     {label}
                   </button>
                 ))}
@@ -1563,9 +1555,7 @@ export function SettingsPage() {
                 <h2 className="text-lg font-semibold text-(--txt-primary)">
                   {firstName} {lastName}
                 </h2>
-                <p className="text-sm text-(--txt-tertiary)">
-                  {user?.email}
-                </p>
+                <p className="text-sm text-(--txt-tertiary)">{user?.email}</p>
               </div>
               <div className="grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
@@ -1605,8 +1595,7 @@ export function SettingsPage() {
                 </div>
                 <div className="sm:col-span-2">
                   <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
-                    Email{" "}
-                    <span className="text-(--txt-danger-primary)">*</span>
+                    Email <span className="text-(--txt-danger-primary)">*</span>
                   </label>
                   <input
                     type="email"
@@ -1653,10 +1642,7 @@ export function SettingsPage() {
               >
                 {profileSaveLoading ? "Saving…" : "Save changes"}
               </Button>
-              <Card
-                variant="outlined"
-                className="border-(--border-subtle)"
-              >
+              <Card variant="outlined" className="border-(--border-subtle)">
                 <button
                   type="button"
                   onClick={() => setDeactivateOpen(!deactivateOpen)}
@@ -3609,10 +3595,7 @@ export function SettingsPage() {
               >
                 {generalUpdateLoading ? "Updating…" : "Update workspace"}
               </Button>
-              <Card
-                variant="outlined"
-                className="border-(--border-subtle)"
-              >
+              <Card variant="outlined" className="border-(--border-subtle)">
                 <button
                   type="button"
                   onClick={() => setDeleteWorkspaceOpen(!deleteWorkspaceOpen)}
@@ -4022,12 +4005,8 @@ export function SettingsPage() {
                   </button>
                 </div>
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-(--txt-tertiary)">
-                    ← Prev
-                  </span>
-                  <span className="text-sm text-(--txt-tertiary)">
-                    Next →
-                  </span>
+                  <span className="text-sm text-(--txt-tertiary)">← Prev</span>
+                  <span className="text-sm text-(--txt-tertiary)">Next →</span>
                 </div>
                 <Card variant="outlined" className="mt-2">
                   <CardContent className="flex flex-col items-center justify-center py-12">

--- a/ui/src/pages/ViewsPage.tsx
+++ b/ui/src/pages/ViewsPage.tsx
@@ -62,9 +62,7 @@ export function ViewsPage() {
     );
   }
   if (!workspace || !project) {
-    return (
-      <div className="text-(--txt-secondary)">Project not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Project not found.</div>;
   }
 
   return (
@@ -75,9 +73,7 @@ export function ViewsPage() {
       </p>
       {views.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-md border border-(--border-subtle) border-dashed bg-(--bg-layer-1) py-12">
-          <p className="text-sm text-(--txt-tertiary)">
-            No saved views yet.
-          </p>
+          <p className="text-sm text-(--txt-tertiary)">No saved views yet.</p>
           <p className="mt-1 text-xs text-(--txt-tertiary)">
             Create a view to save your filters and display options.
           </p>
@@ -89,9 +85,7 @@ export function ViewsPage() {
               key={v.id}
               className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2"
             >
-              <span className="font-medium text-(--txt-primary)">
-                {v.name}
-              </span>
+              <span className="font-medium text-(--txt-primary)">{v.name}</span>
               {v.description && (
                 <p className="mt-0.5 text-sm text-(--txt-secondary)">
                   {v.description}

--- a/ui/src/pages/ViewsPage.tsx
+++ b/ui/src/pages/ViewsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { workspaceService } from "../services/workspaceService";
 import { projectService } from "../services/projectService";
@@ -56,29 +56,29 @@ export function ViewsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace || !project) {
     return (
-      <div className="text-[var(--txt-secondary)]">Project not found.</div>
+      <div className="text-(--txt-secondary)">Project not found.</div>
     );
   }
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-[var(--txt-secondary)]">
+      <p className="text-sm text-(--txt-secondary)">
         Saved views let you quickly access filtered work items. Create a view
         from the &quot;Add view&quot; button above.
       </p>
       {views.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-md border border-[var(--border-subtle)] border-dashed bg-[var(--bg-layer-1)] py-12">
-          <p className="text-sm text-[var(--txt-tertiary)]">
+        <div className="flex flex-col items-center justify-center rounded-md border border-(--border-subtle) border-dashed bg-(--bg-layer-1) py-12">
+          <p className="text-sm text-(--txt-tertiary)">
             No saved views yet.
           </p>
-          <p className="mt-1 text-xs text-[var(--txt-tertiary)]">
+          <p className="mt-1 text-xs text-(--txt-tertiary)">
             Create a view to save your filters and display options.
           </p>
         </div>
@@ -87,13 +87,13 @@ export function ViewsPage() {
           {views.map((v) => (
             <li
               key={v.id}
-              className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2"
+              className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2"
             >
-              <span className="font-medium text-[var(--txt-primary)]">
+              <span className="font-medium text-(--txt-primary)">
                 {v.name}
               </span>
               {v.description && (
-                <p className="mt-0.5 text-sm text-[var(--txt-secondary)]">
+                <p className="mt-0.5 text-sm text-(--txt-secondary)">
                   {v.description}
                 </p>
               )}

--- a/ui/src/pages/WorkspaceHomePage.tsx
+++ b/ui/src/pages/WorkspaceHomePage.tsx
@@ -463,9 +463,7 @@ export function WorkspaceHomePage() {
     );
   }
   if (!workspace) {
-    return (
-      <div className="text-(--txt-secondary)">Workspace not found.</div>
-    );
+    return <div className="text-(--txt-secondary)">Workspace not found.</div>;
   }
 
   const baseUrl = `/${workspace.slug}`;
@@ -795,8 +793,7 @@ export function WorkspaceHomePage() {
           <div className="flex flex-col gap-4">
             <div>
               <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
-                Content{" "}
-                <span className="text-(--txt-tertiary)">Optional</span>
+                Content <span className="text-(--txt-tertiary)">Optional</span>
               </label>
               <textarea
                 value={stickyContent}

--- a/ui/src/pages/WorkspaceHomePage.tsx
+++ b/ui/src/pages/WorkspaceHomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+﻿import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Card, CardContent, Button, Modal, Input } from "../components/ui";
 import { useAuth } from "../contexts/AuthContext";
@@ -457,14 +457,14 @@ export function WorkspaceHomePage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
   }
   if (!workspace) {
     return (
-      <div className="text-[var(--txt-secondary)]">Workspace not found.</div>
+      <div className="text-(--txt-secondary)">Workspace not found.</div>
     );
   }
 
@@ -488,11 +488,11 @@ export function WorkspaceHomePage() {
     <div className="mx-auto max-w-4xl space-y-8 pb-8">
       {/* Welcome */}
       <section className="text-center">
-        <h1 className="text-2xl font-bold tracking-tight text-[var(--txt-primary)]">
+        <h1 className="text-2xl font-bold tracking-tight text-(--txt-primary)">
           {getGreeting()}, {user?.name ?? "User"}
         </h1>
-        <p className="mt-1 flex items-center justify-center gap-2 text-sm text-[var(--txt-tertiary)]">
-          <span className="text-[var(--txt-icon-tertiary)]">
+        <p className="mt-1 flex items-center justify-center gap-2 text-sm text-(--txt-tertiary)">
+          <span className="text-(--txt-icon-tertiary)">
             <IconMoon />
           </span>
           {formatDateTime(new Date())}
@@ -502,13 +502,13 @@ export function WorkspaceHomePage() {
       {/* Quicklinks */}
       <section>
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+          <h2 className="text-base font-semibold text-(--txt-primary)">
             Quicklinks
           </h2>
           <Button
             variant="ghost"
             size="sm"
-            className="gap-1.5 text-[13px] font-medium text-[var(--txt-accent-primary)]"
+            className="gap-1.5 text-[13px] font-medium text-(--txt-accent-primary)"
             onClick={() => setAddQuicklinkOpen(true)}
           >
             <IconPlus />
@@ -535,8 +535,8 @@ export function WorkspaceHomePage() {
         >
           <div className="flex flex-col gap-4">
             <div>
-              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
-                URL <span className="text-[var(--txt-tertiary)]">Required</span>
+              <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
+                URL <span className="text-(--txt-tertiary)">Required</span>
               </label>
               <Input
                 value={quicklinkUrl}
@@ -546,9 +546,9 @@ export function WorkspaceHomePage() {
               />
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+              <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                 Display title{" "}
-                <span className="text-[var(--txt-tertiary)]">Optional</span>
+                <span className="text-(--txt-tertiary)">Optional</span>
               </label>
               <Input
                 value={quicklinkTitle}
@@ -569,17 +569,17 @@ export function WorkspaceHomePage() {
             const content = (
               <Card
                 variant="outlined"
-                className="transition-colors hover:bg-[var(--bg-layer-transparent-hover)]"
+                className="transition-colors hover:bg-(--bg-layer-transparent-hover)"
               >
                 <CardContent className="flex items-center gap-3 p-3">
-                  <div className="flex size-10 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-[var(--bg-layer-1)] text-[var(--txt-icon-tertiary)]">
+                  <div className="flex size-10 shrink-0 items-center justify-center rounded-(--radius-md) bg-(--bg-layer-1) text-(--txt-icon-tertiary)">
                     <IconTarget />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate font-medium text-[var(--txt-primary)]">
+                    <p className="truncate font-medium text-(--txt-primary)">
                       {label}
                     </p>
-                    <p className="text-xs text-[var(--txt-tertiary)]">
+                    <p className="text-xs text-(--txt-tertiary)">
                       {formatRelativeTime(ql.updated_at)}
                     </p>
                   </div>
@@ -606,10 +606,10 @@ export function WorkspaceHomePage() {
         {quicklinks.length === 0 && (
           <Card variant="outlined">
             <CardContent className="flex items-center gap-3 p-3">
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-[var(--bg-layer-1)] text-[var(--txt-icon-tertiary)]">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-(--radius-md) bg-(--bg-layer-1) text-(--txt-icon-tertiary)">
                 <IconTarget />
               </div>
-              <p className="text-sm text-[var(--txt-tertiary)]">
+              <p className="text-sm text-(--txt-tertiary)">
                 No quicklinks yet. Add one to jump back to a project.
               </p>
             </CardContent>
@@ -620,7 +620,7 @@ export function WorkspaceHomePage() {
       {/* Recents */}
       <section>
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+          <h2 className="text-base font-semibold text-(--txt-primary)">
             Recents
           </h2>
           <div className="relative">
@@ -628,7 +628,7 @@ export function WorkspaceHomePage() {
               ref={recentsFilterTriggerRef}
               type="button"
               onClick={() => setRecentsFilterOpen((o) => !o)}
-              className="flex items-center gap-1.5 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-layer-2)] px-2.5 py-1.5 text-[13px] font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-2-hover)]"
+              className="flex items-center gap-1.5 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1.5 text-[13px] font-medium text-(--txt-primary) hover:bg-(--bg-layer-2-hover)"
               aria-expanded={recentsFilterOpen}
               aria-haspopup="listbox"
               aria-label="Filter recents"
@@ -639,7 +639,7 @@ export function WorkspaceHomePage() {
             {recentsFilterOpen && (
               <div
                 ref={recentsFilterDropdownRef}
-                className="absolute right-0 top-full z-10 mt-1 min-w-[10rem] rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-overlay)]"
+                className="absolute right-0 top-full z-10 mt-1 min-w-[10rem] rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-overlay)"
                 role="listbox"
               >
                 {recentsFilterOptions.map((option) => (
@@ -652,7 +652,7 @@ export function WorkspaceHomePage() {
                       setRecentsFilterValue(option);
                       setRecentsFilterOpen(false);
                     }}
-                    className="w-full px-3 py-2 text-left text-[13px] font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                    className="w-full px-3 py-2 text-left text-[13px] font-medium text-(--txt-primary) hover:bg-(--bg-layer-transparent-hover)"
                   >
                     {option}
                   </button>
@@ -662,7 +662,7 @@ export function WorkspaceHomePage() {
           </div>
         </div>
         <Card variant="outlined">
-          <CardContent className="divide-y divide-[var(--border-subtle)] p-0">
+          <CardContent className="divide-y divide-(--border-subtle) p-0">
             {filteredRecents.map((r) => {
               const recentsLink =
                 r.entity_name === "issue" && r.project_id && r.entity_identifier
@@ -677,19 +677,19 @@ export function WorkspaceHomePage() {
               const titleLabel = r.display_title || r.entity_name;
               const inner = (
                 <>
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-[var(--bg-layer-1)] text-[var(--txt-icon-tertiary)]">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-(--radius-md) bg-(--bg-layer-1) text-(--txt-icon-tertiary)">
                     <IconFileText />
                   </span>
                   <div className="min-w-0 flex-1">
                     <p className="flex items-baseline gap-2 text-[13px]">
-                      <span className="font-medium text-[var(--txt-primary)]">
+                      <span className="font-medium text-(--txt-primary)">
                         {idLabel}
                       </span>
-                      <span className="truncate text-[var(--txt-secondary)]">
+                      <span className="truncate text-(--txt-secondary)">
                         {titleLabel}
                       </span>
                     </p>
-                    <p className="mt-0.5 text-xs text-[var(--txt-tertiary)]">
+                    <p className="mt-0.5 text-xs text-(--txt-tertiary)">
                       {formatRelativeTime(r.last_visited_at)}
                     </p>
                   </div>
@@ -699,21 +699,21 @@ export function WorkspaceHomePage() {
                 <Link
                   key={r.id}
                   to={recentsLink}
-                  className="flex items-center gap-3 px-4 py-3 no-underline transition-colors hover:bg-[var(--bg-layer-transparent-hover)]"
+                  className="flex items-center gap-3 px-4 py-3 no-underline transition-colors hover:bg-(--bg-layer-transparent-hover)"
                 >
                   {inner}
                 </Link>
               ) : (
                 <div
                   key={r.id}
-                  className="flex items-center gap-3 px-4 py-3 text-[var(--txt-secondary)]"
+                  className="flex items-center gap-3 px-4 py-3 text-(--txt-secondary)"
                 >
                   {inner}
                 </div>
               );
             })}
             {filteredRecents.length === 0 && (
-              <div className="px-4 py-6 text-center text-sm text-[var(--txt-tertiary)]">
+              <div className="px-4 py-6 text-center text-sm text-(--txt-tertiary)">
                 No recent activity.
               </div>
             )}
@@ -724,15 +724,15 @@ export function WorkspaceHomePage() {
       {/* Your stickies */}
       <section>
         <div className="mb-3 flex items-center justify-between gap-2">
-          <h2 className="text-base font-semibold text-[var(--txt-primary)]">
+          <h2 className="text-base font-semibold text-(--txt-primary)">
             Your stickies
           </h2>
           <div className="flex flex-1 items-center justify-end gap-1 min-w-0">
             <div
               className={`overflow-hidden transition-[width] duration-200 ease-out ${stickySearchOpen ? "w-56" : "w-0"}`}
             >
-              <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2 py-1.5">
-                <span className="shrink-0 text-[var(--txt-icon-tertiary)]">
+              <div className="flex items-center gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1.5">
+                <span className="shrink-0 text-(--txt-icon-tertiary)">
                   <IconSearch />
                 </span>
                 <input
@@ -740,7 +740,7 @@ export function WorkspaceHomePage() {
                   value={stickySearchQuery}
                   onChange={(e) => setStickySearchQuery(e.target.value)}
                   placeholder="Search by title"
-                  className="min-w-0 flex-1 bg-transparent text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                  className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                   aria-label="Search stickies by title"
                 />
                 <button
@@ -749,7 +749,7 @@ export function WorkspaceHomePage() {
                     setStickySearchQuery("");
                     setStickySearchOpen(false);
                   }}
-                  className="shrink-0 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-secondary)]"
+                  className="shrink-0 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-secondary)"
                   aria-label="Clear search"
                 >
                   <IconX />
@@ -760,7 +760,7 @@ export function WorkspaceHomePage() {
               <button
                 type="button"
                 onClick={() => setStickySearchOpen(true)}
-                className="flex size-8 items-center justify-center rounded-[var(--radius-md)] text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                className="flex size-8 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
                 aria-label="Search stickies"
               >
                 <IconSearch />
@@ -769,7 +769,7 @@ export function WorkspaceHomePage() {
             <Button
               variant="ghost"
               size="sm"
-              className="gap-1.5 text-[13px] font-medium text-[var(--txt-accent-primary)]"
+              className="gap-1.5 text-[13px] font-medium text-(--txt-accent-primary)"
               onClick={() => setAddStickyOpen(true)}
             >
               <IconPlus />
@@ -794,16 +794,16 @@ export function WorkspaceHomePage() {
         >
           <div className="flex flex-col gap-4">
             <div>
-              <label className="mb-1 block text-sm font-medium text-[var(--txt-secondary)]">
+              <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
                 Content{" "}
-                <span className="text-[var(--txt-tertiary)]">Optional</span>
+                <span className="text-(--txt-tertiary)">Optional</span>
               </label>
               <textarea
                 value={stickyContent}
                 onChange={(e) => setStickyContent(e.target.value)}
                 placeholder="Jot down an idea, capture an aha..."
                 rows={4}
-                className="w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none focus:border-[var(--border-strong)]"
+                className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
               />
             </div>
           </div>
@@ -818,10 +818,10 @@ export function WorkspaceHomePage() {
             return (
               <Card variant="outlined" className="border-dashed">
                 <CardContent className="flex min-h-[180px] flex-col items-center justify-center gap-3 py-10">
-                  <span className="text-[var(--txt-icon-tertiary)]">
+                  <span className="text-(--txt-icon-tertiary)">
                     <IconClipboard />
                   </span>
-                  <p className="max-w-sm text-center text-sm italic text-[var(--txt-placeholder)]">
+                  <p className="max-w-sm text-center text-sm italic text-(--txt-placeholder)">
                     {stickySearchQuery.trim()
                       ? "No stickies match your search."
                       : "Jot down an idea, capture an aha, or record a brainwave. Add a sticky to get started."}
@@ -840,48 +840,48 @@ export function WorkspaceHomePage() {
                 return (
                   <div
                     key={sticky.id}
-                    className={`flex min-h-[120px] flex-col rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-3 shadow-sm ${isDefaultDark ? "bg-[var(--bg-layer-2)]" : ""}`}
+                    className={`flex min-h-[120px] flex-col rounded-(--radius-md) border border-(--border-subtle) p-3 shadow-sm ${isDefaultDark ? "bg-(--bg-layer-2)" : ""}`}
                     style={
                       isDefaultDark
                         ? undefined
                         : { backgroundColor: sticky.color }
                     }
                   >
-                    <div className="min-h-0 flex-1 text-sm text-[var(--txt-primary)]">
+                    <div className="min-h-0 flex-1 text-sm text-(--txt-primary)">
                       <p className="whitespace-pre-wrap break-words">
                         {sticky.name}
                       </p>
                       {sticky.description && (
-                        <p className="mt-1 whitespace-pre-wrap break-words text-[var(--txt-secondary)]">
+                        <p className="mt-1 whitespace-pre-wrap break-words text-(--txt-secondary)">
                           {sticky.description}
                         </p>
                       )}
                     </div>
-                    <div className="mt-2 flex items-center gap-1 border-t border-[var(--border-subtle)] pt-2">
+                    <div className="mt-2 flex items-center gap-1 border-t border-(--border-subtle) pt-2">
                       <button
                         type="button"
-                        className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                        className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
                         aria-label="Change color"
                       >
                         <IconPalette />
                       </button>
                       <button
                         type="button"
-                        className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                        className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
                         aria-label="Bold"
                       >
                         <IconBold />
                       </button>
                       <button
                         type="button"
-                        className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                        className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
                         aria-label="Italic"
                       >
                         <IconItalic />
                       </button>
                       <button
                         type="button"
-                        className="rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)]"
+                        className="rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover)"
                         aria-label="List"
                       >
                         <IconList />
@@ -889,7 +889,7 @@ export function WorkspaceHomePage() {
                       <button
                         type="button"
                         onClick={() => handleDeleteSticky(sticky.id)}
-                        className="ml-auto rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-transparent-hover)] hover:text-[var(--txt-danger-primary)]"
+                        className="ml-auto rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) hover:text-(--txt-danger-primary)"
                         aria-label="Delete"
                       >
                         <IconTrash />

--- a/ui/src/pages/WorkspaceViewsPage.tsx
+++ b/ui/src/pages/WorkspaceViewsPage.tsx
@@ -701,19 +701,13 @@ export function WorkspaceViewsPage() {
       case "link":
         return <span className="text-(--txt-tertiary)">0 links</span>;
       case "attachment_count":
-        return (
-          <span className="text-(--txt-tertiary)">0 attachments</span>
-        );
+        return <span className="text-(--txt-tertiary)">0 attachments</span>;
       case "sub_work_item_count":
-        return (
-          <span className="text-(--txt-tertiary)">0 sub-work items</span>
-        );
+        return <span className="text-(--txt-tertiary)">0 sub-work items</span>;
       case "estimate":
         return <span className="text-(--txt-tertiary)">Estimate</span>;
       case "module":
-        return (
-          <span className="text-(--txt-tertiary)">Select modules</span>
-        );
+        return <span className="text-(--txt-tertiary)">Select modules</span>;
       case "cycle":
         return <span className="text-(--txt-tertiary)">Select cycle</span>;
       default:
@@ -996,9 +990,7 @@ export function WorkspaceViewsPage() {
           openId={openCellId}
           onOpen={setOpenCellId}
           label="Assignees"
-          icon={
-            <IconUser className="size-3.5 text-(--txt-icon-tertiary)" />
-          }
+          icon={<IconUser className="size-3.5 text-(--txt-icon-tertiary)" />}
           displayValue={displayValue}
           triggerClassName={CELL_TRIGGER_CLASS}
           triggerContent={assigneeTriggerContent}
@@ -1067,9 +1059,7 @@ export function WorkspaceViewsPage() {
                     {m.member_display_name ?? m.member_email ?? m.member_id}
                   </span>
                   {checked && (
-                    <span className="ml-auto text-(--txt-tertiary)">
-                      ✓
-                    </span>
+                    <span className="ml-auto text-(--txt-tertiary)">✓</span>
                   )}
                 </button>
               );
@@ -1104,9 +1094,7 @@ export function WorkspaceViewsPage() {
           openId={openCellId}
           onOpen={setOpenCellId}
           label="Labels"
-          icon={
-            <IconTag className="size-3.5 text-(--txt-icon-tertiary)" />
-          }
+          icon={<IconTag className="size-3.5 text-(--txt-icon-tertiary)" />}
           displayValue={displayValue}
           triggerClassName={CELL_TRIGGER_CLASS}
           triggerContent={labelsTriggerContent}
@@ -1142,9 +1130,7 @@ export function WorkspaceViewsPage() {
                     {l.name}
                   </span>
                   {checked && (
-                    <span className="ml-auto text-(--txt-tertiary)">
-                      ✓
-                    </span>
+                    <span className="ml-auto text-(--txt-tertiary)">✓</span>
                   )}
                 </button>
               );

--- a/ui/src/pages/WorkspaceViewsPage.tsx
+++ b/ui/src/pages/WorkspaceViewsPage.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   Fragment,
   useCallback,
   useEffect,
@@ -146,7 +146,7 @@ const priorityVariant: Record<
 };
 
 const CELL_TRIGGER_CLASS =
-  "flex w-full min-w-0 items-center justify-start gap-2 rounded-none border-0 bg-transparent px-4 py-2 text-left text-sm text-[var(--txt-secondary)] hover:bg-[var(--bg-layer-1-hover)] [&_svg]:shrink-0";
+  "flex w-full min-w-0 items-center justify-start gap-2 rounded-none border-0 bg-transparent px-4 py-2 text-left text-sm text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) [&_svg]:shrink-0";
 
 const STATIC_VIEW_IDS = ["all-issues", "assigned", "created", "subscribed"];
 
@@ -552,7 +552,7 @@ export function WorkspaceViewsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading…
       </div>
     );
@@ -560,10 +560,10 @@ export function WorkspaceViewsPage() {
   if (!workspace) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
-        <p className="text-[var(--txt-secondary)]">Workspace not found.</p>
+        <p className="text-(--txt-secondary)">Workspace not found.</p>
         <Link
           to="/"
-          className="text-sm font-medium text-[var(--txt-accent-primary)] hover:underline"
+          className="text-sm font-medium text-(--txt-accent-primary) hover:underline"
         >
           Go to home
         </Link>
@@ -572,7 +572,7 @@ export function WorkspaceViewsPage() {
   }
   if (viewLoading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading view…
       </div>
     );
@@ -580,16 +580,16 @@ export function WorkspaceViewsPage() {
   if (viewNotFound && workspaceSlug) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-lg font-medium text-[var(--txt-primary)]">
+        <p className="text-lg font-medium text-(--txt-primary)">
           View does not exist
         </p>
-        <p className="text-sm text-[var(--txt-secondary)]">
+        <p className="text-sm text-(--txt-secondary)">
           The view you are looking for does not exist or you don&apos;t have
           permission to view it.
         </p>
         <Link
           to={`/${workspace.slug}/views`}
-          className="inline-flex items-center justify-center rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-3 py-2 text-sm font-medium text-[var(--txt-primary)] hover:bg-[var(--bg-layer-1-hover)]"
+          className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm font-medium text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
         >
           All work items
         </Link>
@@ -627,10 +627,10 @@ export function WorkspaceViewsPage() {
     const firstLabel = firstLabelId ? getLabel(firstLabelId) : undefined;
     switch (key) {
       case "id":
-        return <span className="text-[var(--txt-secondary)]">{displayId}</span>;
+        return <span className="text-(--txt-secondary)">{displayId}</span>;
       case "assignee":
         return assignee ? (
-          <span className="inline-flex items-center gap-2 text-[var(--txt-secondary)]">
+          <span className="inline-flex items-center gap-2 text-(--txt-secondary)">
             {getImageUrl(assignee.member_avatar) ? (
               <img
                 src={getImageUrl(assignee.member_avatar)!}
@@ -638,7 +638,7 @@ export function WorkspaceViewsPage() {
                 className="size-6 shrink-0 rounded-full object-cover"
               />
             ) : (
-              <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-2)] text-xs font-medium text-[var(--txt-secondary)]">
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-2) text-xs font-medium text-(--txt-secondary)">
                 {(
                   assignee.member_display_name ??
                   assignee.member_email ??
@@ -651,23 +651,23 @@ export function WorkspaceViewsPage() {
             </span>
           </span>
         ) : (
-          <span className="text-[var(--txt-tertiary)]">—</span>
+          <span className="text-(--txt-tertiary)">—</span>
         );
       case "start_date":
         return (
-          <span className="text-[var(--txt-secondary)]">
+          <span className="text-(--txt-secondary)">
             {formatDate(issue.start_date ?? undefined)}
           </span>
         );
       case "due_date":
         return (
-          <span className="text-[var(--txt-secondary)]">
+          <span className="text-(--txt-secondary)">
             {formatDate(issue.target_date ?? undefined)}
           </span>
         );
       case "labels":
         return firstLabel ? (
-          <span className="inline-flex items-center gap-2 text-[var(--txt-secondary)]">
+          <span className="inline-flex items-center gap-2 text-(--txt-secondary)">
             <span
               className="size-2.5 shrink-0 rounded-full"
               style={{
@@ -677,14 +677,14 @@ export function WorkspaceViewsPage() {
             {firstLabel.name}
           </span>
         ) : (
-          <span className="inline-flex items-center gap-2 text-[var(--txt-tertiary)]">
+          <span className="inline-flex items-center gap-2 text-(--txt-tertiary)">
             <IconTag className="size-3.5 shrink-0 opacity-70" />
             Select labels
           </span>
         );
       case "priority":
         return (
-          <span className="inline-flex items-center gap-2 text-[var(--txt-secondary)]">
+          <span className="inline-flex items-center gap-2 text-(--txt-secondary)">
             <IconBarChart className="size-3.5 shrink-0 text-amber-500" />
             {issue.priority === "none" || !issue.priority
               ? "None"
@@ -693,29 +693,29 @@ export function WorkspaceViewsPage() {
         );
       case "state":
         return (
-          <span className="inline-flex items-center gap-2 text-[var(--txt-secondary)]">
-            <span className="size-3.5 shrink-0 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-layer-1)]" />
+          <span className="inline-flex items-center gap-2 text-(--txt-secondary)">
+            <span className="size-3.5 shrink-0 rounded-full border border-(--border-subtle) bg-(--bg-layer-1)" />
             {getStateName(issue.state_id ?? undefined)}
           </span>
         );
       case "link":
-        return <span className="text-[var(--txt-tertiary)]">0 links</span>;
+        return <span className="text-(--txt-tertiary)">0 links</span>;
       case "attachment_count":
         return (
-          <span className="text-[var(--txt-tertiary)]">0 attachments</span>
+          <span className="text-(--txt-tertiary)">0 attachments</span>
         );
       case "sub_work_item_count":
         return (
-          <span className="text-[var(--txt-tertiary)]">0 sub-work items</span>
+          <span className="text-(--txt-tertiary)">0 sub-work items</span>
         );
       case "estimate":
-        return <span className="text-[var(--txt-tertiary)]">Estimate</span>;
+        return <span className="text-(--txt-tertiary)">Estimate</span>;
       case "module":
         return (
-          <span className="text-[var(--txt-tertiary)]">Select modules</span>
+          <span className="text-(--txt-tertiary)">Select modules</span>
         );
       case "cycle":
-        return <span className="text-[var(--txt-tertiary)]">Select cycle</span>;
+        return <span className="text-(--txt-tertiary)">Select cycle</span>;
       default:
         return null;
     }
@@ -748,12 +748,12 @@ export function WorkspaceViewsPage() {
     return (
       <th
         key={column}
-        className={`border-r-column-subtle whitespace-nowrap px-4 py-2 font-medium text-[var(--txt-secondary)] last:border-r-0${extraClass}`}
+        className={`border-r-column-subtle whitespace-nowrap px-4 py-2 font-medium text-(--txt-secondary) last:border-r-0${extraClass}`}
       >
         <button
           type="button"
           onClick={() => handleSort(column)}
-          className="inline-flex items-center gap-1.5 hover:text-[var(--txt-primary)]"
+          className="inline-flex items-center gap-1.5 hover:text-(--txt-primary)"
         >
           {icon}
           {label}
@@ -776,9 +776,9 @@ export function WorkspaceViewsPage() {
     display.layout === "gantt_chart"
   ) {
     return (
-      <div className="-mt-[var(--padding-page)] -mr-[var(--padding-page)] -mb-[var(--padding-page)] flex min-h-0 flex-1 flex-col">
+      <div className="-mt-(--padding-page) -mr-(--padding-page) -mb-(--padding-page) flex min-h-0 flex-1 flex-col">
         <div className="flex flex-1 items-center justify-center p-8">
-          <p className="text-sm text-[var(--txt-tertiary)]">
+          <p className="text-sm text-(--txt-tertiary)">
             {display.layout === "kanban" && "Kanban view is coming soon."}
             {display.layout === "calendar" && "Calendar view is coming soon."}
             {display.layout === "gantt_chart" &&
@@ -791,15 +791,15 @@ export function WorkspaceViewsPage() {
 
   if (display.layout === "list") {
     return (
-      <div className="-mt-[var(--padding-page)] -mr-[var(--padding-page)] -mb-[var(--padding-page)] flex min-h-0 flex-1 flex-col">
+      <div className="-mt-(--padding-page) -mr-(--padding-page) -mb-(--padding-page) flex min-h-0 flex-1 flex-col">
         <div className="min-h-0 flex-1 overflow-y-auto">
           {sortedIssues.length === 0 ? (
-            <div className="px-4 py-16 text-center text-sm text-[var(--txt-tertiary)]">
+            <div className="px-4 py-16 text-center text-sm text-(--txt-tertiary)">
               No work items yet. Create one from a project&apos;s Work items
               section or add a view to get started.
             </div>
           ) : (
-            <ul className="divide-y divide-[var(--border-subtle)]">
+            <ul className="divide-y divide-(--border-subtle)">
               {sortedIssues.map((issue) => {
                 const project = getProject(issue.project_id);
                 const issueBaseUrl = project
@@ -808,14 +808,14 @@ export function WorkspaceViewsPage() {
                 return (
                   <li
                     key={issue.id}
-                    className="transition-colors hover:bg-[var(--bg-layer-1-hover)]"
+                    className="transition-colors hover:bg-(--bg-layer-1-hover)"
                   >
                     <Link
                       to={`${issueBaseUrl}/issues/${issue.id}`}
-                      className="flex items-center justify-between px-4 py-3 text-[var(--txt-primary)] no-underline hover:text-[var(--txt-accent-primary)]"
+                      className="flex items-center justify-between px-4 py-3 text-(--txt-primary) no-underline hover:text-(--txt-accent-primary)"
                     >
                       <span className="font-medium">{issue.name}</span>
-                      <span className="text-sm text-[var(--txt-secondary)]">
+                      <span className="text-sm text-(--txt-secondary)">
                         {formatDate(issue.created_at)}
                       </span>
                     </Link>
@@ -836,7 +836,7 @@ export function WorkspaceViewsPage() {
     const sortCol = sortableColumnMap[key];
     const label = headerLabel(key);
     const firstColBorder = isFirstScrollableColumn(key)
-      ? " border-l border-[var(--border-subtle)]"
+      ? " border-l border-(--border-subtle)"
       : "";
     if (sortCol) {
       const icon =
@@ -858,7 +858,7 @@ export function WorkspaceViewsPage() {
     return (
       <th
         key={key}
-        className={`border-r-column-subtle whitespace-nowrap px-4 py-2 font-medium text-[var(--txt-secondary)] last:border-r-0${firstColBorder}`}
+        className={`border-r-column-subtle whitespace-nowrap px-4 py-2 font-medium text-(--txt-secondary) last:border-r-0${firstColBorder}`}
       >
         <span className="inline-flex items-center gap-1.5">
           {key === "state" && (
@@ -885,14 +885,14 @@ export function WorkspaceViewsPage() {
   ) => {
     if (key === "created_at") {
       return (
-        <span className="text-[var(--txt-secondary)]">
+        <span className="text-(--txt-secondary)">
           {formatDate(issue.created_at)}
         </span>
       );
     }
     if (key === "updated_at") {
       return (
-        <span className="text-[var(--txt-secondary)]">
+        <span className="text-(--txt-secondary)">
           {formatDate(issue.updated_at)}
         </span>
       );
@@ -919,7 +919,7 @@ export function WorkspaceViewsPage() {
           ? "None"
           : (issue.priority as string);
       const priorityTriggerContent = (
-        <span className="inline-flex min-w-0 items-center gap-2 text-[var(--txt-secondary)]">
+        <span className="inline-flex min-w-0 items-center gap-2 text-(--txt-secondary)">
           <IconBarChart className="size-3.5 shrink-0 text-amber-500" />
           <span className="truncate">{displayValue}</span>
         </span>
@@ -935,20 +935,20 @@ export function WorkspaceViewsPage() {
           triggerClassName={CELL_TRIGGER_CLASS}
           triggerContent={priorityTriggerContent}
           align="right"
-          panelClassName="max-h-60 min-w-[160px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+          panelClassName="max-h-60 min-w-[160px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
         >
           {(["urgent", "high", "medium", "low", "none"] as Priority[]).map(
             (p) => (
               <button
                 key={p}
                 type="button"
-                className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                 onClick={() => {
                   setOpenCellId(null);
                   updateIssue(issue, { priority: p });
                 }}
               >
-                <span className="truncate capitalize text-[var(--txt-primary)]">
+                <span className="truncate capitalize text-(--txt-primary)">
                   {p}
                 </span>
                 <Badge variant={priorityVariant[p]} className="text-[10px]">
@@ -967,7 +967,7 @@ export function WorkspaceViewsPage() {
       const assigneeIds = issue.assignee_ids ?? [];
       const displayValue = assignee ? getMemberLabel(assignee.member_id) : "—";
       const assigneeTriggerContent = assignee ? (
-        <span className="inline-flex min-w-0 items-center gap-2 text-[var(--txt-secondary)]">
+        <span className="inline-flex min-w-0 items-center gap-2 text-(--txt-secondary)">
           {getImageUrl(assignee.member_avatar) ? (
             <img
               src={getImageUrl(assignee.member_avatar)!}
@@ -975,7 +975,7 @@ export function WorkspaceViewsPage() {
               className="size-6 shrink-0 rounded-full object-cover"
             />
           ) : (
-            <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-2)] text-xs font-medium text-[var(--txt-secondary)]">
+            <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-2) text-xs font-medium text-(--txt-secondary)">
               {(
                 assignee.member_display_name ??
                 assignee.member_email ??
@@ -988,7 +988,7 @@ export function WorkspaceViewsPage() {
           </span>
         </span>
       ) : (
-        <span className="text-[var(--txt-tertiary)]">—</span>
+        <span className="text-(--txt-tertiary)">—</span>
       );
       return (
         <Dropdown
@@ -997,18 +997,18 @@ export function WorkspaceViewsPage() {
           onOpen={setOpenCellId}
           label="Assignees"
           icon={
-            <IconUser className="size-3.5 text-[var(--txt-icon-tertiary)]" />
+            <IconUser className="size-3.5 text-(--txt-icon-tertiary)" />
           }
           displayValue={displayValue}
           triggerClassName={CELL_TRIGGER_CLASS}
           triggerContent={assigneeTriggerContent}
           align="right"
-          panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+          panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
         >
           {currentUser && (
             <button
               type="button"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
               onClick={() => {
                 const checked = assigneeIds.includes(currentUser.id);
                 const next = checked
@@ -1024,13 +1024,13 @@ export function WorkspaceViewsPage() {
                   className="size-5 shrink-0 rounded-full object-cover"
                 />
               ) : (
-                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-200)] text-[10px] font-medium text-[var(--brand-default)]">
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--brand-200) text-[10px] font-medium text-(--brand-default)">
                   {currentUser.name?.charAt(0) ?? "?"}
                 </span>
               )}
-              <span className="truncate text-[var(--txt-primary)]">You</span>
+              <span className="truncate text-(--txt-primary)">You</span>
               {assigneeIds.includes(currentUser.id) && (
-                <span className="ml-auto text-[var(--txt-tertiary)]">✓</span>
+                <span className="ml-auto text-(--txt-tertiary)">✓</span>
               )}
             </button>
           )}
@@ -1042,7 +1042,7 @@ export function WorkspaceViewsPage() {
                 <button
                   key={m.id}
                   type="button"
-                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                   onClick={() => {
                     const next = checked
                       ? assigneeIds.filter((x) => x !== m.member_id)
@@ -1057,17 +1057,17 @@ export function WorkspaceViewsPage() {
                       className="size-5 shrink-0 rounded-full object-cover"
                     />
                   ) : (
-                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--bg-layer-2)] text-[10px] text-[var(--txt-secondary)]">
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--bg-layer-2) text-[10px] text-(--txt-secondary)">
                       {(m.member_display_name ?? m.member_email ?? "?").charAt(
                         0,
                       )}
                     </span>
                   )}
-                  <span className="truncate text-[var(--txt-primary)]">
+                  <span className="truncate text-(--txt-primary)">
                     {m.member_display_name ?? m.member_email ?? m.member_id}
                   </span>
                   {checked && (
-                    <span className="ml-auto text-[var(--txt-tertiary)]">
+                    <span className="ml-auto text-(--txt-tertiary)">
                       ✓
                     </span>
                   )}
@@ -1083,7 +1083,7 @@ export function WorkspaceViewsPage() {
       const firstLabel = firstLabelId ? getLabel(firstLabelId) : undefined;
       const displayValue = firstLabel ? firstLabel.name : "Select labels";
       const labelsTriggerContent = firstLabel ? (
-        <span className="inline-flex min-w-0 items-center gap-2 text-[var(--txt-secondary)]">
+        <span className="inline-flex min-w-0 items-center gap-2 text-(--txt-secondary)">
           <span
             className="size-2.5 shrink-0 rounded-full"
             style={{
@@ -1093,7 +1093,7 @@ export function WorkspaceViewsPage() {
           <span className="truncate">{firstLabel.name}</span>
         </span>
       ) : (
-        <span className="inline-flex min-w-0 items-center gap-2 text-[var(--txt-tertiary)]">
+        <span className="inline-flex min-w-0 items-center gap-2 text-(--txt-tertiary)">
           <IconTag className="size-3.5 shrink-0 opacity-70" />
           <span className="truncate">Select labels</span>
         </span>
@@ -1105,16 +1105,16 @@ export function WorkspaceViewsPage() {
           onOpen={setOpenCellId}
           label="Labels"
           icon={
-            <IconTag className="size-3.5 text-[var(--txt-icon-tertiary)]" />
+            <IconTag className="size-3.5 text-(--txt-icon-tertiary)" />
           }
           displayValue={displayValue}
           triggerClassName={CELL_TRIGGER_CLASS}
           triggerContent={labelsTriggerContent}
           align="right"
-          panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-1 shadow-[var(--shadow-raised)]"
+          panelClassName="max-h-72 min-w-[220px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)"
         >
           {labels.length === 0 ? (
-            <div className="px-3 py-2 text-sm text-[var(--txt-tertiary)]">
+            <div className="px-3 py-2 text-sm text-(--txt-tertiary)">
               No labels.
             </div>
           ) : (
@@ -1124,7 +1124,7 @@ export function WorkspaceViewsPage() {
                 <button
                   key={l.id}
                   type="button"
-                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--bg-layer-1-hover)]"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
                   onClick={() => {
                     const next = checked
                       ? labelIds.filter((x) => x !== l.id)
@@ -1138,11 +1138,11 @@ export function WorkspaceViewsPage() {
                       backgroundColor: l.color ?? "var(--txt-icon-tertiary)",
                     }}
                   />
-                  <span className="truncate text-[var(--txt-primary)]">
+                  <span className="truncate text-(--txt-primary)">
                     {l.name}
                   </span>
                   {checked && (
-                    <span className="ml-auto text-[var(--txt-tertiary)]">
+                    <span className="ml-auto text-(--txt-tertiary)">
                       ✓
                     </span>
                   )}
@@ -1164,12 +1164,12 @@ export function WorkspaceViewsPage() {
           onOpen={setOpenCellId}
           label="Start date"
           icon={
-            <IconCalendar className="size-3.5 text-[var(--txt-icon-tertiary)]" />
+            <IconCalendar className="size-3.5 text-(--txt-icon-tertiary)" />
           }
           displayValue={displayValue}
           triggerClassName={CELL_TRIGGER_CLASS}
           align="right"
-          panelClassName="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-2 shadow-[var(--shadow-raised)]"
+          panelClassName="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-2 shadow-(--shadow-raised)"
         >
           <input
             type="date"
@@ -1179,7 +1179,7 @@ export function WorkspaceViewsPage() {
               updateIssue(issue, { start_date: v });
               setOpenCellId(null);
             }}
-            className="rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5 text-sm text-[var(--txt-primary)]"
+            className="rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5 text-sm text-(--txt-primary)"
           />
         </Dropdown>
       );
@@ -1195,12 +1195,12 @@ export function WorkspaceViewsPage() {
           onOpen={setOpenCellId}
           label="Due date"
           icon={
-            <IconCalendar className="size-3.5 text-[var(--txt-icon-tertiary)]" />
+            <IconCalendar className="size-3.5 text-(--txt-icon-tertiary)" />
           }
           displayValue={displayValue}
           triggerClassName={CELL_TRIGGER_CLASS}
           align="right"
-          panelClassName="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-2 shadow-[var(--shadow-raised)]"
+          panelClassName="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-2 shadow-(--shadow-raised)"
         >
           <input
             type="date"
@@ -1210,7 +1210,7 @@ export function WorkspaceViewsPage() {
               updateIssue(issue, { target_date: v });
               setOpenCellId(null);
             }}
-            className="rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2 py-1.5 text-sm text-[var(--txt-primary)]"
+            className="rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5 text-sm text-(--txt-primary)"
           />
         </Dropdown>
       );
@@ -1219,19 +1219,19 @@ export function WorkspaceViewsPage() {
   };
 
   return (
-    <div className="-mt-[var(--padding-page)] -mr-[var(--padding-page)] -mb-[var(--padding-page)] flex min-h-0 flex-1 flex-col">
+    <div className="-mt-(--padding-page) -mr-(--padding-page) -mb-(--padding-page) flex min-h-0 flex-1 flex-col">
       <div className="flex-1">
         <table className="w-full min-w-max border-collapse text-left text-sm">
           <thead>
-            <tr className="border-b border-[var(--border-subtle)] bg-[var(--bg-layer-1)]">
-              <th className="sticky left-0 z-10 min-w-[200px] whitespace-nowrap border-r border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-4 py-2">
+            <tr className="border-b border-(--border-subtle) bg-(--bg-layer-1)">
+              <th className="sticky left-0 z-10 min-w-[200px] whitespace-nowrap border-r border-(--border-subtle) bg-(--bg-layer-1) px-4 py-2">
                 {(() => {
                   const isActive = display.sortBy === "name";
                   return (
                     <button
                       type="button"
                       onClick={() => handleSort("name")}
-                      className="inline-flex items-center gap-1.5 hover:text-[var(--txt-primary)] font-medium text-[var(--txt-secondary)]"
+                      className="inline-flex items-center gap-1.5 hover:text-(--txt-primary) font-medium text-(--txt-secondary)"
                     >
                       Work items
                       <IconChevronDown
@@ -1254,7 +1254,7 @@ export function WorkspaceViewsPage() {
               <tr>
                 <td
                   colSpan={totalCols}
-                  className="px-4 py-16 text-center text-sm text-[var(--txt-tertiary)]"
+                  className="px-4 py-16 text-center text-sm text-(--txt-tertiary)"
                 >
                   No work items yet. Create one from a project&apos;s Work items
                   section or add a view to get started.
@@ -1269,15 +1269,15 @@ export function WorkspaceViewsPage() {
                 return (
                   <tr
                     key={issue.id}
-                    className="border-b border-[var(--border-subtle)] last:border-b-0 transition-colors"
+                    className="border-b border-(--border-subtle) last:border-b-0 transition-colors"
                   >
-                    <td className="sticky left-0 z-10 min-w-[200px] border-r border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-4 py-2 hover:bg-[var(--bg-layer-1-hover)]">
+                    <td className="sticky left-0 z-10 min-w-[200px] border-r border-(--border-subtle) bg-(--bg-surface-1) px-4 py-2 hover:bg-(--bg-layer-1-hover)">
                       <Link
                         to={`${issueBaseUrl}/issues/${issue.id}`}
-                        className="block font-medium text-[var(--txt-primary)] no-underline hover:text-[var(--txt-accent-primary)]"
+                        className="block font-medium text-(--txt-primary) no-underline hover:text-(--txt-accent-primary)"
                       >
                         {display.properties.includes("id") && (
-                          <span className="mr-3 text-[var(--txt-secondary)]">
+                          <span className="mr-3 text-(--txt-secondary)">
                             {project
                               ? `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`
                               : issue.id.slice(-4)}
@@ -1291,8 +1291,8 @@ export function WorkspaceViewsPage() {
                         key={colKey}
                         className={
                           isEditableColumn(colKey)
-                            ? `border-r-column-subtle p-0 whitespace-nowrap last:border-r-0${isFirstScrollableColumn(colKey) ? " border-l border-[var(--border-subtle)]" : ""}`
-                            : `border-r-column-subtle px-4 py-2 whitespace-nowrap last:border-r-0${isFirstScrollableColumn(colKey) ? " border-l border-[var(--border-subtle)]" : ""}`
+                            ? `border-r-column-subtle p-0 whitespace-nowrap last:border-r-0${isFirstScrollableColumn(colKey) ? " border-l border-(--border-subtle)" : ""}`
+                            : `border-r-column-subtle px-4 py-2 whitespace-nowrap last:border-r-0${isFirstScrollableColumn(colKey) ? " border-l border-(--border-subtle)" : ""}`
                         }
                       >
                         {renderTableCell(issue, colKey)}

--- a/ui/src/pages/instance-admin/InstanceAdminAIPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminAIPage.tsx
@@ -99,9 +99,7 @@ export function InstanceAdminAIPage() {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
-      )}
+      {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
 
       <section className="space-y-3">
         <h2 className="text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">

--- a/ui/src/pages/instance-admin/InstanceAdminAIPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminAIPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Button, IconEye, IconEyeOff, Skeleton } from "../../components/ui";
 import { instanceSettingsService } from "../../services/instanceService";
 import { getApiErrorMessage } from "../../api/client";
@@ -90,45 +90,45 @@ export function InstanceAdminAIPage() {
   return (
     <div className="w-full max-w-6xl space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           AI features for all your workspaces
         </h1>
-        <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+        <p className="mt-0.5 text-xs text-(--txt-secondary)">
           Configure your AI API credentials so Devlane AI features are turned on
           for all your workspaces.
         </p>
       </div>
 
       {error && (
-        <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
       )}
 
       <section className="space-y-3">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--txt-secondary)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">
           OpenAI
         </h2>
-        <p className="text-xs text-[var(--txt-secondary)]">
+        <p className="text-xs text-(--txt-secondary)">
           If you use ChatGPT, this is for you.
         </p>
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           LLM Model
           <input
             type="text"
             value={ai.model ?? ""}
             onChange={(e) => setAi((p) => ({ ...p, model: e.target.value }))}
-            className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+            className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
           />
-          <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+          <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
             Choose an OpenAI engine.{" "}
             <a
               href="#"
-              className="text-[var(--txt-accent-primary)] underline hover:no-underline"
+              className="text-(--txt-accent-primary) underline hover:no-underline"
             >
               Learn more
             </a>
           </p>
         </label>
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           API key
           <div className="relative mt-0.5">
             <input
@@ -139,22 +139,22 @@ export function InstanceAdminAIPage() {
                 if (apiKeyLocal === undefined) setApiKeyLocal(apiKeyDisplay);
               }}
               placeholder={!apiKeyDisplay ? "Enter API key" : ""}
-              className="block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 pr-9 text-xs text-[var(--txt-primary)] focus:outline-none"
+              className="block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 pr-9 text-xs text-(--txt-primary) focus:outline-none"
             />
             <button
               type="button"
               onClick={() => setShowApiKey((v) => !v)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
               aria-label={showApiKey ? "Hide API key" : "Show API key"}
             >
               {showApiKey ? <IconEyeOff /> : <IconEye />}
             </button>
           </div>
-          <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+          <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
             You will find your API key{" "}
             <a
               href="#"
-              className="text-[var(--txt-accent-primary)] underline hover:no-underline"
+              className="text-(--txt-accent-primary) underline hover:no-underline"
             >
               here
             </a>

--- a/ui/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+﻿import React, { useEffect, useState } from "react";
 import { Button, Skeleton } from "../../components/ui";
 import { instanceSettingsService } from "../../services/instanceService";
 import { getApiErrorMessage } from "../../api/client";
@@ -182,7 +182,7 @@ export function InstanceAdminAuthenticationPage() {
           <Skeleton className="h-4 w-80" />
           <Skeleton className="mt-1.5 h-3 w-full max-w-xl" />
         </div>
-        <section className="flex items-start justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3">
+        <section className="flex items-start justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3">
           <div className="min-w-0 flex-1 space-y-1">
             <Skeleton className="h-3 w-64" />
             <Skeleton className="h-3 w-full max-w-md" />
@@ -195,7 +195,7 @@ export function InstanceAdminAuthenticationPage() {
             {[1, 2, 3, 4, 5].map((i) => (
               <li
                 key={i}
-                className="flex items-center justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3"
+                className="flex items-center justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3"
               >
                 <div className="flex min-w-0 flex-1 items-center gap-2.5">
                   <Skeleton className="size-4 shrink-0 rounded" />
@@ -216,29 +216,29 @@ export function InstanceAdminAuthenticationPage() {
   return (
     <div className="w-full space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           Manage authentication modes for your instance
         </h1>
-        <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+        <p className="mt-0.5 text-xs text-(--txt-secondary)">
           Configure authentication modes for your team and restrict sign-ups to
           be invite only.
         </p>
       </div>
 
       {error && (
-        <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
       )}
 
-      <section className="flex items-start justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3">
+      <section className="flex items-start justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3">
         <div>
-          <p className="text-xs font-medium text-[var(--txt-primary)]">
+          <p className="text-xs font-medium text-(--txt-primary)">
             Allow anyone to sign up even without an invite
           </p>
-          <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+          <p className="mt-0.5 text-xs text-(--txt-secondary)">
             Toggling this off will only let users sign up when they are invited.
           </p>
         </div>
-        <label className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full bg-[var(--neutral-400)] has-[:checked]:bg-[var(--brand-default)]">
+        <label className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full bg-(--neutral-400) has-[:checked]:bg-(--brand-default)">
           <input
             type="checkbox"
             className="peer sr-only"
@@ -252,7 +252,7 @@ export function InstanceAdminAuthenticationPage() {
       </section>
 
       <section>
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-[var(--txt-secondary)]">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">
           Available authentication modes
         </h2>
         <ul className="space-y-2">
@@ -262,17 +262,17 @@ export function InstanceAdminAuthenticationPage() {
             return (
               <li
                 key={item.key}
-                className="flex items-center justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3"
+                className="flex items-center justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3"
               >
                 <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                  <span className="flex shrink-0 text-[var(--txt-icon-tertiary)] [&_svg]:size-4 [&_svg]:shrink-0">
+                  <span className="flex shrink-0 text-(--txt-icon-tertiary) [&_svg]:size-4 [&_svg]:shrink-0">
                     <Icon />
                   </span>
                   <div>
-                    <p className="text-sm font-medium text-[var(--txt-primary)]">
+                    <p className="text-sm font-medium text-(--txt-primary)">
                       {item.name}
                     </p>
-                    <p className="text-xs text-[var(--txt-secondary)]">
+                    <p className="text-xs text-(--txt-secondary)">
                       {item.desc}
                     </p>
                   </div>
@@ -283,7 +283,7 @@ export function InstanceAdminAuthenticationPage() {
                       {item.action}
                     </Button>
                   )}
-                  <label className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full bg-[var(--neutral-400)] has-[:checked]:bg-[var(--brand-default)]">
+                  <label className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full bg-(--neutral-400) has-[:checked]:bg-(--brand-default)">
                     <input
                       type="checkbox"
                       className="peer sr-only"

--- a/ui/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
@@ -225,9 +225,7 @@ export function InstanceAdminAuthenticationPage() {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
-      )}
+      {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
 
       <section className="flex items-start justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3">
         <div>

--- a/ui/src/pages/instance-admin/InstanceAdminCreateWorkspacePage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminCreateWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+﻿import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Button, Input } from "../../components/ui";
 import { CreateWorkspaceSetupHint } from "../../components/instance-admin/CreateWorkspaceSetupHint";
@@ -90,10 +90,10 @@ export function InstanceAdminCreateWorkspacePage() {
   return (
     <div className="w-full space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           Create a new workspace on this instance.
         </h1>
-        <p className="mt-1 text-sm text-[var(--txt-secondary)]">
+        <p className="mt-1 text-sm text-(--txt-secondary)">
           You will need to invite users from Workspace Settings after you create
           this workspace.
         </p>
@@ -111,12 +111,12 @@ export function InstanceAdminCreateWorkspacePage() {
         <div className="flex flex-col gap-1">
           <label
             htmlFor="workspace-url"
-            className="text-sm font-medium text-[var(--txt-secondary)]"
+            className="text-sm font-medium text-(--txt-secondary)"
           >
             Set your workspace&apos;s URL
           </label>
-          <div className="flex flex-1 items-center gap-0 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-sm">
-            <span className="shrink-0 truncate border-r border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-3 py-2 text-[var(--txt-tertiary)]">
+          <div className="flex flex-1 items-center gap-0 overflow-hidden rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) text-sm">
+            <span className="shrink-0 truncate border-r border-(--border-subtle) bg-(--bg-layer-1) px-3 py-2 text-(--txt-tertiary)">
               {baseUrl}
             </span>
             <input
@@ -127,7 +127,7 @@ export function InstanceAdminCreateWorkspacePage() {
                 setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))
               }
               placeholder="workspace-name"
-              className="min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+              className="min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
             />
           </div>
         </div>
@@ -135,7 +135,7 @@ export function InstanceAdminCreateWorkspacePage() {
         <div className="flex flex-col gap-1">
           <label
             htmlFor="organization-size"
-            className="text-sm font-medium text-[var(--txt-secondary)]"
+            className="text-sm font-medium text-(--txt-secondary)"
           >
             How many people will use this workspace?
           </label>
@@ -144,7 +144,7 @@ export function InstanceAdminCreateWorkspacePage() {
               id="organization-size"
               value={organizationSize}
               onChange={(e) => setOrganizationSize(e.target.value)}
-              className="h-9 w-full max-w-md appearance-none rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] pl-3 pr-9 text-sm text-[var(--txt-primary)] focus:outline-none"
+              className="h-9 w-full max-w-md appearance-none rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) pl-3 pr-9 text-sm text-(--txt-primary) focus:outline-none"
             >
               {ORGANIZATION_SIZE_OPTIONS.map((opt) => (
                 <option key={opt.value || "empty"} value={opt.value}>
@@ -152,14 +152,14 @@ export function InstanceAdminCreateWorkspacePage() {
                 </option>
               ))}
             </select>
-            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--txt-icon-tertiary)]">
+            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-(--txt-icon-tertiary)">
               <IconChevronDown />
             </span>
           </div>
         </div>
 
         {error && (
-          <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+          <p className="text-sm text-(--txt-danger-primary)">{error}</p>
         )}
 
         <div className="flex flex-wrap gap-3">

--- a/ui/src/pages/instance-admin/InstanceAdminEmailPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminEmailPage.tsx
@@ -140,9 +140,7 @@ export function InstanceAdminEmailPage() {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
-      )}
+      {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
 
       <section className="space-y-3">
         <div className="grid gap-2.5 sm:grid-cols-2">

--- a/ui/src/pages/instance-admin/InstanceAdminEmailPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminEmailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Button, IconEye, IconEyeOff, Skeleton } from "../../components/ui";
 import { instanceSettingsService } from "../../services/instanceService";
 import { getApiErrorMessage } from "../../api/client";
@@ -127,26 +127,26 @@ export function InstanceAdminEmailPage() {
   return (
     <div className="w-full max-w-6xl space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           Secure emails from your own instance
         </h1>
-        <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+        <p className="mt-0.5 text-xs text-(--txt-secondary)">
           Devlane can send useful emails to you and your users from your own
           instance without talking to the Internet. Set it up below and please
           test your settings before you save them.{" "}
-          <span className="text-[var(--txt-danger-primary)]">
+          <span className="text-(--txt-danger-primary)">
             Misconfigs can lead to email bounces and errors.
           </span>
         </p>
       </div>
 
       {error && (
-        <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
       )}
 
       <section className="space-y-3">
         <div className="grid gap-2.5 sm:grid-cols-2">
-          <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+          <label className="block text-xs font-medium text-(--txt-secondary)">
             Host
             <input
               type="text"
@@ -154,10 +154,10 @@ export function InstanceAdminEmailPage() {
               onChange={(e) =>
                 setEmail((p) => ({ ...p, host: e.target.value }))
               }
-              className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+              className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
             />
           </label>
-          <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+          <label className="block text-xs font-medium text-(--txt-secondary)">
             Port
             <input
               type="text"
@@ -165,11 +165,11 @@ export function InstanceAdminEmailPage() {
               onChange={(e) =>
                 setEmail((p) => ({ ...p, port: e.target.value }))
               }
-              className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+              className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
             />
           </label>
         </div>
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           Sender&apos;s email address
           <input
             type="email"
@@ -177,21 +177,21 @@ export function InstanceAdminEmailPage() {
             onChange={(e) =>
               setEmail((p) => ({ ...p, sender_email: e.target.value }))
             }
-            className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+            className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
           />
-          <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+          <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
             This is the email address your users will see when getting emails
             from this instance. You will need to verify this address.
           </p>
         </label>
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           Email security
           <select
             value={email.security ?? "TLS"}
             onChange={(e) =>
               setEmail((p) => ({ ...p, security: e.target.value }))
             }
-            className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+            className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
           >
             <option value="TLS">TLS</option>
             <option value="SSL">SSL</option>
@@ -201,14 +201,14 @@ export function InstanceAdminEmailPage() {
       </section>
 
       <section className="space-y-3">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--txt-secondary)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">
           Authentication
         </h2>
-        <p className="text-xs text-[var(--txt-secondary)]">
+        <p className="text-xs text-(--txt-secondary)">
           This is optional, but we recommend setting up a username and a
           password for your SMTP server.
         </p>
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           Username
           <input
             type="text"
@@ -216,10 +216,10 @@ export function InstanceAdminEmailPage() {
             onChange={(e) =>
               setEmail((p) => ({ ...p, username: e.target.value }))
             }
-            className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+            className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
           />
         </label>
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           Password
           <div className="relative mt-0.5">
             <input
@@ -231,18 +231,18 @@ export function InstanceAdminEmailPage() {
                   setSmtpPasswordLocal(smtpPasswordDisplay);
               }}
               placeholder={!smtpPasswordDisplay ? "Set password" : ""}
-              className="block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 pr-9 text-xs text-[var(--txt-primary)] focus:outline-none"
+              className="block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 pr-9 text-xs text-(--txt-primary) focus:outline-none"
             />
             <button
               type="button"
               onClick={() => setShowSmtpPassword((v) => !v)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
               aria-label={showSmtpPassword ? "Hide password" : "Show password"}
             >
               {showSmtpPassword ? <IconEyeOff /> : <IconEye />}
             </button>
           </div>
-          <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+          <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
             Leave blank to keep existing password.
           </p>
         </label>

--- a/ui/src/pages/instance-admin/InstanceAdminGeneralPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminGeneralPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Button, Skeleton } from "../../components/ui";
 import { instanceSettingsService } from "../../services/instanceService";
 import { getApiErrorMessage } from "../../api/client";
@@ -77,54 +77,54 @@ export function InstanceAdminGeneralPage() {
   return (
     <div className="w-full space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           General settings
         </h1>
-        <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+        <p className="mt-0.5 text-xs text-(--txt-secondary)">
           Change the name of your instance. Admin email and instance ID are set
           at setup and cannot be changed here.
         </p>
       </div>
 
       {error && (
-        <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
       )}
 
       <section className="space-y-3">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--txt-secondary)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">
           Instance details
         </h2>
         <div className="space-y-2.5">
-          <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+          <label className="block text-xs font-medium text-(--txt-secondary)">
             Name of instance
             <input
               type="text"
               value={instanceName}
               onChange={(e) => setInstanceName(e.target.value)}
-              className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 text-xs text-[var(--txt-primary)] focus:outline-none"
+              className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 text-xs text-(--txt-primary) focus:outline-none"
             />
           </label>
-          <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+          <label className="block text-xs font-medium text-(--txt-secondary)">
             Email
             <input
               type="email"
               readOnly
               value={adminEmail}
-              className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2.5 py-1.5 text-xs text-[var(--txt-tertiary)] focus:outline-none"
+              className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2.5 py-1.5 text-xs text-(--txt-tertiary) focus:outline-none"
             />
-            <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+            <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
               Set at initial setup.
             </p>
           </label>
-          <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+          <label className="block text-xs font-medium text-(--txt-secondary)">
             Instance ID
             <input
               type="text"
               readOnly
               value={instanceId}
-              className="mt-0.5 block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-layer-1)] px-2.5 py-1.5 text-xs text-[var(--txt-tertiary)] focus:outline-none"
+              className="mt-0.5 block w-full rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2.5 py-1.5 text-xs text-(--txt-tertiary) focus:outline-none"
             />
-            <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+            <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
               Generated at setup.
             </p>
           </label>

--- a/ui/src/pages/instance-admin/InstanceAdminGeneralPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminGeneralPage.tsx
@@ -86,9 +86,7 @@ export function InstanceAdminGeneralPage() {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
-      )}
+      {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
 
       <section className="space-y-3">
         <h2 className="text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">

--- a/ui/src/pages/instance-admin/InstanceAdminImagePage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminImagePage.tsx
@@ -97,9 +97,7 @@ export function InstanceAdminImagePage() {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
-      )}
+      {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
 
       <section className="space-y-3">
         <label className="block text-xs font-medium text-(--txt-secondary)">

--- a/ui/src/pages/instance-admin/InstanceAdminImagePage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminImagePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Button, IconEye, IconEyeOff, Skeleton } from "../../components/ui";
 import { instanceSettingsService } from "../../services/instanceService";
 import { getApiErrorMessage } from "../../api/client";
@@ -89,20 +89,20 @@ export function InstanceAdminImagePage() {
   return (
     <div className="w-full max-w-6xl space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           Third-party image libraries
         </h1>
-        <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+        <p className="mt-0.5 text-xs text-(--txt-secondary)">
           Let your users search and choose images from third-party libraries.
         </p>
       </div>
 
       {error && (
-        <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
       )}
 
       <section className="space-y-3">
-        <label className="block text-xs font-medium text-[var(--txt-secondary)]">
+        <label className="block text-xs font-medium text-(--txt-secondary)">
           Access key from your Unsplash account
           <div className="relative mt-0.5">
             <input
@@ -114,24 +114,24 @@ export function InstanceAdminImagePage() {
                   setAccessKeyLocal(accessKeyDisplay);
               }}
               placeholder={!accessKeyDisplay ? "Enter access key" : ""}
-              className="block w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] px-2.5 py-1.5 pr-9 text-xs text-[var(--txt-primary)] focus:outline-none"
+              className="block w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5 pr-9 text-xs text-(--txt-primary) focus:outline-none"
             />
             <button
               type="button"
               onClick={() => setShowAccessKey((v) => !v)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
               aria-label={showAccessKey ? "Hide access key" : "Show access key"}
             >
               {showAccessKey ? <IconEyeOff /> : <IconEye />}
             </button>
           </div>
-          <p className="mt-0.5 text-[11px] text-[var(--txt-tertiary)]">
+          <p className="mt-0.5 text-[11px] text-(--txt-tertiary)">
             You will find your access key in your Unsplash developer console.{" "}
             <a
               href="https://unsplash.com/developers/docs/api-reference/access-key"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[var(--txt-accent-primary)] underline hover:no-underline"
+              className="text-(--txt-accent-primary) underline hover:no-underline"
             >
               Learn more.
             </a>

--- a/ui/src/pages/instance-admin/InstanceAdminLoginPage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminLoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+﻿import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, IconEye, IconEyeOff, Input } from "../../components/ui";
 
@@ -41,11 +41,11 @@ export function InstanceAdminLoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--bg-canvas)]">
+    <div className="flex min-h-screen flex-col bg-(--bg-canvas)">
       {/* Top-left branding */}
       <header className="shrink-0 px-6 py-4">
-        <div className="flex items-center gap-2 text-lg font-semibold text-[var(--txt-primary)]">
-          <span className="flex size-9 items-center justify-center rounded-lg bg-[var(--bg-layer-2)] text-[var(--txt-icon-secondary)]">
+        <div className="flex items-center gap-2 text-lg font-semibold text-(--txt-primary)">
+          <span className="flex size-9 items-center justify-center rounded-lg bg-(--bg-layer-2) text-(--txt-icon-secondary)">
             <IconGlobe />
           </span>
           Devlane
@@ -55,10 +55,10 @@ export function InstanceAdminLoginPage() {
       {/* Centered form */}
       <main className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 py-8">
         <div className="w-full max-w-sm">
-          <h1 className="text-center text-xl font-semibold text-[var(--txt-primary)]">
+          <h1 className="text-center text-xl font-semibold text-(--txt-primary)">
             Manage your Devlane instance
           </h1>
-          <p className="mt-2 text-center text-sm text-[var(--txt-secondary)]">
+          <p className="mt-2 text-center text-sm text-(--txt-secondary)">
             Configure instance-wide settings to secure your instance.
           </p>
           <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-4">
@@ -75,7 +75,7 @@ export function InstanceAdminLoginPage() {
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="instance-admin-password"
-                className="text-sm font-medium text-[var(--txt-secondary)]"
+                className="text-sm font-medium text-(--txt-secondary)"
               >
                 Password *
               </label>
@@ -88,19 +88,19 @@ export function InstanceAdminLoginPage() {
                   placeholder="Enter your password"
                   required
                   autoComplete="current-password"
-                  className="h-9 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-10 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                  className="h-9 w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-3 pr-10 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword((p) => !p)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? <IconEyeOff /> : <IconEye />}
                 </button>
               </div>
               {error && (
-                <span className="text-xs text-[var(--txt-danger-primary)]">
+                <span className="text-xs text-(--txt-danger-primary)">
                   {error}
                 </span>
               )}

--- a/ui/src/pages/instance-admin/InstanceAdminWorkspacePage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+﻿import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button, Skeleton } from "../../components/ui";
 import { workspaceService } from "../../services/workspaceService";
@@ -81,7 +81,7 @@ export function InstanceAdminWorkspacePage() {
           <Skeleton className="h-4 w-56" />
           <Skeleton className="mt-1.5 h-3 w-full max-w-md" />
         </div>
-        <section className="flex items-start justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3">
+        <section className="flex items-start justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3">
           <div className="min-w-0 flex-1 space-y-1">
             <Skeleton className="h-3 w-72" />
             <Skeleton className="h-3 w-full max-w-lg" />
@@ -99,7 +99,7 @@ export function InstanceAdminWorkspacePage() {
             {[1, 2, 3].map((i) => (
               <li
                 key={i}
-                className="flex items-center justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3"
+                className="flex items-center justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3"
               >
                 <div className="min-w-0 flex-1">
                   <Skeleton className="h-4 w-32" />
@@ -117,29 +117,29 @@ export function InstanceAdminWorkspacePage() {
   return (
     <div className="w-full space-y-6">
       <div>
-        <h1 className="text-base font-semibold text-[var(--txt-primary)]">
+        <h1 className="text-base font-semibold text-(--txt-primary)">
           Workspaces on this instance
         </h1>
-        <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+        <p className="mt-0.5 text-xs text-(--txt-secondary)">
           See all workspaces and control who can create them.
         </p>
       </div>
 
       {error && (
-        <p className="text-sm text-[var(--txt-danger-primary)]">{error}</p>
+        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
       )}
 
-      <section className="flex items-start justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3">
+      <section className="flex items-start justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3">
         <div>
-          <p className="text-xs font-medium text-[var(--txt-primary)]">
+          <p className="text-xs font-medium text-(--txt-primary)">
             Prevent anyone else from creating a workspace.
           </p>
-          <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+          <p className="mt-0.5 text-xs text-(--txt-secondary)">
             Toggling this on will let only you (the instance admin) create
             workspaces. You will have to invite users to new workspaces.
           </p>
         </div>
-        <label className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full bg-[var(--neutral-400)] has-[:checked]:bg-[var(--brand-default)]">
+        <label className="relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full bg-(--neutral-400) has-[:checked]:bg-(--brand-default)">
           <input
             type="checkbox"
             className="peer sr-only"
@@ -154,10 +154,10 @@ export function InstanceAdminWorkspacePage() {
       <section>
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--txt-secondary)]">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-(--txt-secondary)">
               All workspaces on this instance • {workspaces.length}
             </h2>
-            <p className="mt-0.5 text-xs text-[var(--txt-secondary)]">
+            <p className="mt-0.5 text-xs text-(--txt-secondary)">
               You can&apos;t yet delete workspaces and you can only go to the
               workspace if you are an Admin or a Member.
             </p>
@@ -172,7 +172,7 @@ export function InstanceAdminWorkspacePage() {
           </Button>
         </div>
         {error && (
-          <p className="mb-3 text-sm text-[var(--txt-danger-primary)]">
+          <p className="mb-3 text-sm text-(--txt-danger-primary)">
             {error}
           </p>
         )}
@@ -180,24 +180,24 @@ export function InstanceAdminWorkspacePage() {
           {workspaces.map((w) => (
             <li
               key={w.id}
-              className="flex items-center justify-between gap-3 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] p-3"
+              className="flex items-center justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3"
             >
               <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                <span className="flex size-8 shrink-0 items-center justify-center rounded bg-[var(--bg-layer-2)] text-sm font-semibold text-[var(--txt-icon-secondary)]">
+                <span className="flex size-8 shrink-0 items-center justify-center rounded bg-(--bg-layer-2) text-sm font-semibold text-(--txt-icon-secondary)">
                   {w.name.charAt(0)}
                 </span>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-[var(--txt-primary)]">
+                  <p className="text-sm font-medium text-(--txt-primary)">
                     {w.name}
                   </p>
-                  <p className="text-xs text-[var(--txt-tertiary)]">
+                  <p className="text-xs text-(--txt-tertiary)">
                     [{w.slug}]
                   </p>
                 </div>
               </div>
               <Link
                 to={`/${w.slug}`}
-                className="flex size-8 shrink-0 items-center justify-center rounded text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                className="flex size-8 shrink-0 items-center justify-center rounded text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                 aria-label="Go to workspace"
               >
                 <svg

--- a/ui/src/pages/instance-admin/InstanceAdminWorkspacePage.tsx
+++ b/ui/src/pages/instance-admin/InstanceAdminWorkspacePage.tsx
@@ -125,9 +125,7 @@ export function InstanceAdminWorkspacePage() {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm text-(--txt-danger-primary)">{error}</p>
-      )}
+      {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
 
       <section className="flex items-start justify-between gap-3 rounded border border-(--border-subtle) bg-(--bg-surface-1) p-3">
         <div>
@@ -172,9 +170,7 @@ export function InstanceAdminWorkspacePage() {
           </Button>
         </div>
         {error && (
-          <p className="mb-3 text-sm text-(--txt-danger-primary)">
-            {error}
-          </p>
+          <p className="mb-3 text-sm text-(--txt-danger-primary)">{error}</p>
         )}
         <ul className="space-y-2">
           {workspaces.map((w) => (
@@ -190,9 +186,7 @@ export function InstanceAdminWorkspacePage() {
                   <p className="text-sm font-medium text-(--txt-primary)">
                     {w.name}
                   </p>
-                  <p className="text-xs text-(--txt-tertiary)">
-                    [{w.slug}]
-                  </p>
+                  <p className="text-xs text-(--txt-tertiary)">[{w.slug}]</p>
                 </div>
               </div>
               <Link

--- a/ui/src/pages/setup/InstanceSetupCompletePage.tsx
+++ b/ui/src/pages/setup/InstanceSetupCompletePage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+﻿import { useNavigate } from "react-router-dom";
 import { Button, Card, CardContent } from "../../components/ui";
 
 const IconWorkspace = () => (
@@ -34,15 +34,15 @@ export function InstanceSetupCompletePage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg-canvas)] px-4 py-8">
-      <Card className="w-full max-w-lg border-[var(--border-subtle)] bg-[var(--bg-surface-1)]">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-(--bg-canvas) px-4 py-8">
+      <Card className="w-full max-w-lg border-(--border-subtle) bg-(--bg-surface-1)">
         <CardContent className="p-6">
           <div className="flex gap-6">
             <div className="min-w-0 flex-1">
-              <h2 className="text-xl font-semibold text-[var(--txt-primary)]">
+              <h2 className="text-xl font-semibold text-(--txt-primary)">
                 Create workspace
               </h2>
-              <p className="mt-2 text-sm text-[var(--txt-secondary)]">
+              <p className="mt-2 text-sm text-(--txt-secondary)">
                 Instance setup is complete. Welcome to your Devlane instance.
                 Start your journey by creating your first workspace.
               </p>
@@ -61,7 +61,7 @@ export function InstanceSetupCompletePage() {
               </div>
             </div>
             <div className="hidden shrink-0 sm:block">
-              <span className="flex size-16 items-center justify-center rounded-full bg-[var(--bg-accent-subtle)] text-[var(--txt-accent-primary)]">
+              <span className="flex size-16 items-center justify-center rounded-full bg-(--bg-accent-subtle) text-(--txt-accent-primary)">
                 <IconWorkspace />
               </span>
             </div>

--- a/ui/src/pages/setup/InstanceSetupConfigurePage.tsx
+++ b/ui/src/pages/setup/InstanceSetupConfigurePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+﻿import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, Input } from "../../components/ui";
 import { useAuth } from "../../contexts/AuthContext";
@@ -7,7 +7,7 @@ import { getApiErrorMessage } from "../../api/client";
 
 const LogoMark = () => (
   <span
-    className="flex size-9 items-center justify-center rounded-lg bg-[var(--bg-accent-primary)] text-[var(--txt-on-color)]"
+    className="flex size-9 items-center justify-center rounded-lg bg-(--bg-accent-primary) text-(--txt-on-color)"
     aria-hidden
   >
     <svg
@@ -91,12 +91,12 @@ function usePasswordRequirements(password: string) {
 
 function PasswordRequirement({ met, label }: { met: boolean; label: string }) {
   return (
-    <div className="flex items-center gap-2 text-sm text-[var(--txt-secondary)]">
+    <div className="flex items-center gap-2 text-sm text-(--txt-secondary)">
       <span
         className={`flex size-5 shrink-0 items-center justify-center rounded-full ${
           met
-            ? "bg-[var(--bg-success-primary)] text-[var(--txt-on-color)]"
-            : "bg-[var(--bg-layer-1)] text-[var(--txt-placeholder)]"
+            ? "bg-(--bg-success-primary) text-(--txt-on-color)"
+            : "bg-(--bg-layer-1) text-(--txt-placeholder)"
         }`}
         aria-hidden
       >
@@ -170,9 +170,9 @@ export function InstanceSetupConfigurePage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--bg-canvas)]">
+    <div className="flex min-h-screen flex-col bg-(--bg-canvas)">
       <header className="shrink-0 px-6 py-4">
-        <div className="flex items-center gap-2 text-lg font-semibold text-[var(--txt-primary)]">
+        <div className="flex items-center gap-2 text-lg font-semibold text-(--txt-primary)">
           <LogoMark />
           Devlane
         </div>
@@ -180,10 +180,10 @@ export function InstanceSetupConfigurePage() {
 
       <main className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 py-8">
         <div className="w-full max-w-md">
-          <h1 className="text-center text-xl font-semibold text-[var(--txt-primary)]">
+          <h1 className="text-center text-xl font-semibold text-(--txt-primary)">
             Setup your Devlane instance
           </h1>
-          <p className="mt-2 text-center text-sm text-[var(--txt-secondary)]">
+          <p className="mt-2 text-center text-sm text-(--txt-secondary)">
             Post setup you will be able to manage this Devlane instance.
           </p>
 
@@ -227,7 +227,7 @@ export function InstanceSetupConfigurePage() {
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="setup-password"
-                className="text-sm font-medium text-[var(--txt-secondary)]"
+                className="text-sm font-medium text-(--txt-secondary)"
               >
                 Set a password *
               </label>
@@ -240,12 +240,12 @@ export function InstanceSetupConfigurePage() {
                   placeholder="New password..."
                   required
                   autoComplete="new-password"
-                  className="h-9 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-10 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                  className="h-9 w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-3 pr-10 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword((p) => !p)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? <IconEyeOff /> : <IconEye />}
@@ -275,7 +275,7 @@ export function InstanceSetupConfigurePage() {
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="setup-confirm-password"
-                className="text-sm font-medium text-[var(--txt-secondary)]"
+                className="text-sm font-medium text-(--txt-secondary)"
               >
                 Confirm password *
               </label>
@@ -288,12 +288,12 @@ export function InstanceSetupConfigurePage() {
                   placeholder="Confirm password"
                   required
                   autoComplete="new-password"
-                  className="h-9 w-full rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface-1)] py-2 pl-3 pr-10 text-sm text-[var(--txt-primary)] placeholder:text-[var(--txt-placeholder)] focus:outline-none"
+                  className="h-9 w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) py-2 pl-3 pr-10 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
                 />
                 <button
                   type="button"
                   onClick={() => setShowConfirmPassword((p) => !p)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--txt-icon-tertiary)] hover:bg-[var(--bg-layer-1-hover)] hover:text-[var(--txt-icon-secondary)]"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
                   aria-label={
                     showConfirmPassword ? "Hide password" : "Show password"
                   }
@@ -308,13 +308,13 @@ export function InstanceSetupConfigurePage() {
                 type="checkbox"
                 checked={allowUsageData}
                 onChange={(e) => setAllowUsageData(e.target.checked)}
-                className="mt-0.5 size-4 rounded border-[var(--border-subtle)] bg-[var(--bg-surface-1)] text-[var(--bg-accent-primary)] focus:ring-[var(--border-accent-strong)]"
+                className="mt-0.5 size-4 rounded border-(--border-subtle) bg-(--bg-surface-1) text-(--bg-accent-primary) focus:ring-(--border-accent-strong)"
               />
-              <span className="text-[var(--txt-secondary)]">
+              <span className="text-(--txt-secondary)">
                 Allow Devlane to anonymously collect usage events.{" "}
                 <a
                   href="#"
-                  className="text-[var(--txt-accent-primary)] underline hover:no-underline"
+                  className="text-(--txt-accent-primary) underline hover:no-underline"
                 >
                   See more
                 </a>
@@ -322,7 +322,7 @@ export function InstanceSetupConfigurePage() {
             </label>
 
             {error && (
-              <p className="text-sm text-[var(--txt-danger-primary)]">
+              <p className="text-sm text-(--txt-danger-primary)">
                 {error}
               </p>
             )}

--- a/ui/src/pages/setup/InstanceSetupConfigurePage.tsx
+++ b/ui/src/pages/setup/InstanceSetupConfigurePage.tsx
@@ -322,9 +322,7 @@ export function InstanceSetupConfigurePage() {
             </label>
 
             {error && (
-              <p className="text-sm text-(--txt-danger-primary)">
-                {error}
-              </p>
+              <p className="text-sm text-(--txt-danger-primary)">{error}</p>
             )}
 
             <Button type="submit" className="w-full" disabled={isSubmitting}>

--- a/ui/src/pages/setup/InstanceSetupWelcomePage.tsx
+++ b/ui/src/pages/setup/InstanceSetupWelcomePage.tsx
@@ -1,10 +1,10 @@
-import { useNavigate } from "react-router-dom";
+﻿import { useNavigate } from "react-router-dom";
 import { Button } from "../../components/ui";
 
 /** Devlane logo mark: blue square with white star */
 const LogoMark = () => (
   <span
-    className="flex size-9 items-center justify-center rounded-lg bg-[var(--bg-accent-primary)] text-[var(--txt-on-color)]"
+    className="flex size-9 items-center justify-center rounded-lg bg-(--bg-accent-primary) text-(--txt-on-color)"
     aria-hidden
   >
     <svg
@@ -112,7 +112,7 @@ export function InstanceSetupWelcomePage() {
   const navigate = useNavigate();
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--bg-canvas)]">
+    <div className="flex min-h-screen flex-col bg-(--bg-canvas)">
       {/* Subtle grid background */}
       <div
         className="pointer-events-none fixed inset-0 opacity-[0.4] [background-image:linear-gradient(var(--border-subtle)_1px,transparent_1px),linear-gradient(90deg,var(--border-subtle)_1px,transparent_1px)] [background-size:24px_24px]"
@@ -120,7 +120,7 @@ export function InstanceSetupWelcomePage() {
       />
 
       <header className="relative z-10 shrink-0 px-6 py-4">
-        <div className="flex items-center gap-2 text-lg font-semibold text-[var(--txt-primary)]">
+        <div className="flex items-center gap-2 text-lg font-semibold text-(--txt-primary)">
           <LogoMark />
           Devlane
         </div>
@@ -128,13 +128,13 @@ export function InstanceSetupWelcomePage() {
 
       <main className="relative z-10 flex min-h-0 flex-1 flex-col items-center justify-center px-4 py-8">
         <div className="flex w-full max-w-md flex-col items-center text-center">
-          <h1 className="text-3xl font-bold tracking-tight text-[var(--txt-primary)] sm:text-4xl">
+          <h1 className="text-3xl font-bold tracking-tight text-(--txt-primary) sm:text-4xl">
             Welcome aboard Devlane!
           </h1>
           <div className="mt-6 w-full">
             <WelcomeIllustration />
           </div>
-          <p className="mt-2 text-sm text-[var(--txt-secondary)]">
+          <p className="mt-2 text-sm text-(--txt-secondary)">
             Get started by setting up your instance and workspace.
           </p>
           <Button

--- a/ui/src/routes/InstanceAdminProtectedRoute.tsx
+++ b/ui/src/routes/InstanceAdminProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+﻿import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 interface InstanceAdminProtectedRouteProps {
@@ -13,7 +13,7 @@ export function InstanceAdminProtectedRoute({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading...
       </div>
     );

--- a/ui/src/routes/ProtectedRoute.tsx
+++ b/ui/src/routes/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+﻿import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 interface ProtectedRouteProps {
@@ -11,7 +11,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
         Loading...
       </div>
     );

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react-refresh/only-export-components -- routes file exports router + layout components; keep for future use */
+﻿/* eslint-disable react-refresh/only-export-components -- routes file exports router + layout components; keep for future use */
 import { lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate, Outlet } from "react-router-dom";
 import { AppShell, InstanceAdminLayout } from "../components/layout";
@@ -164,7 +164,7 @@ const InviteSignUpPage = lazy(() =>
 );
 
 const PageFallback = () => (
-  <div className="flex items-center justify-center p-8 text-sm text-[var(--txt-tertiary)]">
+  <div className="flex items-center justify-center p-8 text-sm text-(--txt-tertiary)">
     Loading...
   </div>
 );

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,4 +1,4 @@
-﻿/* eslint-disable react-refresh/only-export-components -- routes file exports router + layout components; keep for future use */
+/* eslint-disable react-refresh/only-export-components -- routes file exports router + layout components; keep for future use */
 import { lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate, Outlet } from "react-router-dom";
 import { AppShell, InstanceAdminLayout } from "../components/layout";
@@ -81,6 +81,11 @@ const CyclesPage = lazy(() =>
 const ModulesPage = lazy(() =>
   import("../pages/ModulesPage").then((m) =>
     page({ ModulesPage: m.ModulesPage }),
+  ),
+);
+const ModuleDetailPage = lazy(() =>
+  import("../pages/ModuleDetailPage").then((m) =>
+    page({ ModuleDetailPage: m.ModuleDetailPage }),
   ),
 );
 const SettingsPage = lazy(() =>
@@ -407,6 +412,14 @@ const router = createBrowserRouter([
                         element: (
                           <Suspense fallback={<PageFallback />}>
                             <ModulesPage />
+                          </Suspense>
+                        ),
+                      },
+                      {
+                        path: "modules/:moduleId",
+                        element: (
+                          <Suspense fallback={<PageFallback />}>
+                            <ModuleDetailPage />
                           </Suspense>
                         ),
                       },

--- a/ui/src/services/moduleService.ts
+++ b/ui/src/services/moduleService.ts
@@ -20,6 +20,17 @@ export const moduleService = {
     return data;
   },
 
+  async get(
+    workspaceSlug: string,
+    projectId: string,
+    moduleId: string,
+  ): Promise<ModuleApiResponse> {
+    const { data } = await apiClient.get<ModuleApiResponse>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/`,
+    );
+    return data;
+  },
+
   async create(
     workspaceSlug: string,
     projectId: string,
@@ -30,6 +41,17 @@ export const moduleService = {
       payload,
     );
     return data;
+  },
+
+  async listIssueIds(
+    workspaceSlug: string,
+    projectId: string,
+    moduleId: string,
+  ): Promise<string[]> {
+    const { data } = await apiClient.get<string[]>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/issues/`,
+    );
+    return Array.isArray(data) ? data : [];
   },
 
   async addIssue(

--- a/ui/src/services/moduleService.ts
+++ b/ui/src/services/moduleService.ts
@@ -1,6 +1,14 @@
 import { apiClient } from "../api/client";
 import type { ModuleApiResponse } from "../api/types";
 
+export interface CreateModulePayload {
+  name: string;
+  description?: string;
+  status?: string;
+  start_date?: string | null;
+  target_date?: string | null;
+}
+
 export const moduleService = {
   async list(
     workspaceSlug: string,
@@ -8,6 +16,18 @@ export const moduleService = {
   ): Promise<ModuleApiResponse[]> {
     const { data } = await apiClient.get<ModuleApiResponse[]>(
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/`,
+    );
+    return data;
+  },
+
+  async create(
+    workspaceSlug: string,
+    projectId: string,
+    payload: CreateModulePayload,
+  ): Promise<ModuleApiResponse> {
+    const { data } = await apiClient.post<ModuleApiResponse>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/`,
+      payload,
     );
     return data;
   },


### PR DESCRIPTION
This pull request primarily focuses on two areas: improving support for default module selection in the work item creation modal, and refactoring how CSS custom properties are used in class names throughout several UI components. Additionally, there are minor enhancements to API types.

**Default module selection and modal improvements:**

* Added a `defaultModuleId` prop to `CreateWorkItemModal` and updated its state handling so that the module selection is properly initialized and reset when the modal opens or closes. This makes it easier to preselect a module when creating a new work item. [[1]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR173) [[2]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR198) [[3]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL216-R220) [[4]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL377-R386)

**Refactoring CSS custom property usage:**

* Refactored multiple UI components (`CoverImageModal.tsx`, `CreateProjectModal.tsx`, `CreateWorkItemModal.tsx`) to use the `--var` CSS custom property syntax consistently in Tailwind class names, improving maintainability and consistency in styling. For example, changed `bg-[var(--bg-surface-1)]` to `bg-(--bg-surface-1)`. [[1]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL167-R185) [[2]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL201-R201) [[3]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL212-R212) [[4]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL222-R225) [[5]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL245-R251) [[6]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL263-R263) [[7]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL273-R284) [[8]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L186-R191) [[9]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L218-R218) [[10]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L256-R256) [[11]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L270-R270) [[12]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L290-R294) [[13]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL499-R514) [[14]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL528-R540) [[15]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL548-R552) [[16]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL563-R574) [[17]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL581-R593)

**API type enhancements:**

* Added an optional `lead_id` property to the `ModuleApiResponse` type, allowing modules to optionally specify a lead.

**Minor improvements:**

* Added a Unicode BOM at the start of some files, likely to ensure proper encoding and compatibility. [[1]](diffhunk://#diff-2f12eab753b9d76e719cbf3a12a6a63a7e5d8e3e8831314de99b1f32e633ca4eL1-R1) [[2]](diffhunk://#diff-b108f9638ab9a9d57c942e4c71f2135062d956d60d5c63a134d1bbdd309dda57L1-R1)