### PR TITLE
[FIX] Removed the outer border, radius, and surface background

### DIFF
--- a/ui/src/components/ui/Avatar.tsx
+++ b/ui/src/components/ui/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { cn } from '../../lib/utils';
 
 export type AvatarSize = 'sm' | 'md' | 'lg';
@@ -10,12 +11,18 @@ export interface AvatarProps {
 }
 
 function getInitials(name: string): string {
-  return name
+  const parts = name
+    .trim()
     .split(/\s+/)
-    .map((part) => part[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
+    .filter((p) => p.length > 0);
+  if (parts.length === 0) {
+    return '?';
+  }
+  if (parts.length === 1) {
+    const w = parts[0];
+    return w.slice(0, 2).toUpperCase();
+  }
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
 const sizeStyles: Record<AvatarSize, string> = {
@@ -24,21 +31,52 @@ const sizeStyles: Record<AvatarSize, string> = {
   lg: 'h-10 w-10 text-base',
 };
 
-export function Avatar({ name, src, size = 'md', className }: AvatarProps) {
+type AvatarInnerProps = {
+  name: string;
+  resolvedSrc: string;
+  size: AvatarSize;
+  className?: string;
+};
+
+/** Holds image error state; parent remounts via `key` when `resolvedSrc` changes. */
+function AvatarInner({ name, resolvedSrc, size, className }: AvatarInnerProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const showImg = resolvedSrc !== '' && !imgFailed;
+
   return (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center justify-center rounded-full bg-(--bg-accent-primary) font-medium text-(--txt-on-color)',
+        'inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-(--bg-accent-primary) font-medium text-(--txt-on-color)',
         sizeStyles[size],
         className,
       )}
       title={name}
     >
-      {src ? (
-        <img src={src} alt={name} className="h-full w-full rounded-full object-cover" />
+      {showImg ? (
+        <img
+          src={resolvedSrc}
+          alt={name}
+          className="h-full w-full object-cover"
+          onError={() => setImgFailed(true)}
+        />
       ) : (
         getInitials(name)
       )}
     </span>
+  );
+}
+
+export function Avatar({ name, src, size = 'md', className }: AvatarProps) {
+  const resolvedSrc = src?.trim() ?? '';
+  const remountKey = resolvedSrc !== '' ? resolvedSrc : `initials:${name}`;
+
+  return (
+    <AvatarInner
+      key={remountKey}
+      name={name}
+      resolvedSrc={resolvedSrc}
+      size={size}
+      className={className}
+    />
   );
 }

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import type { WorkspaceMemberApiResponse } from '../api/types';
 import { config } from '../config/env';
 
 /**
@@ -12,8 +13,39 @@ export function cn(...inputs: ClassValue[]): string {
 /** Resolve image URL for display (relative API paths get base URL prepended). */
 export function getImageUrl(url: string | null | undefined): string | null {
   if (!url || typeof url !== 'string') return null;
-  if (url.startsWith('http://') || url.startsWith('https://')) return url;
+  const t = url.trim();
+  if (t === '') return null;
+  if (
+    t.startsWith('http://') ||
+    t.startsWith('https://') ||
+    t.startsWith('data:') ||
+    t.startsWith('blob:')
+  ) {
+    return t;
+  }
   const base = (config.apiBaseUrl ?? '').replace(/\/+$/, '');
-  const path = url.startsWith('/') ? url : '/' + url;
+  const path = t.startsWith('/') ? t : '/' + t;
   return base + path;
+}
+
+function normId(v: string | null | undefined): string {
+  if (v == null) return '';
+  return String(v).trim().toLowerCase().replace(/-/g, '');
+}
+
+/** Match workspace member by user id (`member_id` = users.id). Also tries workspace member row `id` for older payloads. */
+export function findWorkspaceMemberByUserId(
+  members: WorkspaceMemberApiResponse[],
+  userId: string | null | undefined,
+): WorkspaceMemberApiResponse | undefined {
+  if (userId == null) return undefined;
+  const raw = String(userId).trim();
+  if (raw === '') return undefined;
+  const key = normId(raw);
+  if (key === '') return undefined;
+  return members.find((m) => {
+    const mid = normId(m.member_id);
+    const pk = normId(m.id);
+    return (mid !== '' && mid === key) || (pk !== '' && pk === key);
+  });
 }

--- a/ui/src/pages/ModulesPage.tsx
+++ b/ui/src/pages/ModulesPage.tsx
@@ -14,7 +14,7 @@ import type {
   ModuleApiResponse,
   WorkspaceMemberApiResponse,
 } from '../api/types';
-import { getImageUrl } from '../lib/utils';
+import { findWorkspaceMemberByUserId, getImageUrl } from '../lib/utils';
 import { slugify } from '../lib/slug';
 import { parseISODateLocal } from '../lib/dateOnly';
 import { MODULE_STATUSES } from '../lib/moduleStatuses';
@@ -386,15 +386,19 @@ export function ModulesPage() {
   const layout = filter.layout;
 
   const getLeadMember = (leadId: string | null | undefined) => {
-    if (!leadId) return null;
-    const m = members.find((x) => x.member_id === leadId);
-    const name =
-      m?.member_display_name?.trim() ?? m?.member_email?.split('@')[0] ?? leadId.slice(0, 8);
-    return { name, avatarUrl: m?.member_avatar ?? null };
+    if (leadId == null) return null;
+    const id = String(leadId).trim();
+    if (id === '') return null;
+    const m = findWorkspaceMemberByUserId(members, id);
+    const fromDisplay = m?.member_display_name?.trim() ?? '';
+    const fromEmail = m?.member_email?.trim().split('@')[0]?.trim() ?? '';
+    const name = fromDisplay !== '' ? fromDisplay : fromEmail !== '' ? fromEmail : id.slice(0, 8);
+    const rawAvatar = m?.member_avatar?.trim();
+    return { name, avatarUrl: rawAvatar ? rawAvatar : null };
   };
 
   const renderListLayout = () => (
-    <div className="space-y-0 rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
+    <div className="w-full">
       {sortedModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
@@ -404,7 +408,7 @@ export function ModulesPage() {
         return (
           <div
             key={mod.id}
-            className="flex items-center gap-3 border-b border-(--border-subtle) last:border-b-0 px-4 py-3 hover:bg-(--bg-layer-1-hover)"
+            className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 hover:bg-(--bg-layer-1-hover)"
           >
             <ModuleProgressCircle progress={progress} />
             <div className="min-w-0 flex-1">
@@ -618,6 +622,7 @@ export function ModulesPage() {
       {sortedModules.map((mod) => {
         const progress = getProgress(mod);
         const dateRange = formatModuleDateRange(mod);
+        const lead = getLeadMember(mod.lead_id ?? project.project_lead_id ?? null);
         return (
           <Link
             key={mod.id}
@@ -638,6 +643,17 @@ export function ModulesPage() {
                 {mod.status}
               </span>
             </div>
+            {lead && (
+              <div className="mt-auto flex items-center gap-2 border-t border-(--border-subtle) pt-3">
+                <Avatar
+                  name={lead.name}
+                  src={getImageUrl(lead.avatarUrl) ?? undefined}
+                  size="sm"
+                  className="h-7 w-7 shrink-0 text-[10px]"
+                />
+                <span className="min-w-0 truncate text-xs text-(--txt-secondary)">{lead.name}</span>
+              </div>
+            )}
           </Link>
         );
       })}
@@ -790,35 +806,47 @@ export function ModulesPage() {
                 </tr>
               </thead>
               <tbody>
-                {withDates.map(({ mod, durationDays }) => (
-                  <tr key={mod.id} className="border-b border-(--border-subtle) last:border-b-0">
-                    <td className="px-3 py-2">
-                      <Link
-                        to={modulePath(mod)}
-                        className="flex items-center gap-2 text-sm text-(--txt-primary) no-underline hover:text-(--brand-default)"
-                      >
-                        <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
-                          <svg
-                            width="12"
-                            height="12"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            aria-hidden
-                          >
-                            <circle cx="12" cy="12" r="9" />
-                            <path d="M12 6v6l4 2" />
-                          </svg>
-                        </span>
-                        <span className="min-w-0 truncate">{mod.name}</span>
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2 text-sm text-(--txt-secondary)">
-                      {durationDays > 0 ? `${durationDays} days` : '—'}
-                    </td>
-                  </tr>
-                ))}
+                {withDates.map(({ mod, durationDays }) => {
+                  const rowLead = getLeadMember(mod.lead_id ?? project.project_lead_id ?? null);
+                  return (
+                    <tr key={mod.id} className="border-b border-(--border-subtle) last:border-b-0">
+                      <td className="px-3 py-2">
+                        <Link
+                          to={modulePath(mod)}
+                          className="flex items-center gap-2 text-sm text-(--txt-primary) no-underline hover:text-(--brand-default)"
+                        >
+                          {rowLead ? (
+                            <Avatar
+                              name={rowLead.name}
+                              src={getImageUrl(rowLead.avatarUrl) ?? undefined}
+                              size="sm"
+                              className="size-5 shrink-0 text-[9px]"
+                            />
+                          ) : (
+                            <span className="flex size-4 shrink-0 items-center justify-center text-(--txt-icon-tertiary)">
+                              <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                aria-hidden
+                              >
+                                <circle cx="12" cy="12" r="9" />
+                                <path d="M12 6v6l4 2" />
+                              </svg>
+                            </span>
+                          )}
+                          <span className="min-w-0 truncate">{mod.name}</span>
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 text-sm text-(--txt-secondary)">
+                        {durationDays > 0 ? `${durationDays} days` : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
This pull request improves the display and robustness of user avatars and workspace member lookups, particularly for module leads in the modules page. The changes enhance avatar fallback logic, ensure more reliable member matching, and refine the UI to consistently show lead avatars and names across different layouts.

**Avatar handling improvements:**
- Refactored the `Avatar` component to handle image load failures gracefully, show initials as fallback, and improve how initials are generated (e.g., handling single-word names and empty names more robustly). [[1]](diffhunk://#diff-bc51259a98c3fef937992382c1a64d48307ba599f014e4505ed619b12429051aR1) [[2]](diffhunk://#diff-bc51259a98c3fef937992382c1a64d48307ba599f014e4505ed619b12429051aL13-R25) [[3]](diffhunk://#diff-bc51259a98c3fef937992382c1a64d48307ba599f014e4505ed619b12429051aL27-R82)

**Workspace member lookup enhancements:**
- Added a `findWorkspaceMemberByUserId` utility to reliably match workspace members by user ID, supporting both `member_id` and legacy `id` fields, and improved normalization of IDs for matching. [[1]](diffhunk://#diff-e9794eea6d22efd05f1fdc308fbbd6f095b31e8ec81c620ce29cd07f9b0feea3R3) [[2]](diffhunk://#diff-e9794eea6d22efd05f1fdc308fbbd6f095b31e8ec81c620ce29cd07f9b0feea3L15-R51)

**Modules page updates:**
- Updated the modules page to use the new member lookup utility for finding module leads, with improved name and avatar selection logic. [[1]](diffhunk://#diff-30da839de1b4080007fc195a2c2cff2924df4f76e8457ec768c46e77e98272faL17-R17) [[2]](diffhunk://#diff-30da839de1b4080007fc195a2c2cff2924df4f76e8457ec768c46e77e98272faL389-R401)
- Enhanced the list and table layouts to always show the lead's avatar and name using the improved `Avatar` component, with appropriate fallbacks if data is missing. [[1]](diffhunk://#diff-30da839de1b4080007fc195a2c2cff2924df4f76e8457ec768c46e77e98272faR625) [[2]](diffhunk://#diff-30da839de1b4080007fc195a2c2cff2924df4f76e8457ec768c46e77e98272faR646-R656) [[3]](diffhunk://#diff-30da839de1b4080007fc195a2c2cff2924df4f76e8457ec768c46e77e98272faL793-R825) [[4]](diffhunk://#diff-30da839de1b4080007fc195a2c2cff2924df4f76e8457ec768c46e77e98272faR840-R849)

These changes collectively improve the reliability and user experience of displaying member avatars and names throughout the application.