### PR TITLE
[FEAT] Add Dockerfile for API

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.gitignore
+.idea
+.vscode
+
+*.exe
+*.test
+*.out
+coverage.out
+
+.env
+.env.*
+!.env.example
+
+README.md

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+
+RUN apk add --no-cache ca-certificates git
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/api ./cmd/api
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata \
+  && addgroup -S app && adduser -S app -G app
+
+WORKDIR /app
+
+COPY --from=builder /out/api ./api
+COPY migrations ./migrations
+
+USER app
+
+ENV MIGRATIONS_PATH=/app/migrations
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/api"]


### PR DESCRIPTION
This pull request adds initial Docker support for the API service by introducing a production-ready `Dockerfile` and a corresponding `.dockerignore` file. These changes enable efficient and secure containerization of the Go application.

**Docker support and containerization:**

* Added a `.dockerignore` file to exclude unnecessary files and directories (such as `.git`, IDE settings, environment files, and documentation) from the Docker build context, improving build performance and security.
* Created a multi-stage `Dockerfile` for building and running the Go API:
  * Uses a Go builder stage to compile the application.
  * Produces a minimal Alpine-based runtime image with only the compiled binary and migration files.
  * Sets up a non-root user, environment variables, and exposes port 8080 for the service.

Closes #58 