### PR TITLE
style(stickies): apply placeholder text color to checked checklist items

### DIFF
--- a/ui/src/components/stickies/StickyNoteCard.tsx
+++ b/ui/src/components/stickies/StickyNoteCard.tsx
@@ -315,7 +315,8 @@ export function StickyNoteCard({
 
   const tb =
     'rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) disabled:opacity-40';
-  const isMac = typeof navigator !== 'undefined' && /mac|iphone|ipad|ipod/i.test(navigator.platform);
+  const isMac =
+    typeof navigator !== 'undefined' && /mac|iphone|ipad|ipod/i.test(navigator.platform);
   const modKey = isMac ? 'Cmd' : 'Ctrl';
   const boldShortcut = `${modKey} + B`;
   const italicShortcut = `${modKey} + I`;

--- a/ui/src/components/stickies/StickyNoteCard.tsx
+++ b/ui/src/components/stickies/StickyNoteCard.tsx
@@ -326,7 +326,7 @@ export function StickyNoteCard({
       <div className="min-h-0 text-sm">
         <EditorContent
           editor={editor}
-          className="min-h-[4.5rem] min-w-0 max-w-full overflow-hidden text-sm text-(--txt-primary) focus:outline-none [&_p]:my-0.5 [&_p]:break-words [&_ul]:my-1 [&_ol]:my-1 [&_ul[data-type=taskList]]:m-0 [&_ul[data-type=taskList]]:p-0 [&_li[data-type=taskItem]>label]:mt-0.5 [&_li[data-type=taskItem]>label>input]:h-3.5 [&_li[data-type=taskItem]>label>input]:w-3.5 [&_li[data-type=taskItem][data-checked=true]>div]:opacity-60"
+          className="sticky-note-editor-content min-h-[4.5rem] min-w-0 max-w-full overflow-hidden text-sm text-(--txt-primary) focus:outline-none [&_p]:my-0.5 [&_p]:break-words [&_ul]:my-1 [&_ol]:my-1 [&_ul[data-type=taskList]]:m-0 [&_ul[data-type=taskList]]:p-0 [&_li[data-type=taskItem]>label]:mt-0.5 [&_li[data-type=taskItem]>label>input]:h-3.5 [&_li[data-type=taskItem]>label>input]:w-3.5"
           style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}
         />
         {contentSaveError ? (

--- a/ui/src/components/stickies/StickyNoteCard.tsx
+++ b/ui/src/components/stickies/StickyNoteCard.tsx
@@ -5,6 +5,7 @@ import { TaskItem } from '@tiptap/extension-task-item';
 import { TaskList } from '@tiptap/extension-task-list';
 import StarterKit from '@tiptap/starter-kit';
 import type { StickyApiResponse } from '../../api/types';
+import { Tooltip } from '../ui/Tooltip';
 import { stickiesService } from '../../services/stickiesService';
 import {
   STICKY_BACKGROUND_COLORS_DARK,
@@ -314,6 +315,11 @@ export function StickyNoteCard({
 
   const tb =
     'rounded p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-transparent-hover) disabled:opacity-40';
+  const isMac = typeof navigator !== 'undefined' && /mac|iphone|ipad|ipod/i.test(navigator.platform);
+  const modKey = isMac ? 'Cmd' : 'Ctrl';
+  const boldShortcut = `${modKey} + B`;
+  const italicShortcut = `${modKey} + I`;
+  const todoShortcut = `${modKey} + Shift + 9`;
 
   if (!editor) return null;
   if (!safeSlug) return null;
@@ -337,17 +343,19 @@ export function StickyNoteCard({
       </div>
       <div className="mt-2 flex shrink-0 items-center gap-1 pt-2">
         <div className="relative" ref={colorPanelRef}>
-          <button
-            type="button"
-            className={tb}
-            aria-label="Change color"
-            aria-expanded={colorOpen}
-            aria-haspopup="listbox"
-            aria-controls={colorOpen ? colorListboxId : undefined}
-            onClick={cycleColor}
-          >
-            <IconPalette />
-          </button>
+          <Tooltip content="Background color">
+            <button
+              type="button"
+              className={tb}
+              aria-label="Change color"
+              aria-expanded={colorOpen}
+              aria-haspopup="listbox"
+              aria-controls={colorOpen ? colorListboxId : undefined}
+              onClick={cycleColor}
+            >
+              <IconPalette />
+            </button>
+          </Tooltip>
           {colorOpen && (
             <div
               id={colorListboxId}
@@ -377,38 +385,67 @@ export function StickyNoteCard({
             </div>
           )}
         </div>
-        <button
-          type="button"
-          className={tb}
-          aria-label="Bold"
-          onClick={() => editor.chain().focus().toggleBold().run()}
+        <Tooltip
+          content={
+            <div className="text-center">
+              <p>Bold</p>
+              <p className="text-(--txt-tertiary)">{boldShortcut}</p>
+            </div>
+          }
         >
-          <IconBold />
-        </button>
-        <button
-          type="button"
-          className={tb}
-          aria-label="Italic"
-          onClick={() => editor.chain().focus().toggleItalic().run()}
+          <button
+            type="button"
+            className={tb}
+            aria-label="Bold"
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          >
+            <IconBold />
+          </button>
+        </Tooltip>
+        <Tooltip
+          content={
+            <div className="text-center">
+              <p>Italic</p>
+              <p className="text-(--txt-tertiary)">{italicShortcut}</p>
+            </div>
+          }
         >
-          <IconItalic />
-        </button>
-        <button
-          type="button"
-          className={tb}
-          aria-label="Todo list"
-          onClick={() => editor.chain().focus().toggleTaskList().run()}
+          <button
+            type="button"
+            className={tb}
+            aria-label="Italic"
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          >
+            <IconItalic />
+          </button>
+        </Tooltip>
+        <Tooltip
+          content={
+            <div className="text-center">
+              <p>To-do list</p>
+              <p className="text-(--txt-tertiary)">{todoShortcut}</p>
+            </div>
+          }
         >
-          <IconTodo />
-        </button>
-        <button
-          type="button"
-          onClick={() => onDelete(sticky.id)}
-          className={`${tb} ml-auto hover:text-(--txt-danger-primary)`}
-          aria-label="Delete"
-        >
-          <IconTrash />
-        </button>
+          <button
+            type="button"
+            className={tb}
+            aria-label="Todo list"
+            onClick={() => editor.chain().focus().toggleTaskList().run()}
+          >
+            <IconTodo />
+          </button>
+        </Tooltip>
+        <Tooltip content="Delete sticky note">
+          <button
+            type="button"
+            onClick={() => onDelete(sticky.id)}
+            className={`${tb} ml-auto hover:text-(--txt-danger-primary)`}
+            aria-label="Delete"
+          >
+            <IconTrash />
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/ui/src/components/stickies/StickyNoteCard.tsx
+++ b/ui/src/components/stickies/StickyNoteCard.tsx
@@ -437,16 +437,18 @@ export function StickyNoteCard({
             <IconTodo />
           </button>
         </Tooltip>
-        <Tooltip content="Delete sticky note">
-          <button
-            type="button"
-            onClick={() => onDelete(sticky.id)}
-            className={`${tb} ml-auto hover:text-(--txt-danger-primary)`}
-            aria-label="Delete"
-          >
-            <IconTrash />
-          </button>
-        </Tooltip>
+        <div className="ml-auto">
+          <Tooltip content="Delete sticky note">
+            <button
+              type="button"
+              onClick={() => onDelete(sticky.id)}
+              className={`${tb} hover:text-(--txt-danger-primary)`}
+              aria-label="Delete"
+            >
+              <IconTrash />
+            </button>
+          </Tooltip>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/ui/Tooltip.tsx
+++ b/ui/src/components/ui/Tooltip.tsx
@@ -43,6 +43,23 @@ function computeStyle(el: HTMLElement, placement: TooltipPlacement): CSSProperti
   };
 }
 
+function mergeDescribedBy(existing: string | null, token: string): string {
+  const parts = (existing || '')
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!parts.includes(token)) parts.push(token);
+  return parts.join(' ');
+}
+
+function removeDescribedBy(existing: string | null, token: string): string | null {
+  const next = (existing || '')
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s && s !== token);
+  return next.length ? next.join(' ') : null;
+}
+
 export function Tooltip({
   content,
   children,
@@ -90,7 +107,7 @@ export function Tooltip({
   }, [clearDelay]);
 
   const hideIfLeavingTrigger = useCallback(
-    (e: FocusEvent<HTMLSpanElement>) => {
+    (e: FocusEvent<HTMLElement>) => {
       const next = e.relatedTarget as Node | null;
       if (next && e.currentTarget.contains(next)) return;
       hide();
@@ -111,6 +128,28 @@ export function Tooltip({
       window.removeEventListener('resize', onScroll);
     };
   }, [open, updatePosition]);
+
+  useEffect(() => {
+    const root = triggerRef.current;
+    if (!root) return;
+    const focusable = root.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    if (!focusable) return;
+
+    if (open) {
+      const next = mergeDescribedBy(focusable.getAttribute('aria-describedby'), id);
+      focusable.setAttribute('aria-describedby', next);
+      return;
+    }
+
+    const next = removeDescribedBy(focusable.getAttribute('aria-describedby'), id);
+    if (next) {
+      focusable.setAttribute('aria-describedby', next);
+    } else {
+      focusable.removeAttribute('aria-describedby');
+    }
+  }, [open, id]);
 
   return (
     <>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -84,20 +84,11 @@
 }
 
 /* Sticky checklist: checked items get placeholder-colored text (matches Plane) */
-.sticky-note-editor-content ul[data-type='taskList'] li[data-checked='true'] > div > p {
-  color: var(--txt-placeholder);
-  transition: color 0.2s ease;
-}
-
 .sticky-note-editor-content ul[data-type='taskList'] li[data-checked='true'] > div {
   color: var(--txt-placeholder);
-  transition: color 0.2s ease;
 }
 
+.sticky-note-editor-content ul[data-type='taskList'] li > div,
 .sticky-note-editor-content ul[data-type='taskList'] li > div > p {
-  transition: color 0.2s ease;
-}
-
-.sticky-note-editor-content ul[data-type='taskList'] li > div {
   transition: color 0.2s ease;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -82,3 +82,22 @@
 .border-r-column-subtle {
   border-right: 1px solid color-mix(in srgb, var(--border-subtle) 45%, transparent);
 }
+
+/* Sticky checklist: checked items get placeholder-colored text (matches Plane) */
+.sticky-note-editor-content ul[data-type='taskList'] li[data-checked='true'] > div > p {
+  color: var(--txt-placeholder);
+  transition: color 0.2s ease;
+}
+
+.sticky-note-editor-content ul[data-type='taskList'] li[data-checked='true'] > div {
+  color: var(--txt-placeholder);
+  transition: color 0.2s ease;
+}
+
+.sticky-note-editor-content ul[data-type='taskList'] li > div > p {
+  transition: color 0.2s ease;
+}
+
+.sticky-note-editor-content ul[data-type='taskList'] li > div {
+  transition: color 0.2s ease;
+}


### PR DESCRIPTION
This pull request enhances the `StickyNoteCard` component by adding helpful tooltips to the formatting and action buttons, improving accessibility and user experience. It also introduces platform-aware keyboard shortcut hints and visually distinguishes completed checklist items. The most important changes are grouped below:

**User Experience Improvements:**

* Added `Tooltip` components to formatting buttons (Bold, Italic, To-do list) and the color/background and delete buttons, providing descriptive labels and shortcut hints. [[1]](diffhunk://#diff-d4042ece4af79f161f177eac2de852ae86056ae495b4cd4595f6b537353c645fR347) [[2]](diffhunk://#diff-d4042ece4af79f161f177eac2de852ae86056ae495b4cd4595f6b537353c645fR359) [[3]](diffhunk://#diff-d4042ece4af79f161f177eac2de852ae86056ae495b4cd4595f6b537353c645fR389-R396) [[4]](diffhunk://#diff-d4042ece4af79f161f177eac2de852ae86056ae495b4cd4595f6b537353c645fR405-R413) [[5]](diffhunk://#diff-d4042ece4af79f161f177eac2de852ae86056ae495b4cd4595f6b537353c645fR422-R430) [[6]](diffhunk://#diff-d4042ece4af79f161f177eac2de852ae86056ae495b4cd4595f6b537353c645fR439-R451)
* Displayed keyboard shortcuts in tooltips, dynamically showing `Cmd` or `Ctrl` based on the user's platform for better clarity.

**Visual Enhancements:**

* Styled completed checklist items in sticky notes to use placeholder-colored text, matching the Plane design, and added a color transition for checklist items.
* Added a dedicated class name (`sticky-note-editor-content`) to the editor content for more targeted styling.

**Code Maintenance:**

* Imported the `Tooltip` component into `StickyNoteCard.tsx` to support the new tooltips.
closes #89 