### PR TITLE
feat(workspace-view): set default display properties to only priority

### DIFF
--- a/ui/src/types/workspaceViewDisplay.ts
+++ b/ui/src/types/workspaceViewDisplay.ts
@@ -91,7 +91,7 @@ const SORT_ORDER_PARAM = 'order';
 
 /** All display properties; ID is shown in the Work items column when enabled. */
 export const DEFAULT_WORKSPACE_VIEW_DISPLAY: WorkspaceViewDisplay = {
-  properties: [...DISPLAY_PROPERTY_KEYS],
+  properties: ['priority'],
   showSubWorkItems: false,
   layout: 'spreadsheet',
   sortBy: 'created_at',


### PR DESCRIPTION
This pull request makes a small change to the default display settings for workspace views. The default set of properties shown in the view has been updated to display only the `priority` property instead of all display property keys.
closes #81 