### PR TITLE
chore: release only for amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,6 @@ jobs:
           owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           echo "name=${REGISTRY}/${owner_lc}/devlane-api" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -71,7 +68,7 @@ jobs:
         with:
           context: ./api
           file: ./api/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -93,9 +90,6 @@ jobs:
         run: |
           owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           echo "name=${REGISTRY}/${owner_lc}/devlane-ui" >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -124,13 +118,10 @@ jobs:
         with:
           context: ./ui
           file: ./ui/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # VITE_API_BASE_URL is intentionally left at its default (empty).
-          # Deployments fronting the API on a separate origin should rebuild
-          # with `--build-arg VITE_API_BASE_URL=https://api.example.com`.
           cache-from: type=gha,scope=devlane-ui
           cache-to: type=gha,scope=devlane-ui,mode=max
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` workflow to simplify the Docker build process and restrict builds to the `linux/amd64` platform. It also removes the QEMU setup steps that are no longer needed due to the platform restriction.

**Docker build process simplification:**

* Removed the `Set up QEMU` step, which is only necessary for building multi-architecture images, from both the API and UI build jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L44-L46) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L97-L99)
* Limited Docker image builds to the `linux/amd64` platform only, removing `linux/arm64` from the build matrix for both API and UI images. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L74-R71) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L127-L133)

**Workflow cleanup:**

* Removed comments related to the `VITE_API_BASE_URL` build argument in the UI build step, as they are no longer relevant to the current workflow.