### PR TITLE
Feat/attachments links epics burndown

### DIFF
--- a/api/internal/handler/attachment.go
+++ b/api/internal/handler/attachment.go
@@ -1,0 +1,164 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// AttachmentHandler serves file attachment endpoints for issues.
+type AttachmentHandler struct {
+	Attachment *service.AttachmentService
+}
+
+// InitiateUpload creates the asset/attachment records and returns a presigned upload URL.
+// POST /api/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/
+func (h *AttachmentHandler) InitiateUpload(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	issueID, err := uuid.Parse(c.Param("issueId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	var body struct {
+		Name string  `json:"name" binding:"required"`
+		Size float64 `json:"size"`
+		Type string  `json:"type"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	resp, err := h.Attachment.InitiateUpload(c.Request.Context(), slug, projectID, issueID, user.ID, body.Name, body.Size, body.Type)
+	if err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		if err.Error() == "file storage is not configured" {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "File storage is not configured"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to initiate upload"})
+		return
+	}
+	c.JSON(http.StatusCreated, resp)
+}
+
+// ConfirmUpload marks the upload as complete.
+// PATCH /api/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/:assetId/
+func (h *AttachmentHandler) ConfirmUpload(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	issueID, err := uuid.Parse(c.Param("issueId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	assetID, err := uuid.Parse(c.Param("assetId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid asset ID"})
+		return
+	}
+	if err := h.Attachment.ConfirmUpload(c.Request.Context(), slug, projectID, issueID, assetID, user.ID); err != nil {
+		if err == service.ErrAttachmentNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to confirm upload"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ListAttachments returns uploaded attachments for an issue.
+// GET /api/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/
+func (h *AttachmentHandler) ListAttachments(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	issueID, err := uuid.Parse(c.Param("issueId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	list, err := h.Attachment.ListAttachments(c.Request.Context(), slug, projectID, issueID, user.ID)
+	if err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list attachments"})
+		return
+	}
+	if list == nil {
+		c.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+// DeleteAttachment removes an attachment.
+// DELETE /api/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/:assetId/
+func (h *AttachmentHandler) DeleteAttachment(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	issueID, err := uuid.Parse(c.Param("issueId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	assetID, err := uuid.Parse(c.Param("assetId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid asset ID"})
+		return
+	}
+	if err := h.Attachment.DeleteAttachment(c.Request.Context(), slug, projectID, issueID, assetID, user.ID); err != nil {
+		if err == service.ErrAttachmentNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete attachment"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/api/internal/handler/cycle.go
+++ b/api/internal/handler/cycle.go
@@ -261,6 +261,46 @@ func (h *CycleHandler) AddIssue(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// Progress returns a TProgressSnapshot for the cycle (burndown data).
+// GET /api/workspaces/:slug/projects/:projectId/cycles/:cycleId/progress/
+// GET /api/workspaces/:slug/projects/:projectId/cycles/:cycleId/cycle-progress/
+func (h *CycleHandler) Progress(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	cycleID, err := uuid.Parse(c.Param("cycleId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid cycle ID"})
+		return
+	}
+	snap, err := h.Cycle.GetProgress(c.Request.Context(), slug, projectID, cycleID, user.ID)
+	if err != nil {
+		if err == service.ErrCycleNotFound || err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get cycle progress"})
+		return
+	}
+	c.JSON(http.StatusOK, snap)
+}
+
+// Analytics returns the distribution analytics for the cycle.
+// GET /api/workspaces/:slug/projects/:projectId/cycles/:cycleId/analytics
+func (h *CycleHandler) Analytics(c *gin.Context) {
+	// For now, analytics returns the same progress snapshot so the frontend
+	// completion_chart renders. The ?type query param is accepted but ignored.
+	h.Progress(c)
+}
+
 // RemoveIssue unlinks an issue from the cycle.
 // DELETE /api/workspaces/:slug/projects/:projectId/cycles/:cycleId/issues/:issueId/
 func (h *CycleHandler) RemoveIssue(c *gin.Context) {

--- a/api/internal/handler/cycle_progress_test.go
+++ b/api/internal/handler/cycle_progress_test.go
@@ -1,0 +1,62 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cycleProgressURL(slug, projectID, cycleID string) string {
+	return "/api/workspaces/" + slug + "/projects/" + projectID + "/cycles/" + cycleID + "/progress/"
+}
+
+func cycleAnalyticsURL(slug, projectID, cycleID string) string {
+	return "/api/workspaces/" + slug + "/projects/" + projectID + "/cycles/" + cycleID + "/analytics"
+}
+
+func TestCycleProgress_RequiresAuth(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	nilID := "00000000-0000-0000-0000-000000000000"
+	rr := ts.GET(cycleProgressURL("x", nilID, nilID), "")
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestCycleProgress_EmptyCycle(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	cycle := testutil.CreateCycle(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+
+	rr := ts.GET(cycleProgressURL(w.Workspace.Slug, w.Project.ID.String(), cycle.ID.String()), w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+
+	body := testutil.MustJSONMap(t, rr)
+	assert.Equal(t, float64(0), body["total_issues"])
+	assert.Equal(t, float64(0), body["completed_issues"])
+	dist, ok := body["distribution"].(map[string]interface{})
+	require.True(t, ok, "distribution should be present")
+	_, hasChart := dist["completion_chart"]
+	assert.True(t, hasChart, "completion_chart should be in distribution")
+}
+
+func TestCycleAnalytics_ReturnsProgress(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	cycle := testutil.CreateCycle(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+
+	rr := ts.GET(cycleAnalyticsURL(w.Workspace.Slug, w.Project.ID.String(), cycle.ID.String())+"?type=points", w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+}
+
+func TestCycleProgress_NonMember404(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	cycle := testutil.CreateCycle(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	stranger := testutil.CreateUser(t, ts.DB)
+	strangerSession := testutil.LoginAs(t, ts.DB, stranger)
+
+	rr := ts.GET(cycleProgressURL(w.Workspace.Slug, w.Project.ID.String(), cycle.ID.String()), strangerSession)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/api/internal/handler/epic.go
+++ b/api/internal/handler/epic.go
@@ -1,0 +1,294 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// EpicHandler serves epic (is_epic=true issue) endpoints.
+type EpicHandler struct {
+	Issue *service.IssueService
+}
+
+func epicID(c *gin.Context) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param("epicId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid epic ID"})
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// ListEpics returns all epics for the project.
+// GET /api/workspaces/:slug/projects/:projectId/epics/
+func (h *EpicHandler) ListEpics(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	list, err := h.Issue.ListEpics(c.Request.Context(), slug, projectID, user.ID)
+	if err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list epics"})
+		return
+	}
+	if list == nil {
+		c.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+// CreateEpic creates a new epic.
+// POST /api/workspaces/:slug/projects/:projectId/epics/
+func (h *EpicHandler) CreateEpic(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	var body struct {
+		Name        string      `json:"name" binding:"required"`
+		Description string      `json:"description"`
+		Priority    string      `json:"priority"`
+		StateID     *uuid.UUID  `json:"state_id"`
+		AssigneeIDs []uuid.UUID `json:"assignee_ids"`
+		LabelIDs    []uuid.UUID `json:"label_ids"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	epic, err := h.Issue.CreateEpic(c.Request.Context(), slug, projectID, user.ID, body.Name, body.Description, body.Priority, body.StateID, body.AssigneeIDs, body.LabelIDs)
+	if err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create epic"})
+		return
+	}
+	c.JSON(http.StatusCreated, epic)
+}
+
+// GetEpic returns a single epic.
+// GET /api/workspaces/:slug/projects/:projectId/epics/:epicId/
+func (h *EpicHandler) GetEpic(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	eID, ok := epicID(c)
+	if !ok {
+		return
+	}
+	epic, err := h.Issue.GetEpic(c.Request.Context(), slug, projectID, eID, user.ID)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get epic"})
+		return
+	}
+	c.JSON(http.StatusOK, epic)
+}
+
+// UpdateEpic patches an epic.
+// PATCH /api/workspaces/:slug/projects/:projectId/epics/:epicId/
+func (h *EpicHandler) UpdateEpic(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	eID, ok := epicID(c)
+	if !ok {
+		return
+	}
+	// Reuse IssueHandler.Update — verify it's an epic first.
+	if _, err := h.Issue.GetEpic(c.Request.Context(), slug, projectID, eID, user.ID); err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get epic"})
+		return
+	}
+	var body struct {
+		Name        string      `json:"name"`
+		Description *string     `json:"description"`
+		Priority    string      `json:"priority"`
+		StateID     *uuid.UUID  `json:"state_id"`
+		AssigneeIDs []uuid.UUID `json:"assignee_ids"`
+		LabelIDs    []uuid.UUID `json:"label_ids"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	var name, priority *string
+	if body.Name != "" {
+		name = &body.Name
+	}
+	if body.Priority != "" {
+		priority = &body.Priority
+	}
+	var assigneeIDs *[]uuid.UUID
+	if body.AssigneeIDs != nil {
+		tmp := body.AssigneeIDs
+		assigneeIDs = &tmp
+	}
+	var labelIDs *[]uuid.UUID
+	if body.LabelIDs != nil {
+		tmp := body.LabelIDs
+		labelIDs = &tmp
+	}
+	epic, err := h.Issue.Update(c.Request.Context(), slug, projectID, eID, user.ID, name, priority, body.Description, body.StateID, assigneeIDs, labelIDs, nil, nil, nil, nil)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update epic"})
+		return
+	}
+	c.JSON(http.StatusOK, epic)
+}
+
+// DeleteEpic deletes an epic.
+// DELETE /api/workspaces/:slug/projects/:projectId/epics/:epicId/
+func (h *EpicHandler) DeleteEpic(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	eID, ok := epicID(c)
+	if !ok {
+		return
+	}
+	if _, err := h.Issue.GetEpic(c.Request.Context(), slug, projectID, eID, user.ID); err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get epic"})
+		return
+	}
+	if err := h.Issue.Delete(c.Request.Context(), slug, projectID, eID, user.ID); err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete epic"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ListEpicIssues returns child issues of an epic.
+// GET /api/workspaces/:slug/projects/:projectId/epics/:epicId/issues/
+func (h *EpicHandler) ListEpicIssues(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	eID, ok := epicID(c)
+	if !ok {
+		return
+	}
+	list, err := h.Issue.ListEpicIssues(c.Request.Context(), slug, projectID, eID, user.ID)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list epic issues"})
+		return
+	}
+	if list == nil {
+		c.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+// AddIssueToEpic links an issue to an epic by setting its parent.
+// POST /api/workspaces/:slug/projects/:projectId/epics/:epicId/issues/
+func (h *EpicHandler) AddIssueToEpic(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	eID, ok := epicID(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		IssueID uuid.UUID `json:"issue_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	if err := h.Issue.AddIssueToEpic(c.Request.Context(), slug, projectID, eID, body.IssueID, user.ID); err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add issue to epic"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/api/internal/handler/epic_test.go
+++ b/api/internal/handler/epic_test.go
@@ -1,0 +1,120 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func epicBase(slug, projectID string) string {
+	return "/api/workspaces/" + slug + "/projects/" + projectID + "/epics/"
+}
+
+func TestEpic_RequiresAuth(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	rr := ts.GET(epicBase("x", "00000000-0000-0000-0000-000000000000"), "")
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestEpic_CRUD(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := epicBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// List (empty)
+	rr := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Create
+	rr2 := ts.POST(base, map[string]any{
+		"name":     "Authentication epic",
+		"priority": "high",
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
+	created := testutil.MustJSONMap(t, rr2)
+	epicID, _ := created["id"].(string)
+	require.NotEmpty(t, epicID)
+	assert.Equal(t, true, created["is_epic"], "is_epic should be true")
+
+	// Get
+	rr3 := ts.GET(base+epicID+"/", w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code)
+	got := testutil.MustJSONMap(t, rr3)
+	assert.Equal(t, "Authentication epic", got["name"])
+	assert.Equal(t, true, got["is_epic"])
+
+	// Update
+	rr4 := ts.PATCH(base+epicID+"/", map[string]any{"name": "Auth epic (renamed)"}, w.Session)
+	require.Equal(t, http.StatusOK, rr4.Code, "body=%s", rr4.Body.String())
+	assert.Equal(t, "Auth epic (renamed)", testutil.MustJSONMap(t, rr4)["name"])
+
+	// List (one epic)
+	rr5 := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr5.Code)
+	assert.Contains(t, rr5.Body.String(), "Auth epic")
+
+	// Delete
+	rr6 := ts.DELETE(base+epicID+"/", w.Session)
+	require.Equal(t, http.StatusNoContent, rr6.Code)
+}
+
+func TestEpic_IssuesChild(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := epicBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// Create epic
+	rr := ts.POST(base, map[string]any{"name": "Parent epic"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	epicID, _ := testutil.MustJSONMap(t, rr)["id"].(string)
+
+	// Create a regular issue to link to the epic
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+
+	// Add issue to epic
+	rr2 := ts.POST(base+epicID+"/issues/", map[string]any{"issue_id": issue.ID.String()}, w.Session)
+	require.Equal(t, http.StatusNoContent, rr2.Code, "body=%s", rr2.Body.String())
+
+	// List epic issues
+	rr3 := ts.GET(base+epicID+"/issues/", w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code)
+	assert.Contains(t, rr3.Body.String(), issue.ID.String())
+}
+
+func TestEpic_NonMember404(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	stranger := testutil.CreateUser(t, ts.DB)
+	strangerSession := testutil.LoginAs(t, ts.DB, stranger)
+
+	rr := ts.GET(epicBase(w.Workspace.Slug, w.Project.ID.String()), strangerSession)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestEpic_Link_CRUD(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := epicBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// Create epic
+	rr := ts.POST(base, map[string]any{"name": "Epic with links"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	epicID, _ := testutil.MustJSONMap(t, rr)["id"].(string)
+
+	linkBase := base + epicID + "/links/"
+
+	// Add link to epic
+	rr2 := ts.POST(linkBase, map[string]any{
+		"title": "Design doc",
+		"url":   "https://figma.com/design",
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
+
+	// List links
+	rr3 := ts.GET(linkBase, w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code)
+	assert.Contains(t, rr3.Body.String(), "Design doc")
+}

--- a/api/internal/handler/link.go
+++ b/api/internal/handler/link.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// IssueLinkHandler serves external URL links for issues and epics.
+type IssueLinkHandler struct {
+	Issue *service.IssueService
+}
+
+func (h *IssueLinkHandler) parseIssueContext(c *gin.Context) (slug string, projectID, issueID uuid.UUID, user *model.User, ok bool) {
+	user = middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug = c.Param("slug")
+	var err error
+	if projectID, err = uuid.Parse(c.Param("projectId")); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	// Support both :pk (issue routes) and :epicId (epic routes).
+	pkStr := c.Param("pk")
+	if pkStr == "" {
+		pkStr = c.Param("epicId")
+	}
+	if issueID, err = uuid.Parse(pkStr); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	ok = true
+	return
+}
+
+// ListLinks returns links for the issue/epic.
+// GET /api/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/
+// GET /api/workspaces/:slug/projects/:projectId/epics/:pk/links/
+func (h *IssueLinkHandler) ListLinks(c *gin.Context) {
+	slug, projectID, issueID, user, ok := h.parseIssueContext(c)
+	if !ok {
+		return
+	}
+	links, err := h.Issue.ListLinks(c.Request.Context(), slug, projectID, issueID, user.ID)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list links"})
+		return
+	}
+	if links == nil {
+		c.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	c.JSON(http.StatusOK, links)
+}
+
+// CreateLink adds a link to the issue/epic.
+// POST /api/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/
+// POST /api/workspaces/:slug/projects/:projectId/epics/:pk/links/
+func (h *IssueLinkHandler) CreateLink(c *gin.Context) {
+	slug, projectID, issueID, user, ok := h.parseIssueContext(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Title string `json:"title"`
+		URL   string `json:"url" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	l, err := h.Issue.CreateLink(c.Request.Context(), slug, projectID, issueID, user.ID, body.Title, body.URL)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create link"})
+		return
+	}
+	c.JSON(http.StatusCreated, l)
+}
+
+// UpdateLink edits a link's title or URL.
+// PATCH /api/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/:linkId/
+// PATCH /api/workspaces/:slug/projects/:projectId/epics/:pk/links/:linkId/
+func (h *IssueLinkHandler) UpdateLink(c *gin.Context) {
+	slug, projectID, issueID, user, ok := h.parseIssueContext(c)
+	if !ok {
+		return
+	}
+	linkID, err := uuid.Parse(c.Param("linkId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid link ID"})
+		return
+	}
+	var body struct {
+		Title string `json:"title"`
+		URL   string `json:"url"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	l, err := h.Issue.UpdateLink(c.Request.Context(), slug, projectID, issueID, linkID, user.ID, body.Title, body.URL)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update link"})
+		return
+	}
+	c.JSON(http.StatusOK, l)
+}
+
+// DeleteLink removes a link.
+// DELETE /api/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/:linkId/
+// DELETE /api/workspaces/:slug/projects/:projectId/epics/:pk/links/:linkId/
+func (h *IssueLinkHandler) DeleteLink(c *gin.Context) {
+	slug, projectID, issueID, user, ok := h.parseIssueContext(c)
+	if !ok {
+		return
+	}
+	linkID, err := uuid.Parse(c.Param("linkId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid link ID"})
+		return
+	}
+	if err := h.Issue.DeleteLink(c.Request.Context(), slug, projectID, issueID, linkID, user.ID); err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete link"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/api/internal/handler/link_test.go
+++ b/api/internal/handler/link_test.go
@@ -1,0 +1,83 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func linkBase(slug, projectID, issueID string) string {
+	return issueBase(slug, projectID) + issueID + "/issue-links/"
+}
+
+func TestIssueLink_RequiresAuth(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	nilID := "00000000-0000-0000-0000-000000000000"
+	rr := ts.GET(linkBase("x", nilID, nilID), "")
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestIssueLink_CRUD(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	base := linkBase(w.Workspace.Slug, w.Project.ID.String(), issue.ID.String())
+
+	// List (empty)
+	rr := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Create
+	rr2 := ts.POST(base, map[string]any{
+		"title": "Plane repo",
+		"url":   "https://github.com/makeplane/plane",
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
+	created := testutil.MustJSONMap(t, rr2)
+	linkID, _ := created["id"].(string)
+	require.NotEmpty(t, linkID)
+	assert.Equal(t, "Plane repo", created["title"])
+
+	// List (one item)
+	rr3 := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code)
+	assert.Contains(t, rr3.Body.String(), "Plane repo")
+
+	// Update
+	rr4 := ts.PATCH(base+linkID+"/", map[string]any{"title": "Plane (updated)"}, w.Session)
+	require.Equal(t, http.StatusOK, rr4.Code, "body=%s", rr4.Body.String())
+	assert.Equal(t, "Plane (updated)", testutil.MustJSONMap(t, rr4)["title"])
+
+	// Delete
+	rr5 := ts.DELETE(base+linkID+"/", w.Session)
+	require.Equal(t, http.StatusNoContent, rr5.Code)
+
+	// List (empty again)
+	rr6 := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr6.Code)
+	assert.NotContains(t, rr6.Body.String(), "Plane")
+}
+
+func TestIssueLink_NonMember404(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	stranger := testutil.CreateUser(t, ts.DB)
+	strangerSession := testutil.LoginAs(t, ts.DB, stranger)
+
+	rr := ts.GET(linkBase(w.Workspace.Slug, w.Project.ID.String(), issue.ID.String()), strangerSession)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestIssueLink_MissingURL_400(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	base := linkBase(w.Workspace.Slug, w.Project.ID.String(), issue.ID.String())
+
+	rr := ts.POST(base, map[string]any{"title": "no url here"}, w.Session)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/api/internal/minio/minio.go
+++ b/api/internal/minio/minio.go
@@ -5,16 +5,20 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
+	"time"
 
 	"github.com/Devlaner/devlane/api/internal/config"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
 
 // Client wraps MinIO client.
 type Client struct {
 	*minio.Client
 	bucket string
+	useSSL bool
 }
 
 // New creates a MinIO client and ensures the bucket exists.
@@ -47,7 +51,7 @@ func New(cfg *config.Config, log *slog.Logger) (*Client, error) {
 		log.Info("minio connected", "endpoint", cfg.MinIOEndpoint, "bucket", cfg.MinIOBucket)
 	}
 
-	return &Client{Client: client, bucket: cfg.MinIOBucket}, nil
+	return &Client{Client: client, bucket: cfg.MinIOBucket, useSSL: cfg.MinIOUseSSL}, nil
 }
 
 // Bucket returns the default bucket name.
@@ -64,4 +68,51 @@ func (c *Client) PutObject(ctx context.Context, objectName string, reader io.Rea
 // GetObject returns a reader for the object from the default bucket.
 func (c *Client) GetObject(ctx context.Context, objectName string) (*minio.Object, error) {
 	return c.Client.GetObject(ctx, c.bucket, objectName, minio.GetObjectOptions{})
+}
+
+// PresignedPostFields generates S3-compatible presigned POST policy fields for direct browser upload.
+// Returns the upload URL and form fields to include in the multipart POST.
+func (c *Client) PresignedPostFields(ctx context.Context, objectName, contentType string, maxSize int64, expiry time.Duration) (uploadURL string, fields map[string]string, err error) {
+	policy := minio.NewPostPolicy()
+	if err := policy.SetBucket(c.bucket); err != nil {
+		return "", nil, err
+	}
+	if err := policy.SetKey(objectName); err != nil {
+		return "", nil, err
+	}
+	if err := policy.SetExpires(time.Now().Add(expiry)); err != nil {
+		return "", nil, err
+	}
+	if contentType != "" {
+		if err := policy.SetContentType(contentType); err != nil {
+			return "", nil, err
+		}
+	}
+	if maxSize > 0 {
+		if err := policy.SetContentLengthRange(1, maxSize); err != nil {
+			return "", nil, err
+		}
+	}
+	u, formFields, err := c.Client.PresignedPostPolicy(ctx, policy)
+	if err != nil {
+		return "", nil, err
+	}
+	return u.String(), formFields, nil
+}
+
+// DeleteObject removes an object from the default bucket.
+func (c *Client) DeleteObject(ctx context.Context, objectName string) error {
+	return c.Client.RemoveObject(ctx, c.bucket, objectName, minio.RemoveObjectOptions{})
+}
+
+// PublicURL returns the public-facing URL for an object.
+// Falls back to the internal endpoint if no public URL is configured.
+func (c *Client) PublicURL(objectName string) string {
+	_ = s3utils.CheckValidObjectName(objectName) // no-op; just using the import
+	scheme := "http"
+	if c.useSSL {
+		scheme = "https"
+	}
+	u := &url.URL{Scheme: scheme, Host: c.Client.EndpointURL().Host, Path: "/" + c.bucket + "/" + objectName}
+	return u.String()
 }

--- a/api/internal/model/issue.go
+++ b/api/internal/model/issue.go
@@ -33,6 +33,7 @@ type Issue struct {
 	SortOrder       float64        `gorm:"column:sort_order;default:65535" json:"sort_order"`
 	ArchivedAt      *time.Time     `gorm:"type:timestamptz" json:"archived_at,omitempty"`
 	IsDraft         bool           `gorm:"column:is_draft;default:false" json:"is_draft"`
+	IsEpic          bool           `gorm:"column:is_epic;default:false" json:"is_epic"`
 }
 
 func (Issue) TableName() string { return "issues" }
@@ -105,6 +106,76 @@ func (IssueRelation) TableName() string { return "issue_relations" }
 func (r *IssueRelation) BeforeCreate(tx *gorm.DB) error {
 	if r.ID == uuid.Nil {
 		r.ID = uuid.New()
+	}
+	return nil
+}
+
+// IssueLink matches migration table "issue_links".
+type IssueLink struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	Title       string     `gorm:"type:varchar(255);not null" json:"title"`
+	URL         string     `gorm:"type:text;not null" json:"url"`
+	IssueID     uuid.UUID  `gorm:"type:uuid;not null" json:"issue_id"`
+	ProjectID   uuid.UUID  `gorm:"type:uuid;not null" json:"project_id"`
+	WorkspaceID uuid.UUID  `gorm:"type:uuid;not null" json:"workspace_id"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CreatedByID *uuid.UUID `gorm:"type:uuid" json:"created_by_id,omitempty"`
+}
+
+func (IssueLink) TableName() string { return "issue_links" }
+
+func (l *IssueLink) BeforeCreate(tx *gorm.DB) error {
+	if l.ID == uuid.Nil {
+		l.ID = uuid.New()
+	}
+	return nil
+}
+
+// FileAsset matches migration table "file_assets".
+type FileAsset struct {
+	ID          uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Asset       string         `gorm:"type:varchar(800);not null" json:"asset"`
+	Attributes  JSONMap        `gorm:"type:jsonb;serializer:json" json:"attributes,omitempty"`
+	IsUploaded  bool           `gorm:"column:is_uploaded;default:false" json:"is_uploaded"`
+	IsDeleted   bool           `gorm:"column:is_deleted;default:false" json:"is_deleted"`
+	Size        float64        `gorm:"default:0" json:"size"`
+	WorkspaceID *uuid.UUID     `gorm:"type:uuid" json:"workspace_id,omitempty"`
+	ProjectID   *uuid.UUID     `gorm:"type:uuid" json:"project_id,omitempty"`
+	IssueID     *uuid.UUID     `gorm:"type:uuid" json:"issue_id,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedByID *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
+}
+
+func (FileAsset) TableName() string { return "file_assets" }
+
+func (f *FileAsset) BeforeCreate(tx *gorm.DB) error {
+	if f.ID == uuid.Nil {
+		f.ID = uuid.New()
+	}
+	return nil
+}
+
+// IssueAttachment matches migration table "issue_attachments".
+type IssueAttachment struct {
+	ID          uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	IssueID     uuid.UUID      `gorm:"type:uuid;not null" json:"issue_id"`
+	AssetID     uuid.UUID      `gorm:"type:uuid;not null" json:"asset_id"`
+	ProjectID   uuid.UUID      `gorm:"type:uuid;not null" json:"project_id"`
+	WorkspaceID uuid.UUID      `gorm:"type:uuid;not null" json:"workspace_id"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedByID *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
+}
+
+func (IssueAttachment) TableName() string { return "issue_attachments" }
+
+func (a *IssueAttachment) BeforeCreate(tx *gorm.DB) error {
+	if a.ID == uuid.Nil {
+		a.ID = uuid.New()
 	}
 	return nil
 }

--- a/api/internal/model/issue.go
+++ b/api/internal/model/issue.go
@@ -121,6 +121,7 @@ type IssueLink struct {
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
 	CreatedByID *uuid.UUID `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	UpdatedByID *uuid.UUID `gorm:"type:uuid" json:"updated_by_id,omitempty"`
 }
 
 func (IssueLink) TableName() string { return "issue_links" }
@@ -134,19 +135,28 @@ func (l *IssueLink) BeforeCreate(tx *gorm.DB) error {
 
 // FileAsset matches migration table "file_assets".
 type FileAsset struct {
-	ID          uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
-	Asset       string         `gorm:"type:varchar(800);not null" json:"asset"`
-	Attributes  JSONMap        `gorm:"type:jsonb;serializer:json" json:"attributes,omitempty"`
-	IsUploaded  bool           `gorm:"column:is_uploaded;default:false" json:"is_uploaded"`
-	IsDeleted   bool           `gorm:"column:is_deleted;default:false" json:"is_deleted"`
-	Size        float64        `gorm:"default:0" json:"size"`
-	WorkspaceID *uuid.UUID     `gorm:"type:uuid" json:"workspace_id,omitempty"`
-	ProjectID   *uuid.UUID     `gorm:"type:uuid" json:"project_id,omitempty"`
-	IssueID     *uuid.UUID     `gorm:"type:uuid" json:"issue_id,omitempty"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
-	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
-	CreatedByID *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	ID               uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Asset            string         `gorm:"type:varchar(800);not null" json:"asset"`
+	Attributes       JSONMap        `gorm:"type:jsonb;serializer:json;not null;default:'{}'" json:"attributes,omitempty"`
+	IsUploaded       bool           `gorm:"column:is_uploaded;default:false" json:"is_uploaded"`
+	IsDeleted        bool           `gorm:"column:is_deleted;default:false" json:"is_deleted"`
+	IsArchived       bool           `gorm:"column:is_archived;default:false" json:"is_archived"`
+	Size             float64        `gorm:"default:0" json:"size"`
+	EntityType       string         `gorm:"type:varchar(255);default:''" json:"entity_type,omitempty"`
+	EntityIdentifier string         `gorm:"type:varchar(255);default:''" json:"entity_identifier,omitempty"`
+	ExternalID       string         `gorm:"type:varchar(255);default:''" json:"external_id,omitempty"`
+	ExternalSource   string         `gorm:"type:varchar(255);default:''" json:"external_source,omitempty"`
+	StorageMetadata  JSONMap        `gorm:"type:jsonb;serializer:json" json:"storage_metadata,omitempty"`
+	WorkspaceID      *uuid.UUID     `gorm:"type:uuid" json:"workspace_id,omitempty"`
+	ProjectID        *uuid.UUID     `gorm:"type:uuid" json:"project_id,omitempty"`
+	IssueID          *uuid.UUID     `gorm:"type:uuid" json:"issue_id,omitempty"`
+	UserID           *uuid.UUID     `gorm:"type:uuid" json:"user_id,omitempty"`
+	CommentID        *uuid.UUID     `gorm:"type:uuid" json:"comment_id,omitempty"`
+	CreatedAt        time.Time      `json:"created_at"`
+	UpdatedAt        time.Time      `json:"updated_at"`
+	DeletedAt        gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedByID      *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	UpdatedByID      *uuid.UUID     `gorm:"type:uuid" json:"updated_by_id,omitempty"`
 }
 
 func (FileAsset) TableName() string { return "file_assets" }
@@ -155,20 +165,28 @@ func (f *FileAsset) BeforeCreate(tx *gorm.DB) error {
 	if f.ID == uuid.Nil {
 		f.ID = uuid.New()
 	}
+	// attributes is NOT NULL DEFAULT '{}' — ensure GORM never sends null.
+	if f.Attributes == nil {
+		f.Attributes = JSONMap{}
+	}
 	return nil
 }
 
 // IssueAttachment matches migration table "issue_attachments".
 type IssueAttachment struct {
-	ID          uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
-	IssueID     uuid.UUID      `gorm:"type:uuid;not null" json:"issue_id"`
-	AssetID     uuid.UUID      `gorm:"type:uuid;not null" json:"asset_id"`
-	ProjectID   uuid.UUID      `gorm:"type:uuid;not null" json:"project_id"`
-	WorkspaceID uuid.UUID      `gorm:"type:uuid;not null" json:"workspace_id"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
-	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
-	CreatedByID *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	ID             uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	IssueID        uuid.UUID      `gorm:"type:uuid;not null" json:"issue_id"`
+	AssetID        uuid.UUID      `gorm:"type:uuid;not null" json:"asset_id"`
+	Attributes     JSONMap        `gorm:"type:jsonb;serializer:json;default:'{}'" json:"attributes,omitempty"`
+	ExternalSource string         `gorm:"type:varchar(255);default:''" json:"external_source,omitempty"`
+	ExternalID     string         `gorm:"type:varchar(255);default:''" json:"external_id,omitempty"`
+	ProjectID      uuid.UUID      `gorm:"type:uuid;not null" json:"project_id"`
+	WorkspaceID    uuid.UUID      `gorm:"type:uuid;not null" json:"workspace_id"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedByID    *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	UpdatedByID    *uuid.UUID     `gorm:"type:uuid" json:"updated_by_id,omitempty"`
 }
 
 func (IssueAttachment) TableName() string { return "issue_attachments" }

--- a/api/internal/router/router.go
+++ b/api/internal/router/router.go
@@ -131,6 +131,7 @@ func New(cfg Config) *gin.Engine {
 	issueActivityStore := store.NewIssueActivityStore(cfg.DB)
 	issueSvc := service.NewIssueService(issueStore, projectStore, workspaceStore)
 	issueSvc.SetActivityStore(issueActivityStore)
+	attachmentSvc := service.NewAttachmentService(issueStore, projectStore, workspaceStore, cfg.Minio)
 	cycleSvc := service.NewCycleService(cycleStore, projectStore, workspaceStore)
 	moduleSvc := service.NewModuleService(moduleStore, projectStore, workspaceStore)
 	issueViewSvc := service.NewIssueViewService(issueViewStore, projectStore, workspaceStore, userFavoriteStore)
@@ -206,6 +207,9 @@ func New(cfg Config) *gin.Engine {
 	stateHandler := &handler.StateHandler{State: stateSvc}
 	labelHandler := &handler.LabelHandler{Label: labelSvc}
 	issueHandler := &handler.IssueHandler{Issue: issueSvc}
+	issueLinkHandler := &handler.IssueLinkHandler{Issue: issueSvc}
+	attachmentHandler := &handler.AttachmentHandler{Attachment: attachmentSvc}
+	epicHandler := &handler.EpicHandler{Issue: issueSvc}
 	cycleHandler := &handler.CycleHandler{Cycle: cycleSvc}
 	moduleHandler := &handler.ModuleHandler{Module: moduleSvc}
 	issueViewHandler := &handler.IssueViewHandler{IssueView: issueViewSvc}
@@ -303,6 +307,10 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/issue-relation/", issueHandler.ListRelations)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/issue-relation/", issueHandler.CreateRelations)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/remove-relation/", issueHandler.RemoveRelation)
+		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/", issueLinkHandler.ListLinks)
+		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/", issueLinkHandler.CreateLink)
+		api.PATCH("/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/:linkId/", issueLinkHandler.UpdateLink)
+		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/issue-links/:linkId/", issueLinkHandler.DeleteLink)
 		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/subscribe/", issueHandler.IsSubscribed)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/subscribe/", issueHandler.Subscribe)
 		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/subscribe/", issueHandler.Unsubscribe)
@@ -315,6 +323,9 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/cycles/:cycleId/issues/", cycleHandler.ListIssues)
 		api.POST("/workspaces/:slug/projects/:projectId/cycles/:cycleId/issues/", cycleHandler.AddIssue)
 		api.DELETE("/workspaces/:slug/projects/:projectId/cycles/:cycleId/issues/:issueId/", cycleHandler.RemoveIssue)
+		api.GET("/workspaces/:slug/projects/:projectId/cycles/:cycleId/progress/", cycleHandler.Progress)
+		api.GET("/workspaces/:slug/projects/:projectId/cycles/:cycleId/cycle-progress/", cycleHandler.Progress)
+		api.GET("/workspaces/:slug/projects/:projectId/cycles/:cycleId/analytics", cycleHandler.Analytics)
 
 		api.GET("/workspaces/:slug/projects/:projectId/modules/", moduleHandler.List)
 		api.POST("/workspaces/:slug/projects/:projectId/modules/", moduleHandler.Create)
@@ -324,6 +335,19 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/modules/:moduleId/issues/", moduleHandler.ListIssues)
 		api.POST("/workspaces/:slug/projects/:projectId/modules/:moduleId/issues/", moduleHandler.AddIssue)
 		api.DELETE("/workspaces/:slug/projects/:projectId/modules/:moduleId/issues/:issueId/", moduleHandler.RemoveIssue)
+
+		// Epics (is_epic=true issues with dedicated routes)
+		api.GET("/workspaces/:slug/projects/:projectId/epics/", epicHandler.ListEpics)
+		api.POST("/workspaces/:slug/projects/:projectId/epics/", epicHandler.CreateEpic)
+		api.GET("/workspaces/:slug/projects/:projectId/epics/:epicId/", epicHandler.GetEpic)
+		api.PATCH("/workspaces/:slug/projects/:projectId/epics/:epicId/", epicHandler.UpdateEpic)
+		api.DELETE("/workspaces/:slug/projects/:projectId/epics/:epicId/", epicHandler.DeleteEpic)
+		api.GET("/workspaces/:slug/projects/:projectId/epics/:epicId/issues/", epicHandler.ListEpicIssues)
+		api.POST("/workspaces/:slug/projects/:projectId/epics/:epicId/issues/", epicHandler.AddIssueToEpic)
+		api.GET("/workspaces/:slug/projects/:projectId/epics/:epicId/links/", issueLinkHandler.ListLinks)
+		api.POST("/workspaces/:slug/projects/:projectId/epics/:epicId/links/", issueLinkHandler.CreateLink)
+		api.PATCH("/workspaces/:slug/projects/:projectId/epics/:epicId/links/:linkId/", issueLinkHandler.UpdateLink)
+		api.DELETE("/workspaces/:slug/projects/:projectId/epics/:epicId/links/:linkId/", issueLinkHandler.DeleteLink)
 
 		api.GET("/workspaces/:slug/views/", issueViewHandler.List)
 		api.POST("/workspaces/:slug/views/", issueViewHandler.Create)
@@ -402,6 +426,17 @@ func New(cfg Config) *gin.Engine {
 		api.POST("/workspaces/:slug/projects/:projectId/integrations/github/sync/", integrationHandler.GitHubCreateSync)
 		api.PATCH("/workspaces/:slug/projects/:projectId/integrations/github/sync/", integrationHandler.GitHubUpdateSync)
 		api.DELETE("/workspaces/:slug/projects/:projectId/integrations/github/sync/", integrationHandler.GitHubDeleteSync)
+
+		// File attachments (v2 assets API — matches Plane frontend service URLs).
+		api.GET("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/", attachmentHandler.ListAttachments)
+		api.POST("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/", attachmentHandler.InitiateUpload)
+		api.PATCH("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/:assetId/", attachmentHandler.ConfirmUpload)
+		api.DELETE("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/:assetId/", attachmentHandler.DeleteAttachment)
+		// Epic attachments share the same handler (serviceType=epics in the URL).
+		api.GET("/assets/v2/workspaces/:slug/projects/:projectId/epics/:issueId/attachments/", attachmentHandler.ListAttachments)
+		api.POST("/assets/v2/workspaces/:slug/projects/:projectId/epics/:issueId/attachments/", attachmentHandler.InitiateUpload)
+		api.PATCH("/assets/v2/workspaces/:slug/projects/:projectId/epics/:issueId/attachments/:assetId/", attachmentHandler.ConfirmUpload)
+		api.DELETE("/assets/v2/workspaces/:slug/projects/:projectId/epics/:issueId/attachments/:assetId/", attachmentHandler.DeleteAttachment)
 
 		// GitHub PR ↔ issue links (per-issue, for the issue detail sidebar).
 		// :pk is the issue id (matches the existing /issues/:pk/ routes — Gin

--- a/api/internal/service/attachment.go
+++ b/api/internal/service/attachment.go
@@ -1,0 +1,217 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Devlaner/devlane/api/internal/minio"
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/store"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var ErrAttachmentNotFound = errors.New("attachment not found")
+
+// AttachmentResponse is what the frontend expects for TIssueAttachment.
+type AttachmentResponse struct {
+	ID         uuid.UUID              `json:"id"`
+	Attributes map[string]interface{} `json:"attributes"`
+	AssetURL   string                 `json:"asset_url"`
+	IssueID    uuid.UUID              `json:"issue_id"`
+	UpdatedAt  time.Time              `json:"updated_at"`
+	UpdatedBy  string                 `json:"updated_by"`
+	CreatedBy  string                 `json:"created_by"`
+}
+
+// PresignedUploadResponse matches TIssueAttachmentUploadResponse.
+type PresignedUploadResponse struct {
+	AssetID    uuid.UUID          `json:"asset_id"`
+	AssetURL   string             `json:"asset_url"`
+	UploadData UploadData         `json:"upload_data"`
+	Attachment AttachmentResponse `json:"attachment"`
+}
+
+// UploadData holds the URL and fields for the direct browser upload.
+type UploadData struct {
+	URL    string            `json:"url"`
+	Fields map[string]string `json:"fields"`
+}
+
+// AttachmentService handles file attachment business logic.
+type AttachmentService struct {
+	is    *store.IssueStore
+	ps    *store.ProjectStore
+	ws    *store.WorkspaceStore
+	minio *minio.Client
+}
+
+func NewAttachmentService(is *store.IssueStore, ps *store.ProjectStore, ws *store.WorkspaceStore, m *minio.Client) *AttachmentService {
+	return &AttachmentService{is: is, ps: ps, ws: ws, minio: m}
+}
+
+func (s *AttachmentService) ensureProjectAccess(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID) error {
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return ErrProjectForbidden
+	}
+	ok, _ := s.ws.IsMember(ctx, wrk.ID, userID)
+	if !ok {
+		return ErrProjectForbidden
+	}
+	inWorkspace, _ := s.ps.IsInWorkspace(ctx, projectID, wrk.ID)
+	if !inWorkspace {
+		return ErrProjectNotFound
+	}
+	return nil
+}
+
+// InitiateUpload creates the DB records and returns the presigned upload URL + attachment shape.
+func (s *AttachmentService) InitiateUpload(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, name string, size float64, contentType string) (*PresignedUploadResponse, error) {
+	if s.minio == nil {
+		return nil, errors.New("file storage is not configured")
+	}
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return nil, ErrProjectForbidden
+	}
+
+	assetID := uuid.New()
+	objectName := fmt.Sprintf("attachments/%s/%s", issueID.String(), assetID.String())
+
+	asset := &model.FileAsset{
+		ID:          assetID,
+		Asset:       objectName,
+		Attributes:  model.JSONMap{"name": name, "size": size},
+		Size:        size,
+		IsUploaded:  false,
+		WorkspaceID: &wrk.ID,
+		ProjectID:   &projectID,
+		IssueID:     &issueID,
+		CreatedByID: &userID,
+	}
+	if err := s.is.CreateFileAsset(ctx, asset); err != nil {
+		return nil, err
+	}
+
+	attachment := &model.IssueAttachment{
+		IssueID:     issueID,
+		AssetID:     assetID,
+		ProjectID:   projectID,
+		WorkspaceID: wrk.ID,
+		CreatedByID: &userID,
+	}
+	if err := s.is.CreateAttachment(ctx, attachment); err != nil {
+		return nil, err
+	}
+
+	uploadURL, fields, err := s.minio.PresignedPostFields(ctx, objectName, contentType, 50<<20, 30*time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("presign: %w", err)
+	}
+
+	resp := &PresignedUploadResponse{
+		AssetID:  assetID,
+		AssetURL: "/api/files/" + objectName,
+		UploadData: UploadData{
+			URL:    uploadURL,
+			Fields: fields,
+		},
+		Attachment: AttachmentResponse{
+			ID:         attachment.ID,
+			Attributes: map[string]interface{}{"name": name, "size": size},
+			AssetURL:   "/api/files/" + objectName,
+			IssueID:    issueID,
+			UpdatedAt:  attachment.CreatedAt,
+			UpdatedBy:  userID.String(),
+			CreatedBy:  userID.String(),
+		},
+	}
+	return resp, nil
+}
+
+// ConfirmUpload marks the file asset as uploaded (PATCH step).
+func (s *AttachmentService) ConfirmUpload(ctx context.Context, workspaceSlug string, projectID, issueID, assetID uuid.UUID, userID uuid.UUID) error {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return err
+	}
+	asset, err := s.is.GetFileAssetByID(ctx, assetID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrAttachmentNotFound
+		}
+		return err
+	}
+	if asset.IssueID == nil || *asset.IssueID != issueID {
+		return ErrAttachmentNotFound
+	}
+	return s.is.MarkFileAssetUploaded(ctx, assetID, asset.Asset)
+}
+
+// ListAttachments returns uploaded attachments for an issue.
+func (s *AttachmentService) ListAttachments(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID) ([]AttachmentResponse, error) {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	attachments, assets, err := s.is.ListAttachmentsWithAssets(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	assetMap := make(map[uuid.UUID]model.FileAsset, len(assets))
+	for _, a := range assets {
+		assetMap[a.ID] = a
+	}
+	result := make([]AttachmentResponse, 0, len(attachments))
+	for _, att := range attachments {
+		asset, ok := assetMap[att.AssetID]
+		if !ok {
+			continue
+		}
+		createdBy := ""
+		if att.CreatedByID != nil {
+			createdBy = att.CreatedByID.String()
+		}
+		result = append(result, AttachmentResponse{
+			ID:         att.ID,
+			Attributes: map[string]interface{}{"name": asset.Attributes["name"], "size": asset.Size},
+			AssetURL:   "/api/files/" + asset.Asset,
+			IssueID:    issueID,
+			UpdatedAt:  att.UpdatedAt,
+			UpdatedBy:  createdBy,
+			CreatedBy:  createdBy,
+		})
+	}
+	return result, nil
+}
+
+// DeleteAttachment removes an attachment and its file asset.
+func (s *AttachmentService) DeleteAttachment(ctx context.Context, workspaceSlug string, projectID, issueID, assetID uuid.UUID, userID uuid.UUID) error {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return err
+	}
+	asset, err := s.is.GetFileAssetByID(ctx, assetID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrAttachmentNotFound
+		}
+		return err
+	}
+	if asset.IssueID == nil || *asset.IssueID != issueID {
+		return ErrAttachmentNotFound
+	}
+	if err := s.is.SoftDeleteAttachment(ctx, assetID, issueID); err != nil {
+		return err
+	}
+	if err := s.is.SoftDeleteFileAsset(ctx, assetID); err != nil {
+		return err
+	}
+	if s.minio != nil && asset.IsUploaded && asset.Asset != "" {
+		_ = s.minio.DeleteObject(ctx, asset.Asset)
+	}
+	return nil
+}

--- a/api/internal/service/cycle.go
+++ b/api/internal/service/cycle.go
@@ -195,3 +195,59 @@ func (s *CycleService) RemoveCycleIssue(ctx context.Context, workspaceSlug strin
 	}
 	return s.cs.RemoveCycleIssue(ctx, cycleID, issueID)
 }
+
+// CycleProgressSnapshot holds counts by state group + the completion chart.
+type CycleProgressSnapshot struct {
+	TotalIssues     int                `json:"total_issues"`
+	CompletedIssues int                `json:"completed_issues"`
+	BacklogIssues   int                `json:"backlog_issues"`
+	StartedIssues   int                `json:"started_issues"`
+	UnstartedIssues int                `json:"unstarted_issues"`
+	CancelledIssues int                `json:"cancelled_issues"`
+	Distribution    *CycleDistribution `json:"distribution,omitempty"`
+}
+
+// CycleDistribution contains the per-day completion chart and per-assignee/label breakdowns.
+type CycleDistribution struct {
+	CompletionChart map[string]interface{} `json:"completion_chart"`
+	Assignees       []interface{}          `json:"assignees"`
+	Labels          []interface{}          `json:"labels"`
+}
+
+// GetProgress computes a TProgressSnapshot-compatible response for the cycle.
+func (s *CycleService) GetProgress(ctx context.Context, workspaceSlug string, projectID, cycleID uuid.UUID, userID uuid.UUID) (*CycleProgressSnapshot, error) {
+	cy, err := s.Get(ctx, workspaceSlug, projectID, cycleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	dist, err := s.cs.CycleStateDistribution(ctx, cycleID)
+	if err != nil {
+		return nil, err
+	}
+	total := 0
+	for _, v := range dist {
+		total += v
+	}
+	chart, err := s.cs.CycleCompletionChart(ctx, cycleID, cy.StartDate, cy.EndDate)
+	if err != nil {
+		return nil, err
+	}
+	// Convert int map to interface{} map so JSON null is avoided for missing dates.
+	chartOut := make(map[string]interface{}, len(chart))
+	for k, v := range chart {
+		chartOut[k] = v
+	}
+	return &CycleProgressSnapshot{
+		TotalIssues:     total,
+		CompletedIssues: dist["completed"],
+		BacklogIssues:   dist["backlog"],
+		StartedIssues:   dist["started"],
+		UnstartedIssues: dist["unstarted"],
+		CancelledIssues: dist["cancelled"],
+		Distribution: &CycleDistribution{
+			CompletionChart: chartOut,
+			Assignees:       []interface{}{},
+			Labels:          []interface{}{},
+		},
+	}, nil
+}

--- a/api/internal/service/issue.go
+++ b/api/internal/service/issue.go
@@ -727,3 +727,158 @@ func (s *IssueService) RemoveRelation(ctx context.Context, workspaceSlug string,
 	_ = s.is.DeleteRelation(ctx, relatedIssueID, issueID, reverseType)
 	return nil
 }
+
+// --- Issue Links ---
+
+// ListLinks returns all external links attached to the issue.
+func (s *IssueService) ListLinks(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID) ([]model.IssueLink, error) {
+	if _, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return nil, err
+	}
+	return s.is.ListLinksForIssue(ctx, issueID)
+}
+
+// CreateLink attaches an external URL to the issue.
+func (s *IssueService) CreateLink(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, title, rawURL string) (*model.IssueLink, error) {
+	issue, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID)
+	if err != nil {
+		return nil, err
+	}
+	l := &model.IssueLink{
+		Title:       title,
+		URL:         rawURL,
+		IssueID:     issue.ID,
+		ProjectID:   issue.ProjectID,
+		WorkspaceID: issue.WorkspaceID,
+		CreatedByID: &userID,
+	}
+	if err := s.is.CreateLink(ctx, l); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// UpdateLink edits a link's title or URL.
+func (s *IssueService) UpdateLink(ctx context.Context, workspaceSlug string, projectID, issueID, linkID uuid.UUID, userID uuid.UUID, title, rawURL string) (*model.IssueLink, error) {
+	if _, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return nil, err
+	}
+	l, err := s.is.GetLinkByID(ctx, linkID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrIssueNotFound
+		}
+		return nil, err
+	}
+	if l.IssueID != issueID {
+		return nil, ErrIssueNotFound
+	}
+	if title != "" {
+		l.Title = title
+	}
+	if rawURL != "" {
+		l.URL = rawURL
+	}
+	if err := s.is.UpdateLink(ctx, l); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// DeleteLink removes a link from the issue.
+func (s *IssueService) DeleteLink(ctx context.Context, workspaceSlug string, projectID, issueID, linkID uuid.UUID, userID uuid.UUID) error {
+	if _, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return err
+	}
+	l, err := s.is.GetLinkByID(ctx, linkID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrIssueNotFound
+		}
+		return err
+	}
+	if l.IssueID != issueID {
+		return ErrIssueNotFound
+	}
+	return s.is.DeleteLink(ctx, linkID)
+}
+
+// --- Epics ---
+
+// ListEpics returns all epics (is_epic=true) for the project.
+func (s *IssueService) ListEpics(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) ([]model.Issue, error) {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	list, err := s.is.ListEpicsByProjectID(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		if ids, err := s.is.ListAssigneesForIssue(ctx, list[i].ID); err == nil {
+			list[i].AssigneeIDs = ids
+		}
+		if ids, err := s.is.ListLabelsForIssue(ctx, list[i].ID); err == nil {
+			list[i].LabelIDs = ids
+		}
+	}
+	return list, nil
+}
+
+// CreateEpic creates a new epic in the project.
+func (s *IssueService) CreateEpic(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, description, priority string, stateID *uuid.UUID, assigneeIDs, labelIDs []uuid.UUID) (*model.Issue, error) {
+	epic, err := s.Create(ctx, workspaceSlug, projectID, userID, name, description, priority, stateID, assigneeIDs, labelIDs, nil, nil, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	epic.IsEpic = true
+	if err := s.is.Update(ctx, epic); err != nil {
+		return nil, err
+	}
+	return epic, nil
+}
+
+// GetEpic returns a single epic, verifying it belongs to the project and is_epic=true.
+func (s *IssueService) GetEpic(ctx context.Context, workspaceSlug string, projectID, epicID uuid.UUID, userID uuid.UUID) (*model.Issue, error) {
+	epic, err := s.GetByID(ctx, workspaceSlug, projectID, epicID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !epic.IsEpic {
+		return nil, ErrIssueNotFound
+	}
+	return epic, nil
+}
+
+// ListEpicIssues returns child issues of an epic.
+func (s *IssueService) ListEpicIssues(ctx context.Context, workspaceSlug string, projectID, epicID uuid.UUID, userID uuid.UUID) ([]model.Issue, error) {
+	if _, err := s.GetEpic(ctx, workspaceSlug, projectID, epicID, userID); err != nil {
+		return nil, err
+	}
+	list, err := s.is.ListIssuesByEpicID(ctx, epicID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		if ids, err := s.is.ListAssigneesForIssue(ctx, list[i].ID); err == nil {
+			list[i].AssigneeIDs = ids
+		}
+		if ids, err := s.is.ListLabelsForIssue(ctx, list[i].ID); err == nil {
+			list[i].LabelIDs = ids
+		}
+	}
+	return list, nil
+}
+
+// AddIssueToEpic sets the parent of an existing issue to the epic.
+func (s *IssueService) AddIssueToEpic(ctx context.Context, workspaceSlug string, projectID, epicID, issueID uuid.UUID, userID uuid.UUID) error {
+	if _, err := s.GetEpic(ctx, workspaceSlug, projectID, epicID, userID); err != nil {
+		return err
+	}
+	issue, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID)
+	if err != nil {
+		return err
+	}
+	issue.ParentID = &epicID
+	return s.is.Update(ctx, issue)
+}

--- a/api/internal/store/cycle.go
+++ b/api/internal/store/cycle.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/google/uuid"
@@ -85,6 +86,61 @@ func (s *CycleStore) CountIssuesByCycleIDs(ctx context.Context, cycleIDs []uuid.
 	}
 	for _, r := range rows {
 		out[r.CycleID] = r.Count
+	}
+	return out, nil
+}
+
+// CycleStateDistribution returns issue counts grouped by state group for a cycle.
+func (s *CycleStore) CycleStateDistribution(ctx context.Context, cycleID uuid.UUID) (map[string]int, error) {
+	var rows []struct {
+		Group string `gorm:"column:grp"`
+		Count int    `gorm:"column:count"`
+	}
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT COALESCE(st.group, 'backlog') AS grp, COUNT(i.id) AS count
+		FROM cycle_issues ci
+		JOIN issues i ON i.id = ci.issue_id AND i.deleted_at IS NULL
+		LEFT JOIN states st ON st.id = i.state_id
+		WHERE ci.cycle_id = ? AND ci.deleted_at IS NULL
+		GROUP BY COALESCE(st.group, 'backlog')
+	`, cycleID).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]int{
+		"backlog":   0,
+		"unstarted": 0,
+		"started":   0,
+		"completed": 0,
+		"cancelled": 0,
+	}
+	for _, r := range rows {
+		out[r.Group] = r.Count
+	}
+	return out, nil
+}
+
+// CycleCompletionChart returns a date→count map of issues completed per day within the cycle's range.
+func (s *CycleStore) CycleCompletionChart(ctx context.Context, cycleID uuid.UUID, startDate, endDate *time.Time) (map[string]int, error) {
+	var rows []struct {
+		Date  string `gorm:"column:dt"`
+		Count int    `gorm:"column:count"`
+	}
+	q := s.db.WithContext(ctx).Raw(`
+		SELECT TO_CHAR(i.updated_at, 'YYYY-MM-DD') AS dt, COUNT(i.id) AS count
+		FROM cycle_issues ci
+		JOIN issues i ON i.id = ci.issue_id AND i.deleted_at IS NULL
+		JOIN states st ON st.id = i.state_id AND st.group = 'completed'
+		WHERE ci.cycle_id = ? AND ci.deleted_at IS NULL
+		GROUP BY TO_CHAR(i.updated_at, 'YYYY-MM-DD')
+		ORDER BY dt
+	`, cycleID)
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]int, len(rows))
+	for _, r := range rows {
+		out[r.Date] = r.Count
 	}
 	return out, nil
 }

--- a/api/internal/store/issue.go
+++ b/api/internal/store/issue.go
@@ -188,3 +188,115 @@ func (s *IssueStore) DeleteRelation(ctx context.Context, issueID, relatedIssueID
 		Where("issue_id = ? AND related_issue_id = ? AND relation_type = ?", issueID, relatedIssueID, relationType).
 		Delete(&model.IssueRelation{}).Error
 }
+
+// --- Issue Links ---
+
+func (s *IssueStore) ListLinksForIssue(ctx context.Context, issueID uuid.UUID) ([]model.IssueLink, error) {
+	var rows []model.IssueLink
+	err := s.db.WithContext(ctx).Where("issue_id = ?", issueID).Order("created_at ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (s *IssueStore) CreateLink(ctx context.Context, l *model.IssueLink) error {
+	return s.db.WithContext(ctx).Create(l).Error
+}
+
+func (s *IssueStore) GetLinkByID(ctx context.Context, linkID uuid.UUID) (*model.IssueLink, error) {
+	var l model.IssueLink
+	err := s.db.WithContext(ctx).Where("id = ?", linkID).First(&l).Error
+	if err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+func (s *IssueStore) UpdateLink(ctx context.Context, l *model.IssueLink) error {
+	return s.db.WithContext(ctx).Save(l).Error
+}
+
+func (s *IssueStore) DeleteLink(ctx context.Context, linkID uuid.UUID) error {
+	return s.db.WithContext(ctx).Where("id = ?", linkID).Delete(&model.IssueLink{}).Error
+}
+
+// --- File Assets & Attachments ---
+
+func (s *IssueStore) CreateFileAsset(ctx context.Context, a *model.FileAsset) error {
+	return s.db.WithContext(ctx).Create(a).Error
+}
+
+func (s *IssueStore) GetFileAssetByID(ctx context.Context, assetID uuid.UUID) (*model.FileAsset, error) {
+	var a model.FileAsset
+	err := s.db.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", assetID).First(&a).Error
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (s *IssueStore) MarkFileAssetUploaded(ctx context.Context, assetID uuid.UUID, objectPath string) error {
+	return s.db.WithContext(ctx).Model(&model.FileAsset{}).
+		Where("id = ?", assetID).
+		Updates(map[string]interface{}{"is_uploaded": true, "asset": objectPath}).Error
+}
+
+func (s *IssueStore) SoftDeleteFileAsset(ctx context.Context, assetID uuid.UUID) error {
+	return s.db.WithContext(ctx).Where("id = ?", assetID).Delete(&model.FileAsset{}).Error
+}
+
+func (s *IssueStore) CreateAttachment(ctx context.Context, a *model.IssueAttachment) error {
+	return s.db.WithContext(ctx).Create(a).Error
+}
+
+// ListAttachmentsWithAssets returns attachments + their file asset for an issue.
+func (s *IssueStore) ListAttachmentsWithAssets(ctx context.Context, issueID uuid.UUID) ([]model.IssueAttachment, []model.FileAsset, error) {
+	var attachments []model.IssueAttachment
+	if err := s.db.WithContext(ctx).
+		Where("issue_id = ? AND deleted_at IS NULL", issueID).
+		Order("created_at ASC").Find(&attachments).Error; err != nil {
+		return nil, nil, err
+	}
+	if len(attachments) == 0 {
+		return nil, nil, nil
+	}
+	assetIDs := make([]uuid.UUID, 0, len(attachments))
+	for _, a := range attachments {
+		assetIDs = append(assetIDs, a.AssetID)
+	}
+	var assets []model.FileAsset
+	err := s.db.WithContext(ctx).Where("id IN ? AND is_uploaded = true AND deleted_at IS NULL", assetIDs).Find(&assets).Error
+	return attachments, assets, err
+}
+
+func (s *IssueStore) GetAttachmentByAssetID(ctx context.Context, assetID, issueID uuid.UUID) (*model.IssueAttachment, error) {
+	var a model.IssueAttachment
+	err := s.db.WithContext(ctx).
+		Where("asset_id = ? AND issue_id = ? AND deleted_at IS NULL", assetID, issueID).First(&a).Error
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (s *IssueStore) SoftDeleteAttachment(ctx context.Context, assetID, issueID uuid.UUID) error {
+	return s.db.WithContext(ctx).
+		Where("asset_id = ? AND issue_id = ?", assetID, issueID).
+		Delete(&model.IssueAttachment{}).Error
+}
+
+// --- Epics ---
+
+func (s *IssueStore) ListEpicsByProjectID(ctx context.Context, projectID uuid.UUID) ([]model.Issue, error) {
+	var list []model.Issue
+	err := s.db.WithContext(ctx).
+		Where("project_id = ? AND is_epic = true AND deleted_at IS NULL", projectID).
+		Order("sort_order ASC, created_at DESC").Find(&list).Error
+	return list, err
+}
+
+func (s *IssueStore) ListIssuesByEpicID(ctx context.Context, epicID uuid.UUID) ([]model.Issue, error) {
+	var list []model.Issue
+	err := s.db.WithContext(ctx).
+		Where("parent_id = ? AND is_epic = false AND deleted_at IS NULL", epicID).
+		Order("sort_order ASC, created_at DESC").Find(&list).Error
+	return list, err
+}

--- a/api/migrations/000004_epics.down.sql
+++ b/api/migrations/000004_epics.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_issues_is_epic;
+ALTER TABLE issues DROP COLUMN IF EXISTS is_epic;

--- a/api/migrations/000004_epics.up.sql
+++ b/api/migrations/000004_epics.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE issues ADD COLUMN IF NOT EXISTS is_epic BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX IF NOT EXISTS idx_issues_is_epic ON issues (is_epic) WHERE is_epic = TRUE;


### PR DESCRIPTION
This pull request introduces new handler implementations and corresponding tests for epics, attachments, and cycle progress in the API. It adds full CRUD and linking endpoints for epics, provides endpoints for managing issue attachments, and introduces endpoints and tests for cycle burndown/progress analytics. These changes significantly expand the API's coverage and testability for key project management features.

**New API Handlers**

- Epic endpoints:
  - Implements `EpicHandler` with endpoints to list, create, retrieve, update, and delete epics, as well as manage their child issues and add issues to epics. (`api/internal/handler/epic.go`)
- Attachment endpoints:
  - Adds `AttachmentHandler` with endpoints to initiate, confirm, list, and delete file attachments for issues. (`api/internal/handler/attachment.go`)
- Cycle progress endpoints:
  - Adds new endpoints to retrieve cycle progress (burndown data) and analytics, including error handling for authentication and permissions. (`api/internal/handler/cycle.go`)

**Test Coverage**

- Epic handler tests:
  - Adds comprehensive tests for epic CRUD operations, issue linking, and link management, including authentication and permission checks. (`api/internal/handler/epic_test.go`)
- Cycle progress tests:
  - Adds tests for cycle progress and analytics endpoints, covering authentication, empty cycles, and permission scenarios. (`api/internal/handler/cycle_progress_test.go`)