### PR TITLE
refactor: update handler, router, service, components, drafts for API…

### DIFF
--- a/api/internal/handler/project.go
+++ b/api/internal/handler/project.go
@@ -120,10 +120,8 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 		return
 	}
 	if h.State != nil {
-		if err := h.State.EnsureDefaultStates(c.Request.Context(), slug, p.ID, user.ID); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to seed default states"})
-			return
-		}
+		// Best-effort: project is already created; state listing also seeds on-demand.
+		_ = h.State.EnsureDefaultStates(c.Request.Context(), slug, p.ID, user.ID)
 	}
 
 	// If additional fields were provided, immediately apply them using the same logic as Update.

--- a/api/internal/handler/project.go
+++ b/api/internal/handler/project.go
@@ -120,7 +120,10 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 		return
 	}
 	if h.State != nil {
-		_ = h.State.EnsureDefaultStates(c.Request.Context(), slug, p.ID, user.ID)
+		if err := h.State.EnsureDefaultStates(c.Request.Context(), slug, p.ID, user.ID); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to seed default states"})
+			return
+		}
 	}
 
 	// If additional fields were provided, immediately apply them using the same logic as Update.

--- a/api/internal/handler/project.go
+++ b/api/internal/handler/project.go
@@ -13,6 +13,7 @@ import (
 // ProjectHandler serves project and project-member/invite endpoints.
 type ProjectHandler struct {
 	Project *service.ProjectService
+	State   *service.StateService
 }
 
 func projectID(c *gin.Context) (uuid.UUID, bool) {
@@ -117,6 +118,9 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create project"})
 		return
+	}
+	if h.State != nil {
+		_ = h.State.EnsureDefaultStates(c.Request.Context(), slug, p.ID, user.ID)
 	}
 
 	// If additional fields were provided, immediately apply them using the same logic as Update.

--- a/api/internal/handler/project_test.go
+++ b/api/internal/handler/project_test.go
@@ -39,6 +39,20 @@ func TestProject_Create_Success(t *testing.T) {
 	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
 	body := testutil.MustJSONMap(t, rr)
 	assert.Equal(t, "My Project", body["name"])
+
+	projectID, _ := body["id"].(string)
+	require.NotEmpty(t, projectID)
+
+	statesRR := ts.GET("/api/workspaces/"+ws.Slug+"/projects/"+projectID+"/states/", session)
+	require.Equal(t, http.StatusOK, statesRR.Code, "body=%s", statesRR.Body.String())
+	states := testutil.DecodeJSON[[]map[string]any](t, statesRR)
+	require.Len(t, states, 5)
+	names := make([]string, len(states))
+	for i, st := range states {
+		name, _ := st["name"].(string)
+		names[i] = name
+	}
+	assert.ElementsMatch(t, []string{"Backlog", "Todo", "In Progress", "Done", "Cancelled"}, names)
 }
 
 func TestProject_Create_RequiresMembership(t *testing.T) {

--- a/api/internal/handler/state_test.go
+++ b/api/internal/handler/state_test.go
@@ -46,6 +46,27 @@ func TestState_CRUD(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, rr4.Code)
 }
 
+func TestState_List_SeedsDefaultStates(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	user := testutil.CreateUser(t, ts.DB)
+	ws := testutil.CreateWorkspace(t, ts.DB, user.ID)
+	session := testutil.LoginAs(t, ts.DB, user)
+	project := testutil.CreateProject(t, ts.DB, ws.ID, user.ID)
+
+	base := "/api/workspaces/" + ws.Slug + "/projects/" + project.ID.String() + "/states/"
+	rr := ts.GET(base, session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+
+	list := testutil.DecodeJSON[[]map[string]any](t, rr)
+	require.Len(t, list, 5)
+	names := make([]string, len(list))
+	for i, st := range list {
+		name, _ := st["name"].(string)
+		names[i] = name
+	}
+	assert.ElementsMatch(t, []string{"Backlog", "Todo", "In Progress", "Done", "Cancelled"}, names)
+}
+
 func TestState_NonMember404(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/api/internal/router/router.go
+++ b/api/internal/router/router.go
@@ -202,7 +202,7 @@ func New(cfg Config) *gin.Engine {
 		Queue:      cfg.Queue,
 		AppBaseURL: appBaseURL,
 	}
-	projectHandler := &handler.ProjectHandler{Project: projectSvc}
+	projectHandler := &handler.ProjectHandler{Project: projectSvc, State: stateSvc}
 	favoriteHandler := &handler.FavoriteHandler{Project: projectSvc, Favorites: userFavoriteStore}
 	stateHandler := &handler.StateHandler{State: stateSvc}
 	labelHandler := &handler.LabelHandler{Label: labelSvc}

--- a/api/internal/service/state.go
+++ b/api/internal/service/state.go
@@ -11,6 +11,9 @@ import (
 
 var ErrStateNotFound = errors.New("state not found")
 
+// DefaultProjectStateNames are seeded for new projects (Plane parity, without triage).
+var DefaultProjectStateNames = []string{"Backlog", "Todo", "In Progress", "Done", "Cancelled"}
+
 // StateService handles state (workflow) business logic.
 type StateService struct {
 	ss *store.StateStore
@@ -22,31 +25,35 @@ func NewStateService(ss *store.StateStore, ps *store.ProjectStore, ws *store.Wor
 	return &StateService{ss: ss, ps: ps, ws: ws}
 }
 
-func (s *StateService) ensureProjectAccess(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) error {
+func (s *StateService) ensureProjectAccess(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) (uuid.UUID, error) {
 	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
 	if err != nil {
-		return ErrProjectForbidden
+		return uuid.Nil, ErrProjectForbidden
 	}
 	ok, _ := s.ws.IsMember(ctx, wrk.ID, userID)
 	if !ok {
-		return ErrProjectForbidden
+		return uuid.Nil, ErrProjectForbidden
 	}
 	inWorkspace, _ := s.ps.IsInWorkspace(ctx, projectID, wrk.ID)
 	if !inWorkspace {
-		return ErrProjectNotFound
+		return uuid.Nil, ErrProjectNotFound
 	}
-	return nil
+	return wrk.ID, nil
 }
 
 func (s *StateService) List(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) ([]model.State, error) {
-	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+	workspaceID, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID)
+	if err != nil {
 		return nil, err
 	}
-	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	list, err := s.ss.ListByProjectID(ctx, projectID)
 	if err != nil {
-		return nil, ErrProjectForbidden
+		return nil, err
 	}
-	if err := s.ensureDefaultStates(ctx, projectID, wrk.ID); err != nil {
+	if len(list) > 0 {
+		return list, nil
+	}
+	if err := s.ensureDefaultStates(ctx, projectID, workspaceID); err != nil {
 		return nil, err
 	}
 	return s.ss.ListByProjectID(ctx, projectID)
@@ -85,7 +92,7 @@ func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, works
 			ProjectID:   projectID,
 			WorkspaceID: workspaceID,
 		}
-		if err := s.ss.Create(ctx, st); err != nil {
+		if err := s.ss.CreateIgnoreNameConflict(ctx, st); err != nil {
 			return err
 		}
 	}
@@ -94,21 +101,18 @@ func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, works
 
 // EnsureDefaultStates seeds workflow states for a project that has none (Plane parity).
 func (s *StateService) EnsureDefaultStates(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) error {
-	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+	workspaceID, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID)
+	if err != nil {
 		return err
 	}
-	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
-	if err != nil {
-		return ErrProjectForbidden
-	}
-	return s.ensureDefaultStates(ctx, projectID, wrk.ID)
+	return s.ensureDefaultStates(ctx, projectID, workspaceID)
 }
 
 func (s *StateService) Create(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, color, group string) (*model.State, error) {
-	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+	workspaceID, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID)
+	if err != nil {
 		return nil, err
 	}
-	wrk, _ := s.ws.GetBySlug(ctx, workspaceSlug)
 	if color == "" {
 		color = "#0d0d0d"
 	}
@@ -120,7 +124,7 @@ func (s *StateService) Create(ctx context.Context, workspaceSlug string, project
 		Color:       color,
 		Group:       group,
 		ProjectID:   projectID,
-		WorkspaceID: wrk.ID,
+		WorkspaceID: workspaceID,
 	}
 	if err := s.ss.Create(ctx, st); err != nil {
 		return nil, err
@@ -129,7 +133,7 @@ func (s *StateService) Create(ctx context.Context, workspaceSlug string, project
 }
 
 func (s *StateService) GetByID(ctx context.Context, workspaceSlug string, projectID, stateID uuid.UUID, userID uuid.UUID) (*model.State, error) {
-	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+	if _, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
 		return nil, err
 	}
 	st, err := s.ss.GetByID(ctx, stateID)

--- a/api/internal/service/state.go
+++ b/api/internal/service/state.go
@@ -71,7 +71,7 @@ var defaultProjectStates = []struct {
 	{name: "Todo", color: "#60646C", sequence: 25000, group: "unstarted"},
 	{name: "In Progress", color: "#F59E0B", sequence: 35000, group: "started"},
 	{name: "Done", color: "#46A758", sequence: 45000, group: "completed"},
-	{name: "Cancelled", color: "#9AA4BC", sequence: 55000, group: "cancelled"},
+	{name: "Cancelled", color: "#9AA4BC", sequence: 55000, group: "canceled"},
 }
 
 func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, workspaceID uuid.UUID) error {

--- a/api/internal/service/state.go
+++ b/api/internal/service/state.go
@@ -42,7 +42,66 @@ func (s *StateService) List(ctx context.Context, workspaceSlug string, projectID
 	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
 		return nil, err
 	}
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return nil, ErrProjectForbidden
+	}
+	if err := s.ensureDefaultStates(ctx, projectID, wrk.ID); err != nil {
+		return nil, err
+	}
 	return s.ss.ListByProjectID(ctx, projectID)
+}
+
+// defaultProjectStates mirrors Plane's DEFAULT_STATES (without triage).
+var defaultProjectStates = []struct {
+	name      string
+	color     string
+	sequence  float64
+	group     string
+	isDefault bool
+}{
+	{name: "Backlog", color: "#60646C", sequence: 15000, group: "backlog", isDefault: true},
+	{name: "Todo", color: "#60646C", sequence: 25000, group: "unstarted"},
+	{name: "In Progress", color: "#F59E0B", sequence: 35000, group: "started"},
+	{name: "Done", color: "#46A758", sequence: 45000, group: "completed"},
+	{name: "Cancelled", color: "#9AA4BC", sequence: 55000, group: "cancelled"},
+}
+
+func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, workspaceID uuid.UUID) error {
+	list, err := s.ss.ListByProjectID(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	if len(list) > 0 {
+		return nil
+	}
+	for _, def := range defaultProjectStates {
+		st := &model.State{
+			Name:        def.name,
+			Color:       def.color,
+			Sequence:    def.sequence,
+			Group:       def.group,
+			Default:     def.isDefault,
+			ProjectID:   projectID,
+			WorkspaceID: workspaceID,
+		}
+		if err := s.ss.Create(ctx, st); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnsureDefaultStates seeds workflow states for a project that has none (Plane parity).
+func (s *StateService) EnsureDefaultStates(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) error {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return err
+	}
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return ErrProjectForbidden
+	}
+	return s.ensureDefaultStates(ctx, projectID, wrk.ID)
 }
 
 func (s *StateService) Create(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, color, group string) (*model.State, error) {

--- a/api/internal/service/state.go
+++ b/api/internal/service/state.go
@@ -92,7 +92,7 @@ func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, works
 			ProjectID:   projectID,
 			WorkspaceID: workspaceID,
 		}
-		if err := s.ss.CreateIgnoreNameConflict(ctx, st); err != nil {
+		if err := s.ss.RestoreOrCreateByNameAndProject(ctx, st); err != nil {
 			return err
 		}
 	}

--- a/api/internal/store/state.go
+++ b/api/internal/store/state.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // StateStore handles state persistence.
@@ -15,6 +16,14 @@ func NewStateStore(db *gorm.DB) *StateStore { return &StateStore{db: db} }
 
 func (s *StateStore) Create(ctx context.Context, st *model.State) error {
 	return s.db.WithContext(ctx).Create(st).Error
+}
+
+// CreateIgnoreNameConflict inserts a state but ignores unique (name, project_id) violations.
+func (s *StateStore) CreateIgnoreNameConflict(ctx context.Context, st *model.State) error {
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "name"}, {Name: "project_id"}},
+		DoNothing: true,
+	}).Create(st).Error
 }
 
 func (s *StateStore) GetByID(ctx context.Context, id uuid.UUID) (*model.State, error) {

--- a/api/internal/store/state.go
+++ b/api/internal/store/state.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/google/uuid"
@@ -18,8 +19,28 @@ func (s *StateStore) Create(ctx context.Context, st *model.State) error {
 	return s.db.WithContext(ctx).Create(st).Error
 }
 
-// CreateIgnoreNameConflict inserts a state but ignores unique (name, project_id) violations.
-func (s *StateStore) CreateIgnoreNameConflict(ctx context.Context, st *model.State) error {
+// RestoreOrCreateByNameAndProject inserts a default state, restoring a soft-deleted row
+// with the same (name, project_id) when present so UNIQUE constraints do not block reseeding.
+func (s *StateStore) RestoreOrCreateByNameAndProject(ctx context.Context, st *model.State) error {
+	var existing model.State
+	err := s.db.WithContext(ctx).Unscoped().
+		Where("name = ? AND project_id = ?", st.Name, st.ProjectID).
+		First(&existing).Error
+	if err == nil {
+		if !existing.DeletedAt.Valid {
+			return nil
+		}
+		existing.Color = st.Color
+		existing.Sequence = st.Sequence
+		existing.Group = st.Group
+		existing.Default = st.Default
+		existing.WorkspaceID = st.WorkspaceID
+		existing.DeletedAt = gorm.DeletedAt{}
+		return s.db.WithContext(ctx).Unscoped().Save(&existing).Error
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
 	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "name"}, {Name: "project_id"}},
 		DoNothing: true,

--- a/ui/src/components/CreateWorkItemModal.tsx
+++ b/ui/src/components/CreateWorkItemModal.tsx
@@ -275,8 +275,8 @@ export function CreateWorkItemModal({
   }, [workspaceSlug]);
 
   const stateName = stateId ? (states.find((s) => s.id === stateId)?.name ?? '') : '';
-  const showModules = Boolean(selectedProject?.module_view);
-  const showCycles = Boolean(selectedProject?.cycle_view);
+  const showModules = selectedProject?.module_view ?? true;
+  const showCycles = selectedProject?.cycle_view ?? true;
   const assigneeNames =
     assigneeIds
       .map((id) => members.find((m) => m.id === id)?.name ?? id.slice(0, 8))

--- a/ui/src/components/CreateWorkItemModal.tsx
+++ b/ui/src/components/CreateWorkItemModal.tsx
@@ -274,7 +274,9 @@ export function CreateWorkItemModal({
     };
   }, [workspaceSlug]);
 
-  const stateName = stateId ? states.find((s) => s.id === stateId)?.name : '';
+  const stateName = stateId ? (states.find((s) => s.id === stateId)?.name ?? '') : '';
+  const showModules = Boolean(selectedProject?.module_view);
+  const showCycles = Boolean(selectedProject?.cycle_view);
   const assigneeNames =
     assigneeIds
       .map((id) => members.find((m) => m.id === id)?.name ?? id.slice(0, 8))
@@ -298,6 +300,11 @@ export function CreateWorkItemModal({
   const filteredLabels = labels.filter((l) => q(l.name).includes(q(labelSearch)));
   const filteredCycles = cycles.filter((c) => q(c.name).includes(q(cycleSearch)));
   const filteredModules = modules.filter((m) => q(m.name).includes(q(moduleSearch)));
+
+  useEffect(() => {
+    if (!showCycles) setCycleId(null);
+    if (!showModules) setModuleId(null);
+  }, [showCycles, showModules]);
 
   useEffect(() => {
     if (open) {
@@ -345,7 +352,7 @@ export function CreateWorkItemModal({
           title,
           description,
           projectId,
-          stateId: draftOnly ? undefined : stateId || undefined,
+          stateId: stateId || undefined,
           priority: priority !== 'none' ? priority : undefined,
           assigneeIds: assigneeIds.length ? assigneeIds : undefined,
           assigneeId: assigneeIds[0] ?? undefined,
@@ -444,6 +451,7 @@ export function CreateWorkItemModal({
                 id="project"
                 openId={openDropdown}
                 onOpen={setOpenDropdown}
+                allowDismissInsideDialog
                 label="Select project"
                 icon={
                   selectedProject?.name.includes('Logistics') ? <IconTruck /> : <IconBuilding />
@@ -502,6 +510,7 @@ export function CreateWorkItemModal({
                 icon={<IconCog />}
                 displayValue={stateName || 'Backlog'}
                 compact
+                allowDismissInsideDialog
                 panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
               >
                 <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
@@ -514,25 +523,30 @@ export function CreateWorkItemModal({
                   />
                 </div>
                 <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
-                  {filteredStates.map((s) => (
-                    <button
-                      key={s.id}
-                      type="button"
-                      onClick={() => {
-                        setStateId(s.id);
-                        setOpenDropdown(null);
-                      }}
-                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
-                    >
-                      {s.name}
-                    </button>
-                  ))}
+                  {filteredStates.length === 0 ? (
+                    <div className="px-2 py-1 text-xs text-(--txt-tertiary)">No states</div>
+                  ) : (
+                    filteredStates.map((s) => (
+                      <button
+                        key={s.id}
+                        type="button"
+                        onClick={() => {
+                          setStateId(s.id);
+                          setOpenDropdown(null);
+                        }}
+                        className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+                      >
+                        {s.name}
+                      </button>
+                    ))
+                  )}
                 </div>
               </Dropdown>
               <Dropdown
                 id="priority"
                 openId={openDropdown}
                 onOpen={setOpenDropdown}
+                allowDismissInsideDialog
                 label="None"
                 icon={<IconCircleSlash />}
                 displayValue={
@@ -561,6 +575,7 @@ export function CreateWorkItemModal({
                 id="assignees"
                 openId={openDropdown}
                 onOpen={setOpenDropdown}
+                allowDismissInsideDialog
                 label="Assignees"
                 icon={<IconUsers />}
                 displayValue={assigneeNames || 'Add assignees'}
@@ -607,6 +622,7 @@ export function CreateWorkItemModal({
                 id="labels"
                 openId={openDropdown}
                 onOpen={setOpenDropdown}
+                allowDismissInsideDialog
                 label="Labels"
                 icon={<IconTag />}
                 displayValue={labelNames}
@@ -672,96 +688,102 @@ export function CreateWorkItemModal({
                 onChange={setDueDate}
                 placeholder="Due date"
               />
-              <Dropdown
-                id="cycle"
-                openId={openDropdown}
-                onOpen={setOpenDropdown}
-                label="Cycle"
-                icon={<IconCycle />}
-                displayValue={cycleName || 'No cycle'}
-                compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
-              >
-                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
-                  <input
-                    type="text"
-                    placeholder="Search..."
-                    value={cycleSearch}
-                    onChange={(e) => setCycleSearch(e.target.value)}
-                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
-                  />
-                </div>
-                <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setCycleId(null);
-                      setOpenDropdown(null);
-                    }}
-                    className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
-                  >
-                    No cycle
-                  </button>
-                  {filteredCycles.map((c) => (
+              {showCycles ? (
+                <Dropdown
+                  id="cycle"
+                  openId={openDropdown}
+                  onOpen={setOpenDropdown}
+                  allowDismissInsideDialog
+                  label="Cycle"
+                  icon={<IconCycle />}
+                  displayValue={cycleName || 'No cycle'}
+                  compact
+                  panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
+                >
+                  <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
+                    <input
+                      type="text"
+                      placeholder="Search..."
+                      value={cycleSearch}
+                      onChange={(e) => setCycleSearch(e.target.value)}
+                      className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
+                    />
+                  </div>
+                  <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
                     <button
-                      key={c.id}
                       type="button"
                       onClick={() => {
-                        setCycleId(c.id);
+                        setCycleId(null);
                         setOpenDropdown(null);
                       }}
-                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+                      className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
                     >
-                      {c.name}
+                      No cycle
                     </button>
-                  ))}
-                </div>
-              </Dropdown>
-              <Dropdown
-                id="modules"
-                openId={openDropdown}
-                onOpen={setOpenDropdown}
-                label="Modules"
-                icon={<IconGrid />}
-                displayValue={moduleName ?? ''}
-                compact
-                panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
-              >
-                <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
-                  <input
-                    type="text"
-                    placeholder="Search..."
-                    value={moduleSearch}
-                    onChange={(e) => setModuleSearch(e.target.value)}
-                    className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
-                  />
-                </div>
-                <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setModuleId(null);
-                      setOpenDropdown(null);
-                    }}
-                    className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
-                  >
-                    No module
-                  </button>
-                  {filteredModules.map((m) => (
+                    {filteredCycles.map((c) => (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={() => {
+                          setCycleId(c.id);
+                          setOpenDropdown(null);
+                        }}
+                        className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+                      >
+                        {c.name}
+                      </button>
+                    ))}
+                  </div>
+                </Dropdown>
+              ) : null}
+              {showModules ? (
+                <Dropdown
+                  id="modules"
+                  openId={openDropdown}
+                  onOpen={setOpenDropdown}
+                  allowDismissInsideDialog
+                  label="Modules"
+                  icon={<IconGrid />}
+                  displayValue={moduleName ?? ''}
+                  compact
+                  panelClassName="flex min-w-[120px] max-h-52 flex-col rounded border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-raised)"
+                >
+                  <div className="sticky top-0 border-b border-(--border-subtle) bg-(--bg-surface-1) p-1.5">
+                    <input
+                      type="text"
+                      placeholder="Search..."
+                      value={moduleSearch}
+                      onChange={(e) => setModuleSearch(e.target.value)}
+                      className="w-full rounded border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-xs placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
+                    />
+                  </div>
+                  <div className="overflow-auto py-0.5 [&_button]:px-2 [&_button]:py-1 [&_button]:text-xs">
                     <button
-                      key={m.id}
                       type="button"
                       onClick={() => {
-                        setModuleId(m.id);
+                        setModuleId(null);
                         setOpenDropdown(null);
                       }}
-                      className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+                      className="w-full text-left text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover)"
                     >
-                      {m.name}
+                      No module
                     </button>
-                  ))}
-                </div>
-              </Dropdown>
+                    {filteredModules.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        onClick={() => {
+                          setModuleId(m.id);
+                          setOpenDropdown(null);
+                        }}
+                        className="w-full text-left text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+                      >
+                        {m.name}
+                      </button>
+                    ))}
+                  </div>
+                </Dropdown>
+              ) : null}
               <button
                 type="button"
                 onClick={() => setParentModalOpen(true)}

--- a/ui/src/components/drafts/DraftIssueRowProperties.tsx
+++ b/ui/src/components/drafts/DraftIssueRowProperties.tsx
@@ -15,6 +15,7 @@ import type { StateGroup } from '../../types/workspaceViewFilters';
 import { PRIORITY_LABELS } from '../workspace-views/WorkspaceViewsFiltersData';
 import { findWorkspaceMemberByUserId, getImageUrl } from '../../lib/utils';
 import { labelService } from '../../services/labelService';
+import { buildDraftStateOptions } from './draftStateOptions';
 
 const PRIORITIES: Priority[] = ['urgent', 'high', 'medium', 'low', 'none'];
 const PRIORITY_TILE: Record<Priority, string> = {
@@ -439,26 +440,7 @@ export function DraftIssueRowProperties({
   const moduleCount = issue.module_ids?.length ?? 0;
   const currentCycleId = issue.cycle_ids?.[0] ?? null;
   const cycleName = currentCycleId ? cycles.find((c) => c.id === currentCycleId)?.name : '';
-  const stateOptions = useMemo(() => {
-    const byGroup = new Map<string, StateApiResponse>();
-    for (const s of states) {
-      const g = (s.group ?? '').toLowerCase();
-      if (!g) continue;
-      if (!byGroup.has(g)) byGroup.set(g, s);
-    }
-    // Plane drafts shows these groups in this order
-    const ORDER: Array<{ group: string; label: string }> = [
-      { group: 'backlog', label: 'Backlog' },
-      { group: 'unstarted', label: 'Todo' },
-      { group: 'started', label: 'In Progress' },
-      { group: 'completed', label: 'Done' },
-      { group: 'canceled', label: 'Cancelled' },
-    ];
-    return ORDER.map(({ group, label }) => {
-      const st = byGroup.get(group);
-      return { group, label, id: st?.id ?? null };
-    });
-  }, [states]);
+  const stateOptions = useMemo(() => buildDraftStateOptions(states), [states]);
 
   const filteredStateOptions = useMemo(() => {
     const q = stateSearch.trim().toLowerCase();
@@ -577,8 +559,15 @@ export function DraftIssueRowProperties({
                   className={cx(
                     'flex w-full items-center gap-2 px-3 py-2 text-left text-[13px] text-(--txt-primary) hover:bg-(--bg-layer-1-hover)',
                     isSelected && 'bg-(--bg-layer-1)',
+                    !opt.id && 'cursor-not-allowed opacity-40',
                   )}
+                  disabled={!opt.id}
                   onClick={() => {
+                    if (!opt.id) return;
+                    if (opt.id === issue.state_id) {
+                      setOpenDropdownId(null);
+                      return;
+                    }
                     void onPatch(issue, { state_id: opt.id });
                     setOpenDropdownId(null);
                   }}

--- a/ui/src/components/drafts/DraftIssueRowProperties.tsx
+++ b/ui/src/components/drafts/DraftIssueRowProperties.tsx
@@ -496,8 +496,8 @@ export function DraftIssueRowProperties({
   const panelClass =
     'max-h-64 min-w-[180px] overflow-auto rounded-md border border-(--border-subtle) bg-(--bg-surface-1) py-1 shadow-(--shadow-raised)';
 
-  const showModules = Boolean(project?.module_view);
-  const showCycles = Boolean(project?.cycle_view);
+  const showModules = project?.module_view ?? true;
+  const showCycles = project?.cycle_view ?? true;
 
   const moduleLabel =
     moduleCount > 1

--- a/ui/src/components/drafts/draftStateOptions.ts
+++ b/ui/src/components/drafts/draftStateOptions.ts
@@ -5,14 +5,14 @@ const DRAFT_STATE_ORDER: Array<{ group: string; label: string }> = [
   { group: 'unstarted', label: 'Todo' },
   { group: 'started', label: 'In Progress' },
   { group: 'completed', label: 'Done' },
-  { group: 'cancelled', label: 'Cancelled' },
+  { group: 'canceled', label: 'Cancelled' },
 ];
 
 export type DraftStateOption = { group: string; label: string; id: string | null };
 
 function normalizeStateGroup(group: string | undefined): string {
   const g = (group ?? '').toLowerCase();
-  if (g === 'canceled') return 'cancelled';
+  if (g === 'cancelled') return 'canceled';
   return g;
 }
 

--- a/ui/src/components/drafts/draftStateOptions.ts
+++ b/ui/src/components/drafts/draftStateOptions.ts
@@ -1,0 +1,44 @@
+import type { StateApiResponse } from '../../api/types';
+
+const DRAFT_STATE_ORDER: Array<{ group: string; label: string }> = [
+  { group: 'backlog', label: 'Backlog' },
+  { group: 'unstarted', label: 'Todo' },
+  { group: 'started', label: 'In Progress' },
+  { group: 'completed', label: 'Done' },
+  { group: 'cancelled', label: 'Cancelled' },
+];
+
+export type DraftStateOption = { group: string; label: string; id: string | null };
+
+function normalizeStateGroup(group: string | undefined): string {
+  const g = (group ?? '').toLowerCase();
+  if (g === 'canceled') return 'cancelled';
+  return g;
+}
+
+/** Plane-style grouped state options for draft work items. */
+export function buildDraftStateOptions(states: StateApiResponse[]): DraftStateOption[] {
+  const byGroup = new Map<string, StateApiResponse>();
+  for (const s of states) {
+    const g = normalizeStateGroup(s.group);
+    if (!g) continue;
+    if (!byGroup.has(g)) byGroup.set(g, s);
+  }
+  return DRAFT_STATE_ORDER.map(({ group, label }) => {
+    const st = byGroup.get(group);
+    return { group, label, id: st?.id ?? null };
+  });
+}
+
+export function draftStateDisplayLabel(
+  stateId: string,
+  states: StateApiResponse[],
+  options: DraftStateOption[],
+): string {
+  const current = states.find((s) => s.id === stateId);
+  if (current?.group) {
+    const match = options.find((o) => o.group === normalizeStateGroup(current.group));
+    if (match) return match.label;
+  }
+  return current?.name ?? 'Backlog';
+}

--- a/ui/src/components/work-item/Dropdown.tsx
+++ b/ui/src/components/work-item/Dropdown.tsx
@@ -27,6 +27,8 @@ export interface DropdownProps {
   /** Optional accessible name for trigger button. */
   triggerAriaLabel?: string;
   disabled?: boolean;
+  /** When true, clicking elsewhere inside an open dialog still closes this dropdown. */
+  allowDismissInsideDialog?: boolean;
 }
 
 export function Dropdown({
@@ -45,6 +47,7 @@ export function Dropdown({
   triggerTitle,
   triggerAriaLabel,
   disabled = false,
+  allowDismissInsideDialog = false,
 }: DropdownProps) {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -107,14 +110,14 @@ export function Dropdown({
       const targetEl = target as HTMLElement | null;
       // If a modal is open (e.g. date-range picker), don't close the dropdown
       // when the user clicks inside the modal (modal is portaled to `body`).
-      if (targetEl?.closest?.('[role="dialog"]')) return;
+      if (!allowDismissInsideDialog && targetEl?.closest?.('[role="dialog"]')) return;
       if (!triggerRef.current?.contains(target) && !panelRef.current?.contains(target)) {
         onOpen(null);
       }
     };
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [open, onOpen]);
+  }, [open, onOpen, allowDismissInsideDialog]);
 
   return (
     <div className="relative shrink-0">


### PR DESCRIPTION
This pull request introduces improvements to both backend and frontend logic for project states, ensuring that default workflow states are automatically seeded for new projects and enhancing the UI/UX for state selection in work item creation and draft editing. The backend now guarantees Plane-style default states for new projects, while the frontend offers better handling of state options and dropdowns, especially in modal dialogs.

**Backend: Automatic Default State Seeding**
- Projects now automatically receive a set of default workflow states (mirroring Plane's defaults) when created, if none exist. This is handled in the `StateService` and invoked during project creation. [[1]](diffhunk://#diff-6490ab7c1c1f75875e96460ac6523884d858a9a32e432432e45417c42d8e19acR16) [[2]](diffhunk://#diff-6490ab7c1c1f75875e96460ac6523884d858a9a32e432432e45417c42d8e19acR122-R124) [[3]](diffhunk://#diff-6c7a123f53268675b236bc5db96d9c6c798e649a17cf21558fa01e42d1400b2aR45-R106) [[4]](diffhunk://#diff-28d2c8c54ec523a39be83c8e754ae18a7446956fa04e14f2d9d7a93e36d6b9b3L205-R205)

**Frontend: Improved State Handling and Dropdown UX**
- The work item creation modal and draft issue properties now use enhanced logic for displaying and selecting state options, including Plane-style grouping and labels, and improved handling when no states are available. [[1]](diffhunk://#diff-06e130e5de9feef3517ebd2198033770bdc9b13bb90444be40204138b09adaccL442-R443) [[2]](diffhunk://#diff-fc64d88e06f9b4921b7354afef3a564f433952b73339e82da28eb2fe96788b30R1-R44) [[3]](diffhunk://#diff-06e130e5de9feef3517ebd2198033770bdc9b13bb90444be40204138b09adaccR562-R570) [[4]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL517-R529)
- The `Dropdown` component supports a new `allowDismissInsideDialog` prop, allowing dropdowns to close even when clicking inside dialogs, which improves modal usability. This prop is now used in several dropdowns throughout the work item creation modal. [[1]](diffhunk://#diff-e88f29ce70466f3d929acc04990051954f64c4ecccc34a971aed833a0d72228eR30-R31) [[2]](diffhunk://#diff-e88f29ce70466f3d929acc04990051954f64c4ecccc34a971aed833a0d72228eR50) [[3]](diffhunk://#diff-e88f29ce70466f3d929acc04990051954f64c4ecccc34a971aed833a0d72228eL110-R120) [[4]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR454) [[5]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR513) [[6]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL529-R549) [[7]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR578) [[8]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR625) [[9]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR691-R696) [[10]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR738-R744) [[11]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR786)

**UI Logic and Bug Fixes**
- The work item creation modal now conditionally shows modules and cycles dropdowns based on project settings, and resets their values when hidden. [[1]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dL277-R279) [[2]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR304-R308) [[3]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR691-R696) [[4]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR738-R744) [[5]](diffhunk://#diff-ea1a06d5a3860bf6a146a10deb67ef2350cde7c346fff85a3cec5a7fd2cf0f5dR786)
- Minor bug fixes and UI tweaks, such as ensuring state names default to an empty string if not found, and always passing `stateId` in the creation payload.

**Code Organization**
- Refactored draft state option logic into a new utility module (`draftStateOptions`), improving code reuse and maintainability. [[1]](diffhunk://#diff-06e130e5de9feef3517ebd2198033770bdc9b13bb90444be40204138b09adaccR18) [[2]](diffhunk://#diff-fc64d88e06f9b4921b7354afef3a564f433952b73339e82da28eb2fe96788b30R1-R44)

**User Experience**
- Disabled and visually indicated unavailable state options in the draft issue properties dropdown, preventing user errors.
closes #77 