### PR TITLE
chore: remove third-party product references (closes #134)

### DIFF
--- a/apps/api/internal/handler/auth.go
+++ b/apps/api/internal/handler/auth.go
@@ -990,7 +990,7 @@ func clearSessionCookie(c *gin.Context) {
 
 var autoSlugRe = regexp.MustCompile(`[^a-z0-9-]+`)
 
-// postSignUpWorkflow mirrors Plane's post_user_auth_workflow: auto-accepts all
+// postSignUpWorkflow auto-accepts all
 // pending workspace invites for the user's email, creates a default workspace
 // when the user ends up with none and workspace creation is allowed, and marks
 // is_onboarded. All failures are logged but never block the sign-up.

--- a/apps/api/internal/handler/instance.go
+++ b/apps/api/internal/handler/instance.go
@@ -107,7 +107,7 @@ func (h *InstanceHandler) InstanceSetup(c *gin.Context) {
 		return
 	}
 
-	// Register the first user as an instance admin (mirrors Plane's setup flow).
+	// Register the first user as an instance admin.
 	if h.Admins != nil {
 		_ = h.Admins.Create(c.Request.Context(), &model.InstanceAdmin{
 			UserID:     user.ID,
@@ -145,8 +145,8 @@ func generateInstanceID() string {
 }
 
 // isInstanceAdmin reports whether the authenticated user is an instance admin,
-// looked up in the instance_admins table by user id + role (mirrors Plane's
-// InstanceAdminPermission). Fails closed on any error.
+// looked up in the instance_admins table by user id + role. Fails closed on any
+// error.
 func (h *InstanceSettingsHandler) isInstanceAdmin(c *gin.Context) bool {
 	user := middleware.GetUser(c)
 	if user == nil || h.Admins == nil {
@@ -252,8 +252,8 @@ func (h *InstanceSettingsHandler) RemoveAdmin(c *gin.Context) {
 }
 
 // GetSettings returns all instance settings sections with secrets decrypted for
-// the admin UI (mirrors Plane). Admin access is required — the gate is the
-// protection, not masking.
+// the admin UI. Admin access is required — the gate is the protection, not
+// masking.
 // GET /api/instance/settings/
 func (h *InstanceSettingsHandler) GetSettings(c *gin.Context) {
 	if !h.requireInstanceAdmin(c) {
@@ -527,7 +527,7 @@ func (h *InstanceSettingsHandler) UpdateSetting(c *gin.Context) {
 	if h.OnSectionUpdated != nil {
 		h.OnSectionUpdated(c.Request.Context(), key)
 	}
-	// Return decrypted secrets so the admin UI reflects the saved value (Plane parity).
+	// Return decrypted secrets so the admin UI reflects the saved value.
 	responseValue := decryptSectionSecretsInternal(key, value)
 	c.JSON(http.StatusOK, gin.H{"key": key, "value": responseValue})
 }

--- a/apps/api/internal/handler/instance_test.go
+++ b/apps/api/internal/handler/instance_test.go
@@ -129,7 +129,7 @@ func TestInstance_Settings_SecretsReturnedToAdmin(t *testing.T) {
 	}, session)
 	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
 
-	// Matching Plane: the admin GET returns the decrypted secret value.
+	// The admin GET returns the decrypted secret value.
 	rr2 := ts.GET("/api/instance/settings/", session)
 	require.Equal(t, http.StatusOK, rr2.Code)
 	body := testutil.MustJSONMap(t, rr2)

--- a/apps/api/internal/handler/link_test.go
+++ b/apps/api/internal/handler/link_test.go
@@ -32,24 +32,24 @@ func TestIssueLink_CRUD(t *testing.T) {
 
 	// Create
 	rr2 := ts.POST(base, map[string]any{
-		"title": "Plane repo",
-		"url":   "https://github.com/makeplane/plane",
+		"title": "Example repo",
+		"url":   "https://github.com/example/example",
 	}, w.Session)
 	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
 	created := testutil.MustJSONMap(t, rr2)
 	linkID, _ := created["id"].(string)
 	require.NotEmpty(t, linkID)
-	assert.Equal(t, "Plane repo", created["title"])
+	assert.Equal(t, "Example repo", created["title"])
 
 	// List (one item)
 	rr3 := ts.GET(base, w.Session)
 	require.Equal(t, http.StatusOK, rr3.Code)
-	assert.Contains(t, rr3.Body.String(), "Plane repo")
+	assert.Contains(t, rr3.Body.String(), "Example repo")
 
 	// Update
-	rr4 := ts.PATCH(base+linkID+"/", map[string]any{"title": "Plane (updated)"}, w.Session)
+	rr4 := ts.PATCH(base+linkID+"/", map[string]any{"title": "Example (updated)"}, w.Session)
 	require.Equal(t, http.StatusOK, rr4.Code, "body=%s", rr4.Body.String())
-	assert.Equal(t, "Plane (updated)", testutil.MustJSONMap(t, rr4)["title"])
+	assert.Equal(t, "Example (updated)", testutil.MustJSONMap(t, rr4)["title"])
 
 	// Delete
 	rr5 := ts.DELETE(base+linkID+"/", w.Session)
@@ -58,7 +58,7 @@ func TestIssueLink_CRUD(t *testing.T) {
 	// List (empty again)
 	rr6 := ts.GET(base, w.Session)
 	require.Equal(t, http.StatusOK, rr6.Code)
-	assert.NotContains(t, rr6.Body.String(), "Plane")
+	assert.NotContains(t, rr6.Body.String(), "Example")
 }
 
 func TestIssueLink_NonMember404(t *testing.T) {

--- a/apps/api/internal/handler/oauth.go
+++ b/apps/api/internal/handler/oauth.go
@@ -166,9 +166,8 @@ func (h *OAuthHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	// Enforce allow_public_signup for new users — matches Plane's
-	// Adapter.__check_signup: if signup is disabled, only users with a
-	// pending workspace invite may register.
+	// Enforce allow_public_signup for new users: if signup is disabled, only
+	// users with a pending workspace invite may register.
 	if !h.Auth.EmailExists(ctx, userInfo.Email) {
 		var allowPublicSignup = true
 		if h.Settings != nil {

--- a/apps/api/internal/model/instance_admin.go
+++ b/apps/api/internal/model/instance_admin.go
@@ -8,9 +8,9 @@ import (
 )
 
 // InstanceAdmin matches the instance_admins table — the set of users authorized
-// to manage instance-level settings (mirrors Plane's InstanceAdmin). Devlane is
-// single-instance, so the row keys on user_id only (no instance FK). Role uses
-// the shared Role* levels; the gate allows role >= RoleAdmin.
+// to manage instance-level settings. Devlane is single-instance, so the row keys
+// on user_id only (no instance FK). Role uses the shared Role* levels; the gate
+// allows role >= RoleAdmin.
 type InstanceAdmin struct {
 	ID         uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	UserID     uuid.UUID      `gorm:"type:uuid;not null" json:"user_id"`

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -434,7 +434,7 @@ func New(cfg Config) *gin.Engine {
 		api.PATCH("/workspaces/:slug/projects/:projectId/integrations/github/sync/", integrationHandler.GitHubUpdateSync)
 		api.DELETE("/workspaces/:slug/projects/:projectId/integrations/github/sync/", integrationHandler.GitHubDeleteSync)
 
-		// File attachments (v2 assets API — matches Plane frontend service URLs).
+		// File attachments (v2 assets API).
 		api.GET("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/", attachmentHandler.ListAttachments)
 		api.POST("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/", attachmentHandler.InitiateUpload)
 		api.PATCH("/assets/v2/workspaces/:slug/projects/:projectId/issues/:issueId/attachments/:assetId/", attachmentHandler.ConfirmUpload)

--- a/apps/api/internal/service/state.go
+++ b/apps/api/internal/service/state.go
@@ -11,7 +11,7 @@ import (
 
 var ErrStateNotFound = errors.New("state not found")
 
-// DefaultProjectStateNames are seeded for new projects (Plane parity, without triage).
+// DefaultProjectStateNames are seeded for new projects (without triage).
 var DefaultProjectStateNames = []string{"Backlog", "Todo", "In Progress", "Done", "Cancelled"}
 
 // StateService handles state (workflow) business logic.
@@ -59,7 +59,7 @@ func (s *StateService) List(ctx context.Context, workspaceSlug string, projectID
 	return s.ss.ListByProjectID(ctx, projectID)
 }
 
-// defaultProjectStates mirrors Plane's DEFAULT_STATES (without triage).
+// defaultProjectStates are the default workflow states (without triage).
 var defaultProjectStates = []struct {
 	name      string
 	color     string
@@ -99,7 +99,7 @@ func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, works
 	return nil
 }
 
-// EnsureDefaultStates seeds workflow states for a project that has none (Plane parity).
+// EnsureDefaultStates seeds workflow states for a project that has none.
 func (s *StateService) EnsureDefaultStates(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) error {
 	workspaceID, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID)
 	if err != nil {

--- a/apps/api/internal/store/instance_admin.go
+++ b/apps/api/internal/store/instance_admin.go
@@ -14,7 +14,7 @@ import (
 var ErrLastInstanceAdmin = errors.New("cannot remove the last instance admin")
 
 // InstanceAdminStore handles instance_admins persistence — the set of users
-// authorized to manage instance settings (mirrors Plane's InstanceAdmin).
+// authorized to manage instance settings.
 type InstanceAdminStore struct{ db *gorm.DB }
 
 func NewInstanceAdminStore(db *gorm.DB) *InstanceAdminStore {

--- a/apps/api/migrations/000001_init_schema.up.sql
+++ b/apps/api/migrations/000001_init_schema.up.sql
@@ -555,7 +555,7 @@ CREATE TABLE instances (
     current_version VARCHAR(255) NOT NULL,
     latest_version VARCHAR(255),
     edition VARCHAR(255) NOT NULL DEFAULT 'COMMUNITY',
-    product VARCHAR(50) NOT NULL DEFAULT 'plane-ce',
+    product VARCHAR(50) NOT NULL DEFAULT 'devlane-ce',
     domain TEXT DEFAULT '',
     last_checked_at TIMESTAMPTZ NOT NULL,
     namespace VARCHAR(255),

--- a/apps/api/migrations/000003_integrations_schema.up.sql
+++ b/apps/api/migrations/000003_integrations_schema.up.sql
@@ -1,8 +1,8 @@
 -- GitHub App + integrations enhancements.
 --
 -- The integration tables already exist (see 000001), but they were modeled on
--- Plane's user-OAuth-token approach. For Devlane we use a GitHub App, which
--- has installation IDs (no Plane API token to associate). This migration:
+-- a user-OAuth-token approach. Devlane uses a GitHub App instead, which has
+-- installation IDs (no per-user API token to associate). This migration:
 --   1. Relaxes the NOT NULL on workspace_integrations.api_token_id.
 --   2. Adds GitHub App columns (installation_id, account_login, ...).
 --   3. Extends github_issue_syncs to support pull-request sync (state, draft,

--- a/apps/api/migrations/000006_instance_admins.up.sql
+++ b/apps/api/migrations/000006_instance_admins.up.sql
@@ -1,7 +1,7 @@
--- The instance_admins table already exists from 000001 (copied from Plane's
--- schema) with a NOT NULL instance_id FK to `instances`. Devlane is
--- single-instance and tracks instance info in instance_settings, so it never
--- populates `instances`. Adapt the existing table to key admins on user_id:
+-- The instance_admins table already exists from 000001 with a NOT NULL
+-- instance_id FK to `instances`. Devlane is single-instance and tracks instance
+-- info in instance_settings, so it never populates `instances`. Adapt the
+-- existing table to key admins on user_id:
 --   1. allow a NULL instance_id (no instances row required),
 --   2. add a soft-delete column,
 --   3. add a partial unique index so one user maps to one active admin row.

--- a/apps/web/src/components/drafts/DraftIssueRowProperties.tsx
+++ b/apps/web/src/components/drafts/DraftIssueRowProperties.tsx
@@ -584,7 +584,7 @@ export function DraftIssueRowProperties({
         )}
       </Dropdown>
 
-      {/* Priority — Plane PriorityDropdown border-without-text */}
+      {/* Priority — border-without-text variant */}
       <Dropdown
         id={`${issue.id}:priority`}
         openId={openDropdownId}
@@ -735,7 +735,7 @@ export function DraftIssueRowProperties({
         ) : null}
       </Dropdown>
 
-      {/* Start date — icon-only + hidden date input (Plane DateDropdown border-without-text) */}
+      {/* Start date — icon-only + hidden date input (border-without-text variant) */}
       <div
         className={`${propBtnSquare}${busy ? ' pointer-events-none opacity-40' : ''}`}
         title={`Start date ${issue.start_date ? issue.start_date.slice(0, 10) : 'None'}`}
@@ -837,7 +837,7 @@ export function DraftIssueRowProperties({
         })}
       </Dropdown>
 
-      {/* Modules — Plane ModuleDropdown icon */}
+      {/* Modules — icon dropdown */}
       {showModules ? (
         <Dropdown
           id={`${issue.id}:module`}
@@ -886,7 +886,7 @@ export function DraftIssueRowProperties({
         </Dropdown>
       ) : null}
 
-      {/* Cycles — Plane CycleDropdown border-with-text */}
+      {/* Cycles — border-with-text variant */}
       {showCycles ? (
         <Dropdown
           id={`${issue.id}:cycle`}
@@ -935,7 +935,7 @@ export function DraftIssueRowProperties({
         </Dropdown>
       ) : null}
 
-      {/* Quick actions — ⋯ menu (Plane: Edit, Make a copy, Move to issues, Delete) */}
+      {/* Quick actions — ⋯ menu (Edit, Make a copy, Move to issues, Delete) */}
       <div className="relative shrink-0" data-draft-actions>
         <button
           type="button"

--- a/apps/web/src/components/drafts/draftStateOptions.ts
+++ b/apps/web/src/components/drafts/draftStateOptions.ts
@@ -16,7 +16,7 @@ function normalizeStateGroup(group: string | undefined): string {
   return g;
 }
 
-/** Plane-style grouped state options for draft work items. */
+/** Grouped state options for draft work items. */
 export function buildDraftStateOptions(states: StateApiResponse[]): DraftStateOption[] {
   const byGroup = new Map<string, StateApiResponse>();
   for (const s of states) {

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -13,8 +13,8 @@ export function AppShell() {
   const isModulesRoute = pathname.includes('/modules');
   const isDraftsRoute = pathname.includes('/drafts');
   // Pages list and detail pages render their own padding/chrome so the tabs
-  // row sits flush against the PageHeader (Plane parity — header bottom-border
-  // doubles as the tabs-row top-border).
+  // row sits flush against the PageHeader — the header bottom-border doubles as
+  // the tabs-row top-border.
   const isPagesRoute = pathname.includes('/pages');
 
   return (

--- a/apps/web/src/components/layout/ModuleDetailHeader.tsx
+++ b/apps/web/src/components/layout/ModuleDetailHeader.tsx
@@ -67,7 +67,7 @@ const IconChevronUp = () => (
   </svg>
 );
 
-/** 2×2 grid — matches “Modules” in Plane-style breadcrumbs */
+/** 2×2 grid — the “Modules” breadcrumb icon */
 const IconLayoutGrid = () => (
   <svg
     width="16"

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -3532,9 +3532,9 @@ function ProjectSavedViewDetailHeader({
 // ---------------------------------------------------------------------------
 
 /**
- * Header rendered for `/:slug/projects/:projectId/pages/:pageId`. Mirrors
- * Plane's page-detail header — a single top row that contains the project
- * breadcrumb on the left and the per-page action cluster on the right
+ * Header rendered for `/:slug/projects/:projectId/pages/:pageId`. A single top
+ * row that contains the project breadcrumb on the left and the per-page action
+ * cluster on the right
  * (lock / link / star / more / panel-toggle). The actions slot is filled by
  * `PageDetailPage` via `useSetPageDetailHeader` so this component stays
  * stateless about the page itself.

--- a/apps/web/src/components/layout/ProjectSectionNavChevron.tsx
+++ b/apps/web/src/components/layout/ProjectSectionNavChevron.tsx
@@ -137,7 +137,7 @@ const SECTION_ICONS: Record<ProjectSectionNav, ReactNode> = {
 const SECTION_ORDER: ProjectSectionNav[] = ['issues', 'cycles', 'modules', 'views', 'pages'];
 
 /**
- * Breadcrumb “&gt;” control (Plane-style): opens the project area switcher
+ * Breadcrumb “&gt;” control: opens the project area switcher
  * (Work items, Cycles, Modules, …) on hover or click.
  */
 export function ProjectSectionNavChevron({

--- a/apps/web/src/components/module-work-items/ModuleWorkItemsToolbarPanels.tsx
+++ b/apps/web/src/components/module-work-items/ModuleWorkItemsToolbarPanels.tsx
@@ -38,9 +38,9 @@ const DUE_PRESETS: { id: ModuleDueDatePreset; label: string }[] = [
   { id: 'custom', label: 'Custom' },
 ];
 
-const PLANE_SECTION_TITLE = 'text-[13px] font-medium text-(--txt-tertiary)';
+const SECTION_TITLE_CLASS = 'text-[13px] font-medium text-(--txt-tertiary)';
 
-const API_GROUP_TO_PLANE: Record<string, StateGroup> = {
+const API_GROUP_TO_STATE_GROUP: Record<string, StateGroup> = {
   backlog: 'backlog',
   unstarted: 'unstarted',
   started: 'started',
@@ -51,7 +51,7 @@ const API_GROUP_TO_PLANE: Record<string, StateGroup> = {
 
 function stateGroupForState(s: StateApiResponse) {
   const g = s.group?.toLowerCase();
-  const sg = g ? API_GROUP_TO_PLANE[g] : undefined;
+  const sg = g ? API_GROUP_TO_STATE_GROUP[g] : undefined;
   return sg ?? 'unstarted';
 }
 
@@ -216,7 +216,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Priority"
           open={open.priority}
           onToggle={() => toggle('priority')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {PRIORITIES.filter((p) => filterSearch(PRIORITY_LABELS[p])).map((p) => (
             <FiltersPanelOptionRow
@@ -233,7 +233,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="State"
           open={open.state}
           onToggle={() => toggle('state')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {(() => {
             const matchingGroups = groupOrder.filter((g) => filterSearch(STATE_GROUP_LABELS[g]));
@@ -264,7 +264,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Assignee"
           open={open.assignee}
           onToggle={() => toggle('assignee')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {(() => {
             const youMatches =
@@ -333,7 +333,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Cycle"
           open={open.cycle}
           onToggle={() => toggle('cycle')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {filteredCycles.length === 0 ? (
             emptyFilterHint
@@ -363,7 +363,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Mention"
           open={open.mention}
           onToggle={() => toggle('mention')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {(() => {
             const youMatches =
@@ -431,7 +431,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Created by"
           open={open.created_by}
           onToggle={() => toggle('created_by')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {filteredMembers.length === 0 ? (
             emptyFilterHint
@@ -467,7 +467,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Label"
           open={open.label}
           onToggle={() => toggle('label')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {filteredLabels.length === 0 ? (
             emptyFilterHint
@@ -501,7 +501,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Work item Grouping"
           open={open.work_item_grouping}
           onToggle={() => toggle('work_item_grouping')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           <FiltersPanelOptionRow
             checked={filters.workItemGrouping === 'all'}
@@ -527,7 +527,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Start date"
           open={open.start}
           onToggle={() => toggle('start')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {DATE_PRESETS.filter((d) => filterSearch(DATE_PRESET_LABELS[d])).map((d) =>
             d === 'custom' ? (
@@ -571,7 +571,7 @@ export function ModuleWorkItemsFiltersPanel({
           title="Due date"
           open={open.due}
           onToggle={() => toggle('due')}
-          titleClassName={PLANE_SECTION_TITLE}
+          titleClassName={SECTION_TITLE_CLASS}
         >
           {DUE_PRESETS.filter((pr) => filterSearch(pr.label)).map((pr) => (
             <FiltersPanelOptionRow

--- a/apps/web/src/components/page-editor/ColorDropdown.tsx
+++ b/apps/web/src/components/page-editor/ColorDropdown.tsx
@@ -4,8 +4,8 @@ import type { Editor } from '@tiptap/react';
 import { cn } from '../../lib/utils';
 
 /**
- * Curated palette mirroring Plane's COLORS_LIST — soft enough for body text
- * and pastel-ish for highlights so dark and light themes look coherent.
+ * Curated color palette — soft enough for body text and pastel-ish for
+ * highlights so dark and light themes look coherent.
  */
 const COLORS = [
   { key: 'gray', text: '#6b7280', bg: '#f3f4f6' },
@@ -25,9 +25,8 @@ interface Props {
 }
 
 /**
- * Text color + background highlight picker. Matches Plane's color dropdown:
- * row of swatches for foreground, row of swatches for background, plus a
- * "clear" affordance for each.
+ * Text color + background highlight picker: a row of swatches for foreground,
+ * a row of swatches for background, plus a "clear" affordance for each.
  */
 export function ColorDropdown({ editor, stateTick }: Props) {
   const [open, setOpen] = useState(false);

--- a/apps/web/src/components/page-editor/EmojiLogoPicker.tsx
+++ b/apps/web/src/components/page-editor/EmojiLogoPicker.tsx
@@ -38,7 +38,7 @@ const PRESET_EMOJIS = [
 ];
 
 export interface PageLogo {
-  /** "emoji" is the only supported kind today; matches Plane's logo_props.in_use field. */
+  /** "emoji" is the only supported kind today; maps to the logo_props.in_use field. */
   in_use?: 'emoji' | null;
   emoji?: { value?: string };
   // Allow forward-compatible properties without breaking type-compat with the
@@ -60,12 +60,12 @@ interface Props {
 }
 
 /**
- * Emoji-based page logo picker, modelled after Plane's `Logo` button. Shows
- * the current emoji (or the page-icon fallback), opens a popover with a
- * curated emoji palette, and lets owners clear the logo from the same panel.
+ * Emoji-based page logo picker. Shows the current emoji (or the page-icon
+ * fallback), opens a popover with a curated emoji palette, and lets owners
+ * clear the logo from the same panel.
  *
  * We deliberately avoid bringing in a full emoji library — the curated set
- * covers >95% of the page-categorisation use case Plane optimises for.
+ * covers >95% of the page-categorisation use case.
  */
 export function EmojiLogoPicker({ value, disabled, onChange, size = 32, className }: Props) {
   const [open, setOpen] = useState(false);

--- a/apps/web/src/components/page-editor/PageEditorToolbar.tsx
+++ b/apps/web/src/components/page-editor/PageEditorToolbar.tsx
@@ -210,14 +210,14 @@ interface Props {
   /**
    * Optional content rendered at the far right of the toolbar row (e.g. a
    * side-panel toggle). It is anchored to the right while the toolbar items
-   * stay centered. Plane's page-editor lays out the panel toggle this way.
+   * stay centered.
    */
   endSlot?: ReactNode;
 }
 
 /**
- * Plane-style page toolbar. Mounts above the page content and stays in sync
- * with the editor's selection so active marks/blocks render highlighted.
+ * Page toolbar. Mounts above the page content and stays in sync with the
+ * editor's selection so active marks/blocks render highlighted.
  */
 export function PageEditorToolbar({ editor, className, endSlot }: Props) {
   // Subscribe to selection / transaction events so each button can re-render its
@@ -242,7 +242,7 @@ export function PageEditorToolbar({ editor, className, endSlot }: Props) {
     <div
       // Full-width row so the bottom border spans the page; an inner three-
       // column layout keeps the toolbar items centered while reserving room
-      // for an optional `endSlot` (the side-panel toggle in Plane's design).
+      // for an optional `endSlot` (the side-panel toggle).
       // overflow stays visible (no overflow-x-auto) so dropdown panels aren't
       // clipped by the toolbar's stacking context.
       className={cn(

--- a/apps/web/src/components/page-editor/TypographyDropdown.tsx
+++ b/apps/web/src/components/page-editor/TypographyDropdown.tsx
@@ -36,8 +36,8 @@ interface Props {
 }
 
 /**
- * "Text / Heading 1 / …" typography menu, equivalent to Plane's TYPOGRAPHY_ITEMS
- * dropdown. Clicking a heading sets the block; clicking "Text" reverts to a paragraph.
+ * "Text / Heading 1 / …" typography menu. Clicking a heading sets the block;
+ * clicking "Text" reverts to a paragraph.
  */
 export function TypographyDropdown({ editor, stateTick }: Props) {
   const [open, setOpen] = useState(false);

--- a/apps/web/src/components/page-editor/usePageEditor.ts
+++ b/apps/web/src/components/page-editor/usePageEditor.ts
@@ -30,10 +30,10 @@ export interface UsePageEditorOptions {
 }
 
 /**
- * Page editor singleton. Built on TipTap with the same extension surface
- * as Plane's document editor — typography, color, alignment, lists,
- * to-do lists, images, and tables — minus collaboration (we use REST autosave
- * instead of Yjs so the data layer stays simple).
+ * Page editor singleton. Built on TipTap with a rich extension surface —
+ * typography, color, alignment, lists, to-do lists, images, and tables — minus
+ * collaboration (we use REST autosave instead of Yjs so the data layer stays
+ * simple).
  *
  * The hook only constructs the editor; rendering is split into separate
  * `<PageEditorToolbar editor>` and `<PageEditorContent editor>` components so

--- a/apps/web/src/components/stickies/stickyPalette.ts
+++ b/apps/web/src/components/stickies/stickyPalette.ts
@@ -1,4 +1,4 @@
-/** Plane light — plane/packages/editor/src/styles/variables.css [data-theme*="light"] */
+/** Light theme sticky palette. */
 export const STICKY_BACKGROUND_COLORS_LIGHT = [
   '#d6d6d8',
   '#ffd5d7',
@@ -10,7 +10,7 @@ export const STICKY_BACKGROUND_COLORS_LIGHT = [
   '#e3d8fd',
 ] as const;
 
-/** Plane dark — same file [data-theme*="dark"] */
+/** Dark theme sticky palette. */
 export const STICKY_BACKGROUND_COLORS_DARK = [
   '#404144',
   '#593032',
@@ -22,7 +22,7 @@ export const STICKY_BACKGROUND_COLORS_DARK = [
   '#3d325a',
 ] as const;
 
-/** Prior muted palette → Plane light hex (canonical slot) */
+/** Prior muted palette → light theme hex (canonical slot) */
 const LEGACY_STICKY_BACKGROUND_HEX: Record<string, string> = {
   '#cfcfd2': '#d6d6d8',
   '#f0c8ca': '#ffd5d7',

--- a/apps/web/src/components/work-item/DescriptionEditor.tsx
+++ b/apps/web/src/components/work-item/DescriptionEditor.tsx
@@ -31,8 +31,8 @@ export interface DescriptionEditorProps {
  * Rich-text editor for the issue description. Auto-saves on debounced change
  * so users don't need to remember to hit a Save button.
  *
- * Pattern matches Plane's `DescriptionInput` (TipTap + 1.5s debounce + status
- * indicator). The toolbar is a simplified version of CommentEditor's.
+ * Built on TipTap with a 1.5s debounce and a status indicator. The toolbar is
+ * a simplified version of CommentEditor's.
  */
 export function DescriptionEditor({
   initialHtml,

--- a/apps/web/src/components/work-item/IssueActivityFeed.tsx
+++ b/apps/web/src/components/work-item/IssueActivityFeed.tsx
@@ -28,8 +28,8 @@ interface IssueActivityFeedProps {
 
 /**
  * Renders one row per IssueActivity. Each row is "icon + actor avatar + sentence + relative time".
- * Mirrors Plane's per-field activity component dispatch but kept in a single
- * function for compactness — extend the switch below to add new field types.
+ * Dispatches per-field activity rendering in a single function for compactness
+ * — extend the switch below to add new field types.
  */
 export function IssueActivityFeed({ activities, members, states, labels }: IssueActivityFeedProps) {
   const stateById = useMemo(() => new Map(states.map((s) => [s.id, s])), [states]);

--- a/apps/web/src/components/work-item/layouts/IssueLayoutTypes.ts
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutTypes.ts
@@ -7,7 +7,7 @@ import type {
   WorkspaceMemberApiResponse,
 } from '../../../api/types';
 
-/** Available layout keys. Mirrors Plane's EIssueLayoutTypes. */
+/** Available layout keys. */
 export const ISSUE_LAYOUTS = ['list', 'board', 'spreadsheet', 'calendar', 'gantt'] as const;
 export type IssueLayout = (typeof ISSUE_LAYOUTS)[number];
 

--- a/apps/web/src/components/workspace-views/WorkspaceViewsFiltersShared.tsx
+++ b/apps/web/src/components/workspace-views/WorkspaceViewsFiltersShared.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { FILTER_ICONS } from './WorkspaceViewsFiltersData';
 
-/** Plane-style filter row: small square checkbox or round radio, optional leading icon, label. */
+/** Filter row: small square checkbox or round radio, optional leading icon, label. */
 export function FiltersPanelOptionRow({
   checked,
   onToggle,

--- a/apps/web/src/contexts/PageDetailHeaderContext.tsx
+++ b/apps/web/src/contexts/PageDetailHeaderContext.tsx
@@ -4,8 +4,8 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 /**
  * Lets the route-rendered `PageDetailPage` push its breadcrumb + actions
  * into the global `PageHeader` slot so the page-detail view uses the same
- * top header bar as every other route (Plane parity — there is only one
- * header row, not two stacked).
+ * top header bar as every other route — there is only one header row, not two
+ * stacked.
  *
  * The state and the writer are intentionally split into two contexts:
  *   - `StateContext` carries the current slot; only the header renderer

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -83,7 +83,7 @@
   border-right: 1px solid color-mix(in srgb, var(--border-subtle) 45%, transparent);
 }
 
-/* Sticky checklist: checked items get placeholder-colored text (matches Plane) */
+/* Sticky checklist: checked items get placeholder-colored text */
 .sticky-note-editor-content ul[data-type='taskList'] li[data-checked='true'] > div {
   color: var(--txt-placeholder);
 }
@@ -94,7 +94,7 @@
 }
 
 /* ----- Page editor (TipTap) -------------------------------------------------
- * Mirrors Plane's document editor: roomy heading hierarchy, soft code blocks,
+ * Document editor styling: roomy heading hierarchy, soft code blocks,
  * checkbox-styled to-do lists, full-width tables with thin borders.
  *
  * Scoped under `.page-editor-prose` so we don't fight Tailwind's `prose` defaults

--- a/apps/web/src/pages/DraftsPage.tsx
+++ b/apps/web/src/pages/DraftsPage.tsx
@@ -25,7 +25,7 @@ import type { Priority } from '../types';
 
 const PAGE_SIZE = 50;
 
-/** Plane-style key + sequence (e.g. LOGI1). Never use placeholder em-dashes for the key. */
+/** Key + sequence (e.g. LOGI1). Never use placeholder em-dashes for the key. */
 function projectIssueKey(proj: ProjectApiResponse | undefined, issue: IssueApiResponse): string {
   const raw = proj?.identifier?.trim();
   if (raw && raw.length > 0) return raw.toUpperCase();

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -47,8 +47,8 @@ import type { Priority } from '../types';
 /**
  * Shared trigger style for the Properties sidebar dropdowns. Borderless +
  * background-on-hover so each row reads like a "value" rather than a button —
- * matches Plane's transparent-with-text variant. Content-width so the row's
- * `justify-end` can right-align it.
+ * the transparent-with-text variant. Content-width so the row's `justify-end`
+ * can right-align it.
  */
 const GHOST_TRIGGER =
   'inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-(--radius-md) px-2 py-1.5 text-xs text-(--txt-secondary) hover:bg-(--bg-layer-1-hover)';

--- a/apps/web/src/pages/PageDetailPage.tsx
+++ b/apps/web/src/pages/PageDetailPage.tsx
@@ -88,8 +88,7 @@ export function PageDetailPage() {
   const [bodyStatus, setBodyStatus] = useState<SaveStatus>({ kind: 'idle' });
 
   const [isFavorite, setIsFavorite] = useState(false);
-  // Closed by default — match Plane's page-detail header where the panel
-  // toggle reveals sub-pages / history on demand.
+  // Closed by default — the panel toggle reveals sub-pages / history on demand.
   const [sidePanel, setSidePanel] = useState<SidePanel>('closed');
   const [versions, setVersions] = useState<PageVersionApiResponse[] | null>(null);
   const [previewVersion, setPreviewVersion] = useState<PageVersionApiResponse | null>(null);
@@ -326,8 +325,8 @@ export function PageDetailPage() {
 
   // ----- Versions panel ----------------------------------------------------
   // Loaded on demand from the panel-switch handler — keeping it out of an
-  // effect avoids the react-hooks/set-state-in-effect lint rule and matches
-  // Plane's user-initiated history load.
+  // effect avoids the react-hooks/set-state-in-effect lint rule and keeps the
+  // history load user-initiated.
   const loadVersions = useCallback(async () => {
     if (!workspaceSlug || !page) return;
     try {
@@ -515,7 +514,7 @@ export function PageDetailPage() {
 
   // Page actions cluster (lock / link / favorite / more) — rendered into
   // the global PageHeader via `useSetPageDetailHeader`. The side-panel
-  // toggle lives on the toolbar (Plane parity), not here.
+  // toggle lives on the toolbar, not here.
   const headerActions = page ? (
     <>
       {isArchived ? (
@@ -668,9 +667,9 @@ export function PageDetailPage() {
     <div className="flex h-full min-h-0 w-full flex-col">
       {/* The breadcrumb + actions cluster is rendered by `PageDetailHeader`
        * (mounted via `useSetPageDetailHeader` above) into the global
-       * PageHeader bar — Plane parity: there is only one top header row. */}
+       * PageHeader bar — there is only one top header row. */}
 
-      {/* Sticky toolbar — Plane's page-toolbar; panel toggle anchors right */}
+      {/* Sticky toolbar — the page-toolbar; panel toggle anchors right */}
       {!editorReadOnly ? (
         <PageEditorToolbar editor={editor} endSlot={panelToggle} />
       ) : (

--- a/apps/web/src/pages/PagesPage.tsx
+++ b/apps/web/src/pages/PagesPage.tsx
@@ -292,11 +292,11 @@ export function PagesPage() {
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
-      {/* Secondary header — Plane's pages-list-header.
+      {/* Secondary header — the pages-list header.
        * Sits flush under the project sub-header so the sub-header's
        * bottom border doubles as this row's top border (a single 1px line).
        * Each tab is a full-height column so its accent underline aligns with
-       * (and overrides) this row's `border-b`, matching Plane exactly. */}
+       * (and overrides) this row's `border-b`. */}
       <div className="flex shrink-0 items-stretch justify-between border-b border-(--border-subtle) bg-(--bg-canvas) px-(--padding-page)">
         <nav className="flex items-stretch" aria-label="Page visibility">
           {TABS.map((t) => {
@@ -329,7 +329,7 @@ export function PagesPage() {
           })}
         </nav>
         <div className="flex items-center gap-2 py-2">
-          {/* Search — collapses to an icon when empty (matches Plane). */}
+          {/* Search — collapses to an icon when empty. */}
           <div className="flex items-center">
             {searchOpen || search ? (
               <div className="flex h-8 w-64 items-center gap-2 rounded-md border border-(--border-subtle) bg-(--bg-canvas) px-2.5">
@@ -496,8 +496,8 @@ export function PagesPage() {
       {/* Page list — edge-to-edge rows with `border-b` per row.
        * The tabs row above already paints a single bottom-border, so the
        * first row sits flush against it (no `border-t` on row 0). Each row
-       * carries its own `border-b` so the rhythm matches Plane: one 1px
-       * line separates every horizontal section. */}
+       * carries its own `border-b` so one 1px line separates every horizontal
+       * section. */}
       <div className="min-h-0 flex-1 overflow-y-auto">
         {visible.length === 0 ? (
           <div className="grid place-items-center py-16 text-center">


### PR DESCRIPTION
## Summary

Closes #134. Removes stray references to a third-party product (left over from earlier research) across comments, test fixtures, and one migration default, so the codebase reads as Devlane's own implementation.

## What changed

- **Code comments** (`apps/api` + `apps/web`, ~30 files) — reworded to describe Devlane's behavior directly; dropped "mirrors/matches/parity with …" attributions. The technical meaning of each comment is preserved.
- **Test fixtures** — `link_test.go` now uses neutral example names/URLs (`Example repo`, `github.com/example/example`); test logic and assertions are unchanged and still pass.
- **Local identifiers** — `ModuleWorkItemsToolbarPanels.tsx` had two non-exported, file-scoped identifiers whose names embedded the product name; renamed to behavior-preserving local names (used only within that file).
- **Migration default** — `instances.product` default changed to `'devlane-ce'` in `000001`. Comment-only rewording in `000003` / `000006` (no DDL touched).

## Notes for reviewers

- The `instances.product` value is **never read by code** (verified), so the default change is cosmetic with no functional impact. Editing a merged migration is normally avoided, but this is a one-time, no-behavior reference cleanup; existing databases are unaffected (the migration does not re-run), and fresh databases simply get the neutral default.
- `.gitignore` deliberately still ignores the local reference folder, so it can never be committed accidentally.

## Verification

- `npm run validate` passes: web typecheck + ESLint + Prettier check, `go vet ./...`, and `go test ./...` (incl. the renamed `link_test` fixtures).
- `git grep -in "plane" -- ':!.gitignore'` → 0 hits.

## AI assistance

- [x] AI tools were used — tool: Claude Code (Opus 4.8) — and the commit includes a `Co-Authored-By:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved instance admin record handling to better support inactive/removed mappings.
  - Updated the default instance product label for new deployments.
- **Documentation**
  - Clarified several in-app and API comments for auth, layout, editors, filters, and page sections.
- **Chores**
  - Renamed internal examples and wording in tests and UI text for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->