### PR TITLE
feat(issue): add emoji reactions to work items

### DIFF
--- a/apps/api/internal/database/database.go
+++ b/apps/api/internal/database/database.go
@@ -23,6 +23,10 @@ func NewDB(cfg *config.Config, log *slog.Logger) (*gorm.DB, error) {
 
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: gormLog,
+		// Translate driver errors to GORM sentinels (e.g. gorm.ErrDuplicatedKey)
+		// so callers can distinguish a unique-constraint violation from a real
+		// failure without inspecting the raw pg error.
+		TranslateError: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)

--- a/apps/api/internal/handler/issue_reaction.go
+++ b/apps/api/internal/handler/issue_reaction.go
@@ -1,0 +1,118 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// reactionNotFound maps service access errors to a 404.
+func reactionIsNotFound(err error) bool {
+	return err == service.ErrProjectForbidden || err == service.ErrProjectNotFound || err == service.ErrIssueNotFound
+}
+
+// ListReactions returns all emoji reactions on an issue.
+// GET /api/workspaces/:slug/projects/:projectId/issues/:pk/reactions/
+func (h *IssueHandler) ListReactions(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	iid, ok := issueID(c)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	list, err := h.Issue.ListReactions(c.Request.Context(), slug, projectID, iid, user.ID)
+	if err != nil {
+		if reactionIsNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list reactions"})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+// AddReaction adds an emoji reaction to an issue.
+// POST /api/workspaces/:slug/projects/:projectId/issues/:pk/reactions/
+func (h *IssueHandler) AddReaction(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	iid, ok := issueID(c)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	var body addReactionRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		return
+	}
+	r, err := h.Issue.AddReaction(c.Request.Context(), slug, projectID, iid, user.ID, body.Reaction)
+	if err != nil {
+		if reactionIsNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		// Unique-constraint violation = the user already reacted with this emoji.
+		c.JSON(http.StatusConflict, gin.H{"error": "Already reacted"})
+		return
+	}
+	c.JSON(http.StatusCreated, r)
+}
+
+// RemoveReaction removes a user's emoji reaction from an issue.
+// DELETE /api/workspaces/:slug/projects/:projectId/issues/:pk/reactions/:reaction/
+func (h *IssueHandler) RemoveReaction(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	iid, ok := issueID(c)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	reaction := c.Param("reaction")
+	if reaction == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Reaction is required"})
+		return
+	}
+	if err := h.Issue.RemoveReaction(c.Request.Context(), slug, projectID, iid, user.ID, reaction); err != nil {
+		if reactionIsNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove reaction"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/apps/api/internal/handler/issue_reaction.go
+++ b/apps/api/internal/handler/issue_reaction.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
@@ -71,12 +72,15 @@ func (h *IssueHandler) AddReaction(c *gin.Context) {
 	}
 	r, err := h.Issue.AddReaction(c.Request.Context(), slug, projectID, iid, user.ID, body.Reaction)
 	if err != nil {
-		if reactionIsNotFound(err) {
+		switch {
+		case reactionIsNotFound(err):
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
-			return
+		case errors.Is(err, service.ErrReactionExists):
+			// The user already reacted with this emoji (unique-constraint).
+			c.JSON(http.StatusConflict, gin.H{"error": "Already reacted"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add reaction"})
 		}
-		// Unique-constraint violation = the user already reacted with this emoji.
-		c.JSON(http.StatusConflict, gin.H{"error": "Already reacted"})
 		return
 	}
 	c.JSON(http.StatusCreated, r)

--- a/apps/api/internal/handler/issue_reaction_test.go
+++ b/apps/api/internal/handler/issue_reaction_test.go
@@ -1,0 +1,47 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func issueReactionBase(slug, projectID, issueID string) string {
+	return "/api/workspaces/" + slug + "/projects/" + projectID + "/issues/" + issueID + "/reactions/"
+}
+
+func TestIssueReactions_RequiresAuth(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	rr := ts.GET(issueReactionBase("x", "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"), "")
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestIssue_Reactions(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	base := issueReactionBase(w.Workspace.Slug, w.Project.ID.String(), issue.ID.String())
+
+	// List (empty)
+	rr := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+
+	// Add reaction
+	rr2 := ts.POST(base, map[string]any{"reaction": "👍"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
+
+	// List (now contains the reaction)
+	rr3 := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code, "body=%s", rr3.Body.String())
+	require.Contains(t, rr3.Body.String(), "👍")
+
+	// Adding the same reaction again is rejected by the unique constraint
+	rr4 := ts.POST(base, map[string]any{"reaction": "👍"}, w.Session)
+	require.Equal(t, http.StatusConflict, rr4.Code, "body=%s", rr4.Body.String())
+
+	// Remove reaction (URL-encoded thumbs-up)
+	rr5 := ts.DELETE(base+"%F0%9F%91%8D/", w.Session)
+	require.Equal(t, http.StatusNoContent, rr5.Code, "body=%s", rr5.Body.String())
+}

--- a/apps/api/internal/model/issue_reaction.go
+++ b/apps/api/internal/model/issue_reaction.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// IssueReaction matches table "issue_reactions". Unique on (issue_id,
+// reaction, actor_id) so each user can drop one of each emoji per issue.
+type IssueReaction struct {
+	ID          uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	IssueID     uuid.UUID `gorm:"column:issue_id;type:uuid;not null" json:"issue_id"`
+	Reaction    string    `gorm:"type:varchar(50);not null" json:"reaction"`
+	ActorID     uuid.UUID `gorm:"column:actor_id;type:uuid;not null" json:"actor_id"`
+	ProjectID   uuid.UUID `gorm:"column:project_id;type:uuid;not null" json:"project_id"`
+	WorkspaceID uuid.UUID `gorm:"column:workspace_id;type:uuid;not null" json:"workspace_id"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+func (IssueReaction) TableName() string { return "issue_reactions" }
+
+func (r *IssueReaction) BeforeCreate(tx *gorm.DB) error {
+	if r.ID == uuid.Nil {
+		r.ID = uuid.New()
+	}
+	return nil
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -146,6 +146,8 @@ func New(cfg Config) *gin.Engine {
 	notificationSvc.SetPreferenceStore(userNotifPrefStore)
 	issueSvc.SetNotificationService(notificationSvc)
 	issueSvc.SetSubscriberStore(issueSubscriberStore)
+	issueReactionStore := store.NewIssueReactionStore(cfg.DB)
+	issueSvc.SetReactionStore(issueReactionStore)
 	commentReactionStore := store.NewCommentReactionStore(cfg.DB)
 	commentSvc := service.NewCommentService(commentStore, issueStore, projectStore, workspaceStore)
 	commentSvc.SetReactionStore(commentReactionStore)
@@ -321,6 +323,9 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/subscribe/", issueHandler.IsSubscribed)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/subscribe/", issueHandler.Subscribe)
 		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/subscribe/", issueHandler.Unsubscribe)
+		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/", issueHandler.ListReactions)
+		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/", issueHandler.AddReaction)
+		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/:reaction/", issueHandler.RemoveReaction)
 
 		api.GET("/workspaces/:slug/projects/:projectId/cycles/", cycleHandler.List)
 		api.POST("/workspaces/:slug/projects/:projectId/cycles/", cycleHandler.Create)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -18,12 +18,13 @@ var (
 
 // IssueService handles issue business logic.
 type IssueService struct {
-	is       *store.IssueStore
-	ps       *store.ProjectStore
-	ws       *store.WorkspaceStore
-	activity *store.IssueActivityStore   // optional — may be nil
-	notify   *NotificationService        // optional — may be nil
-	subs     *store.IssueSubscriberStore // optional — auto-subscribe assignees/mentions
+	is        *store.IssueStore
+	ps        *store.ProjectStore
+	ws        *store.WorkspaceStore
+	activity  *store.IssueActivityStore   // optional — may be nil
+	notify    *NotificationService        // optional — may be nil
+	subs      *store.IssueSubscriberStore // optional — auto-subscribe assignees/mentions
+	reactions *store.IssueReactionStore   // optional — per-issue emoji reactions
 }
 
 func NewIssueService(is *store.IssueStore, ps *store.ProjectStore, ws *store.WorkspaceStore) *IssueService {
@@ -41,6 +42,9 @@ func (s *IssueService) SetNotificationService(n *NotificationService) { s.notify
 // SetSubscriberStore injects the issue-subscriber store so assignees and mention
 // targets are auto-subscribed when they're added to an issue. Optional.
 func (s *IssueService) SetSubscriberStore(subs *store.IssueSubscriberStore) { s.subs = subs }
+
+// SetReactionStore wires per-issue emoji reactions support. Optional.
+func (s *IssueService) SetReactionStore(r *store.IssueReactionStore) { s.reactions = r }
 
 // autoSubscribe is a fire-and-forget helper used by the assignee and mention
 // hooks. Errors are logged-and-ignored — the user's primary action must not
@@ -118,6 +122,64 @@ func (s *IssueService) ensureWorkspaceAccess(ctx context.Context, workspaceSlug 
 		return nil, ErrWorkspaceForbidden
 	}
 	return wrk, nil
+}
+
+// issueForReaction auth-checks the caller and returns the issue, ensuring it
+// belongs to the project in the URL.
+func (s *IssueService) issueForReaction(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID) (*model.Issue, error) {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	issue, err := s.is.GetByID(ctx, issueID)
+	if err != nil || issue.ProjectID != projectID {
+		return nil, ErrIssueNotFound
+	}
+	return issue, nil
+}
+
+// ListReactions returns all emoji reactions on an issue after auth-checking.
+func (s *IssueService) ListReactions(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID) ([]model.IssueReaction, error) {
+	if s.reactions == nil {
+		return []model.IssueReaction{}, nil
+	}
+	if _, err := s.issueForReaction(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return nil, err
+	}
+	return s.reactions.ListByIssueID(ctx, issueID)
+}
+
+// AddReaction adds a user's emoji reaction to an issue. Duplicates are rejected
+// by the DB unique constraint.
+func (s *IssueService) AddReaction(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID, emoji string) (*model.IssueReaction, error) {
+	if s.reactions == nil {
+		return nil, errors.New("reactions store is not configured")
+	}
+	issue, err := s.issueForReaction(ctx, workspaceSlug, projectID, issueID, userID)
+	if err != nil {
+		return nil, err
+	}
+	r := &model.IssueReaction{
+		IssueID:     issue.ID,
+		Reaction:    emoji,
+		ActorID:     userID,
+		ProjectID:   issue.ProjectID,
+		WorkspaceID: issue.WorkspaceID,
+	}
+	if err := s.reactions.Add(ctx, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// RemoveReaction deletes a user's emoji reaction from an issue.
+func (s *IssueService) RemoveReaction(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID, emoji string) error {
+	if s.reactions == nil {
+		return errors.New("reactions store is not configured")
+	}
+	if _, err := s.issueForReaction(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return err
+	}
+	return s.reactions.Remove(ctx, issueID, userID, emoji)
 }
 
 // ListDraftsForWorkspace returns draft issues for all projects in the workspace the user can access.

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -14,6 +14,9 @@ import (
 
 var (
 	ErrIssueNotFound = errors.New("issue not found")
+	// ErrReactionExists is returned when a user adds an emoji they have already
+	// reacted with (the issue_reactions unique constraint).
+	ErrReactionExists = errors.New("reaction already exists")
 )
 
 // IssueService handles issue business logic.
@@ -166,6 +169,9 @@ func (s *IssueService) AddReaction(ctx context.Context, workspaceSlug string, pr
 		WorkspaceID: issue.WorkspaceID,
 	}
 	if err := s.reactions.Add(ctx, r); err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil, ErrReactionExists
+		}
 		return nil, err
 	}
 	return r, nil

--- a/apps/api/internal/store/issue_reaction.go
+++ b/apps/api/internal/store/issue_reaction.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// IssueReactionStore handles issue_reactions persistence.
+type IssueReactionStore struct{ db *gorm.DB }
+
+func NewIssueReactionStore(db *gorm.DB) *IssueReactionStore {
+	return &IssueReactionStore{db: db}
+}
+
+// ListByIssueID returns all reactions for a single issue.
+func (s *IssueReactionStore) ListByIssueID(ctx context.Context, issueID uuid.UUID) ([]model.IssueReaction, error) {
+	var list []model.IssueReaction
+	err := s.db.WithContext(ctx).
+		Where("issue_id = ?", issueID).
+		Order("created_at ASC").
+		Find(&list).Error
+	return list, err
+}
+
+// ListByIssueIDs returns reactions for many issues at once.
+func (s *IssueReactionStore) ListByIssueIDs(ctx context.Context, issueIDs []uuid.UUID) ([]model.IssueReaction, error) {
+	if len(issueIDs) == 0 {
+		return nil, nil
+	}
+	var list []model.IssueReaction
+	err := s.db.WithContext(ctx).
+		Where("issue_id IN ?", issueIDs).
+		Order("created_at ASC").
+		Find(&list).Error
+	return list, err
+}
+
+// Add inserts a reaction (the unique index rejects duplicates).
+func (s *IssueReactionStore) Add(ctx context.Context, r *model.IssueReaction) error {
+	return s.db.WithContext(ctx).Create(r).Error
+}
+
+// Remove deletes one user's reaction.
+func (s *IssueReactionStore) Remove(ctx context.Context, issueID, actorID uuid.UUID, reaction string) error {
+	return s.db.WithContext(ctx).
+		Where("issue_id = ? AND actor_id = ? AND reaction = ?", issueID, actorID, reaction).
+		Delete(&model.IssueReaction{}).Error
+}

--- a/apps/api/internal/testutil/pg.go
+++ b/apps/api/internal/testutil/pg.go
@@ -102,6 +102,9 @@ func initPG() {
 	dsn := cfg.DSN()
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
+		// Mirror production (database.New): translate driver errors to GORM
+		// sentinels so tests exercise the same error-handling paths.
+		TranslateError: true,
 	})
 	if err != nil {
 		pgErr = fmt.Errorf("open gorm: %w", err)

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -817,6 +817,15 @@ export interface CommentReactionApiResponse {
   created_at: string;
 }
 
+/** One emoji reaction on a work item. */
+export interface IssueReactionApiResponse {
+  id: string;
+  issue_id: string;
+  reaction: string;
+  actor_id: string;
+  created_at: string;
+}
+
 /** Quick link (workspace user link) as returned by the API */
 export interface QuickLinkApiResponse {
   id: string;

--- a/apps/web/src/components/work-item/IssueReactions.tsx
+++ b/apps/web/src/components/work-item/IssueReactions.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+import { SmilePlus } from 'lucide-react';
+import { issueService } from '../../services/issueService';
+import type { IssueReactionApiResponse } from '../../api/types';
+
+const QUICK_EMOJIS = ['👍', '🎉', '❤️', '🚀', '👀', '😄'];
+
+interface IssueReactionsProps {
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+  /** ID of the current user — needed to know which reactions are "mine" so we can toggle. */
+  currentUserId?: string | null;
+}
+
+/**
+ * Reactions row for a work item + a small "add reaction" button. Mirrors the
+ * comment-reactions UX: a minimal six-emoji picker, grouped counts, and a
+ * highlighted state for emojis the current user has reacted with.
+ */
+export function IssueReactions({
+  workspaceSlug,
+  projectId,
+  issueId,
+  currentUserId,
+}: IssueReactionsProps) {
+  const [reactions, setReactions] = useState<IssueReactionApiResponse[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    issueService
+      .listReactions(workspaceSlug, projectId, issueId)
+      .then((list) => {
+        if (!cancelled) setReactions(list ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setReactions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId, issueId]);
+
+  // Close picker on outside click.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [pickerOpen]);
+
+  // Group by emoji, count, and remember if I reacted.
+  const grouped = new Map<string, { count: number; mine: boolean }>();
+  for (const r of reactions) {
+    const cur = grouped.get(r.reaction) ?? { count: 0, mine: false };
+    cur.count += 1;
+    if (currentUserId && r.actor_id === currentUserId) cur.mine = true;
+    grouped.set(r.reaction, cur);
+  }
+
+  const toggle = async (emoji: string) => {
+    const existing = grouped.get(emoji);
+    setPickerOpen(false);
+    try {
+      if (existing?.mine) {
+        await issueService.removeReaction(workspaceSlug, projectId, issueId, emoji);
+      } else {
+        await issueService.addReaction(workspaceSlug, projectId, issueId, emoji);
+      }
+      // Refetch — small list, simpler than reconciling locally.
+      const next = await issueService.listReactions(workspaceSlug, projectId, issueId);
+      setReactions(next ?? []);
+    } catch {
+      // best-effort; a missing reaction or network blip shouldn't disrupt the UX
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className="relative flex flex-wrap items-center gap-1">
+      {[...grouped.entries()].map(([emoji, info]) => (
+        <button
+          key={emoji}
+          type="button"
+          onClick={() => void toggle(emoji)}
+          className={`inline-flex h-6 items-center gap-1 rounded-(--radius-md) border px-1.5 text-[11px] transition-colors ${
+            info.mine
+              ? 'border-(--bg-accent-primary) bg-(--bg-accent-subtle) text-(--txt-accent-primary)'
+              : 'border-(--border-subtle) bg-(--bg-surface-1) text-(--txt-secondary) hover:bg-(--bg-layer-1-hover)'
+          }`}
+          aria-label={`${emoji} ${info.count}`}
+        >
+          <span>{emoji}</span>
+          <span>{info.count}</span>
+        </button>
+      ))}
+      <button
+        type="button"
+        className="inline-flex h-6 w-6 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
+        onClick={() => setPickerOpen((v) => !v)}
+        aria-label="Add reaction"
+      >
+        <SmilePlus className="h-3.5 w-3.5" />
+      </button>
+      {pickerOpen && (
+        <div className="absolute left-0 top-full z-20 mt-1 inline-flex items-center gap-0.5 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-1.5 py-1 shadow-(--shadow-raised)">
+          {QUICK_EMOJIS.map((e) => (
+            <button
+              key={e}
+              type="button"
+              onClick={() => void toggle(e)}
+              className="inline-flex h-7 w-7 items-center justify-center rounded text-base hover:bg-(--bg-layer-1-hover)"
+              aria-label={`React with ${e}`}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/work-item/IssueReactions.tsx
+++ b/apps/web/src/components/work-item/IssueReactions.tsx
@@ -73,12 +73,15 @@ export function IssueReactions({
       } else {
         await issueService.addReaction(workspaceSlug, projectId, issueId, emoji);
       }
-      // Refetch — small list, simpler than reconciling locally.
-      const next = await issueService.listReactions(workspaceSlug, projectId, issueId);
-      setReactions(next ?? []);
     } catch {
       // best-effort; a missing reaction or network blip shouldn't disrupt the UX
     }
+    // Always resync after a toggle attempt so the UI reflects server truth even
+    // when the request failed (e.g. a conflict from concurrent toggles).
+    const next = await issueService
+      .listReactions(workspaceSlug, projectId, issueId)
+      .catch(() => null);
+    if (next) setReactions(next);
   };
 
   return (
@@ -104,15 +107,23 @@ export function IssueReactions({
         className="inline-flex h-6 w-6 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
         onClick={() => setPickerOpen((v) => !v)}
         aria-label="Add reaction"
+        aria-haspopup="menu"
+        aria-expanded={pickerOpen}
+        aria-controls="issue-reactions-picker"
       >
         <SmilePlus className="h-3.5 w-3.5" />
       </button>
       {pickerOpen && (
-        <div className="absolute left-0 top-full z-20 mt-1 inline-flex items-center gap-0.5 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-1.5 py-1 shadow-(--shadow-raised)">
+        <div
+          id="issue-reactions-picker"
+          role="menu"
+          className="absolute left-0 top-full z-20 mt-1 inline-flex items-center gap-0.5 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-1.5 py-1 shadow-(--shadow-raised)"
+        >
           {QUICK_EMOJIS.map((e) => (
             <button
               key={e}
               type="button"
+              role="menuitem"
               onClick={() => void toggle(e)}
               className="inline-flex h-7 w-7 items-center justify-center rounded text-base hover:bg-(--bg-layer-1-hover)"
               aria-label={`React with ${e}`}

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { Dropdown, DatePickerTrigger, CommentEditor } from '../components/work-item';
 import { sanitizeHtml, safeUrl } from '../lib/sanitize';
 import { DescriptionEditor } from '../components/work-item/DescriptionEditor';
+import { IssueReactions } from '../components/work-item/IssueReactions';
 import { IssueActivityFeed } from '../components/work-item/IssueActivityFeed';
 import { CommentReactions } from '../components/work-item/CommentReactions';
 import { workspaceService } from '../services/workspaceService';
@@ -636,6 +637,16 @@ export function IssueDetailPage() {
                 placeholder="Add a description… (type / for commands)"
                 mentionMembers={mentionMembers}
               />
+              {workspaceSlug && projectId && issueId && (
+                <div className="mt-3">
+                  <IssueReactions
+                    workspaceSlug={workspaceSlug}
+                    projectId={projectId}
+                    issueId={issueId}
+                    currentUserId={currentUser?.id}
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
 

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -6,6 +6,7 @@ import type {
   IssueLinkApiResponse,
   IssueRelationApiResponse,
   IssueRelationType,
+  IssueReactionApiResponse,
   CreateIssueRequest,
 } from '../api/types';
 
@@ -256,6 +257,41 @@ export const issueService = {
   ): Promise<void> {
     await apiClient.delete(
       `/api/assets/v2/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/issues/${encodeURIComponent(issueId)}/attachments/${encodeURIComponent(assetId)}/`,
+    );
+  },
+
+  async listReactions(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+  ): Promise<IssueReactionApiResponse[]> {
+    const { data } = await apiClient.get<IssueReactionApiResponse[]>(
+      `${base(workspaceSlug, projectId, issueId)}/reactions/`,
+    );
+    return data;
+  },
+
+  async addReaction(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    reaction: string,
+  ): Promise<IssueReactionApiResponse> {
+    const { data } = await apiClient.post<IssueReactionApiResponse>(
+      `${base(workspaceSlug, projectId, issueId)}/reactions/`,
+      { reaction },
+    );
+    return data;
+  },
+
+  async removeReaction(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    reaction: string,
+  ): Promise<void> {
+    await apiClient.delete(
+      `${base(workspaceSlug, projectId, issueId)}/reactions/${encodeURIComponent(reaction)}/`,
     );
   },
 };


### PR DESCRIPTION
## Feature summary

Closes #165. Adds emoji reactions to work items. The `issue_reactions` table already existed in the schema but had no code wiring it up; this connects it end to end, mirroring the existing comment-reactions feature.

## What changed

### API (`apps/api/`)
- `model/issue_reaction.go` — `IssueReaction` (table `issue_reactions`).
- `store/issue_reaction.go` — `IssueReactionStore` (`ListByIssueID`, `ListByIssueIDs`, `Add`, `Remove`).
- `service/issue.go` — `SetReactionStore` + `ListReactions` / `AddReaction` / `RemoveReaction`, each verifying workspace membership and that the issue belongs to the project.
- `handler/issue_reaction.go` — `GET` / `POST` / `DELETE .../issues/:pk/reactions/[:reaction/]`. Access errors map to 404; a duplicate reaction maps to 409.
- Wired the store into `IssueService` and registered the routes in `router.go`.

### UI (`apps/web/`)
- `services/issueService.ts` — `listReactions` / `addReaction` / `removeReaction`; `IssueReactionApiResponse` type.
- `components/work-item/IssueReactions.tsx` — reactions row + a six-emoji quick picker, grouped counts, and a highlighted "mine" state for toggling. Mounted under the description on the work-item detail page.

## Test plan

- [x] New handler test `TestIssue_Reactions` (empty list → add → list contains → duplicate 409 → remove 204) and `TestIssueReactions_RequiresAuth`.
- [x] `npm run validate` green (web typecheck + lint + prettier; `go vet` + `go test`).
- [x] End-to-end in the browser: opened a work item, added 🚀 (chip shows `🚀 1`, persisted via the API), then toggled it off (reactions back to 0).

## AI assistance

- [x] AI tools were used — tool: Claude Code (Opus 4.8) — and the commit includes a `Co-Authored-By:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-issue emoji reactions on issue detail pages, including viewing grouped reaction counts, adding a reaction, and removing your own reaction.
  * Enabled new backend endpoints to list, create, and delete reactions for a specific issue.
* **Bug Fixes**
  * Duplicate reactions are prevented with a clear conflict response, and missing reactions return the correct not-found response.
  * Reaction UI now refreshes after toggling to keep counts in sync.
* **Tests**
  * Added endpoint tests covering authentication, add/list/remove flows, and duplicate-reaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->