### PR TITLE
feat(issue): add per-issue archive and restore

### DIFF
--- a/apps/api/internal/handler/issue_archive.go
+++ b/apps/api/internal/handler/issue_archive.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// Archive marks a work item as archived (hidden from active lists).
+// POST /api/workspaces/:slug/projects/:projectId/issues/:pk/archive/
+func (h *IssueHandler) Archive(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	iid, ok := issueID(c)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	if err := h.Issue.Archive(c.Request.Context(), slug, projectID, iid, user.ID); err != nil {
+		if issueAccessNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to archive work item"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "archived"})
+}
+
+// Restore un-archives a work item.
+// DELETE /api/workspaces/:slug/projects/:projectId/issues/:pk/archive/
+func (h *IssueHandler) Restore(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	iid, ok := issueID(c)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	if err := h.Issue.Restore(c.Request.Context(), slug, projectID, iid, user.ID); err != nil {
+		if issueAccessNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to restore work item"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "restored"})
+}
+
+// ListArchived returns archived work items for a project.
+// GET /api/workspaces/:slug/projects/:projectId/archived-issues/
+func (h *IssueHandler) ListArchived(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	list, err := h.Issue.ListArchived(c.Request.Context(), slug, projectID, user.ID, limit, offset)
+	if err != nil {
+		if issueAccessNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list archived work items"})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}

--- a/apps/api/internal/handler/issue_archive_test.go
+++ b/apps/api/internal/handler/issue_archive_test.go
@@ -1,0 +1,44 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue_ArchiveRestore(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	id := issue.ID.String()
+	issuesBase := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/"
+	archivedBase := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/archived-issues/"
+
+	// Active list contains the issue; archived list is empty.
+	rr := ts.GET(issuesBase, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Contains(t, rr.Body.String(), id)
+	rrA := ts.GET(archivedBase, w.Session)
+	require.Equal(t, http.StatusOK, rrA.Code, "body=%s", rrA.Body.String())
+	require.NotContains(t, rrA.Body.String(), id)
+
+	// Archive it.
+	rr2 := ts.POST(issuesBase+id+"/archive/", map[string]any{}, w.Session)
+	require.Equal(t, http.StatusOK, rr2.Code, "body=%s", rr2.Body.String())
+
+	// Now absent from the active list, present in the archived list.
+	rr3 := ts.GET(issuesBase, w.Session)
+	require.NotContains(t, rr3.Body.String(), id)
+	rr4 := ts.GET(archivedBase, w.Session)
+	require.Contains(t, rr4.Body.String(), id)
+
+	// Restore it.
+	rr5 := ts.DELETE(issuesBase+id+"/archive/", w.Session)
+	require.Equal(t, http.StatusOK, rr5.Code, "body=%s", rr5.Body.String())
+
+	// Back in the active list.
+	rr6 := ts.GET(issuesBase, w.Session)
+	require.Contains(t, rr6.Body.String(), id)
+}

--- a/apps/api/internal/handler/issue_reaction.go
+++ b/apps/api/internal/handler/issue_reaction.go
@@ -10,8 +10,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// reactionNotFound maps service access errors to a 404.
-func reactionIsNotFound(err error) bool {
+// issueAccessNotFound reports whether a service error should map to a 404
+// (workspace/project/issue access failures).
+func issueAccessNotFound(err error) bool {
 	return err == service.ErrProjectForbidden || err == service.ErrProjectNotFound || err == service.ErrIssueNotFound
 }
 
@@ -36,7 +37,7 @@ func (h *IssueHandler) ListReactions(c *gin.Context) {
 	}
 	list, err := h.Issue.ListReactions(c.Request.Context(), slug, projectID, iid, user.ID)
 	if err != nil {
-		if reactionIsNotFound(err) {
+		if issueAccessNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 			return
 		}
@@ -73,7 +74,7 @@ func (h *IssueHandler) AddReaction(c *gin.Context) {
 	r, err := h.Issue.AddReaction(c.Request.Context(), slug, projectID, iid, user.ID, body.Reaction)
 	if err != nil {
 		switch {
-		case reactionIsNotFound(err):
+		case issueAccessNotFound(err):
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 		case errors.Is(err, service.ErrReactionExists):
 			// The user already reacted with this emoji (unique-constraint).
@@ -111,7 +112,7 @@ func (h *IssueHandler) RemoveReaction(c *gin.Context) {
 		return
 	}
 	if err := h.Issue.RemoveReaction(c.Request.Context(), slug, projectID, iid, user.ID, reaction); err != nil {
-		if reactionIsNotFound(err) {
+		if issueAccessNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 			return
 		}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -326,6 +326,9 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/", issueHandler.ListReactions)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/", issueHandler.AddReaction)
 		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/:reaction/", issueHandler.RemoveReaction)
+		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/archive/", issueHandler.Archive)
+		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/archive/", issueHandler.Restore)
+		api.GET("/workspaces/:slug/projects/:projectId/archived-issues/", issueHandler.ListArchived)
 
 		api.GET("/workspaces/:slug/projects/:projectId/cycles/", cycleHandler.List)
 		api.POST("/workspaces/:slug/projects/:projectId/cycles/", cycleHandler.Create)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -127,9 +127,9 @@ func (s *IssueService) ensureWorkspaceAccess(ctx context.Context, workspaceSlug 
 	return wrk, nil
 }
 
-// issueForReaction auth-checks the caller and returns the issue, ensuring it
+// issueForAccess auth-checks the caller and returns the issue, ensuring it
 // belongs to the project in the URL.
-func (s *IssueService) issueForReaction(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID) (*model.Issue, error) {
+func (s *IssueService) issueForAccess(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID) (*model.Issue, error) {
 	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (s *IssueService) ListReactions(ctx context.Context, workspaceSlug string, 
 	if s.reactions == nil {
 		return []model.IssueReaction{}, nil
 	}
-	if _, err := s.issueForReaction(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+	if _, err := s.issueForAccess(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
 		return nil, err
 	}
 	return s.reactions.ListByIssueID(ctx, issueID)
@@ -157,7 +157,7 @@ func (s *IssueService) AddReaction(ctx context.Context, workspaceSlug string, pr
 	if s.reactions == nil {
 		return nil, errors.New("reactions store is not configured")
 	}
-	issue, err := s.issueForReaction(ctx, workspaceSlug, projectID, issueID, userID)
+	issue, err := s.issueForAccess(ctx, workspaceSlug, projectID, issueID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -182,10 +182,35 @@ func (s *IssueService) RemoveReaction(ctx context.Context, workspaceSlug string,
 	if s.reactions == nil {
 		return errors.New("reactions store is not configured")
 	}
-	if _, err := s.issueForReaction(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+	if _, err := s.issueForAccess(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
 		return err
 	}
 	return s.reactions.Remove(ctx, issueID, userID, emoji)
+}
+
+// Archive marks an issue as archived (hidden from active lists, kept for the
+// archived view). Restore reverses it.
+func (s *IssueService) Archive(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID) error {
+	if _, err := s.issueForAccess(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return err
+	}
+	return s.is.SetArchived(ctx, issueID, true)
+}
+
+// Restore un-archives an issue.
+func (s *IssueService) Restore(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID) error {
+	if _, err := s.issueForAccess(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return err
+	}
+	return s.is.SetArchived(ctx, issueID, false)
+}
+
+// ListArchived returns archived issues for a project.
+func (s *IssueService) ListArchived(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID, limit, offset int) ([]model.Issue, error) {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	return s.is.ListArchivedByProjectID(ctx, projectID, limit, offset)
 }
 
 // ListDraftsForWorkspace returns draft issues for all projects in the workspace the user can access.

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/binary"
+	"time"
 
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/google/uuid"
@@ -75,7 +76,9 @@ func (s *IssueStore) ListByIDs(ctx context.Context, ids []uuid.UUID) ([]model.Is
 
 func (s *IssueStore) ListByProjectID(ctx context.Context, projectID uuid.UUID, limit, offset int) ([]model.Issue, error) {
 	var list []model.Issue
-	q := s.db.WithContext(ctx).Where("project_id = ? AND deleted_at IS NULL", projectID).Order("sort_order ASC, created_at DESC")
+	q := s.db.WithContext(ctx).
+		Where("project_id = ? AND deleted_at IS NULL AND archived_at IS NULL", projectID).
+		Order("sort_order ASC, created_at DESC")
 	if limit > 0 {
 		q = q.Limit(limit)
 	}
@@ -84,6 +87,35 @@ func (s *IssueStore) ListByProjectID(ctx context.Context, projectID uuid.UUID, l
 	}
 	err := q.Find(&list).Error
 	return list, err
+}
+
+// ListArchivedByProjectID returns archived (non-deleted) issues for a project.
+func (s *IssueStore) ListArchivedByProjectID(ctx context.Context, projectID uuid.UUID, limit, offset int) ([]model.Issue, error) {
+	var list []model.Issue
+	q := s.db.WithContext(ctx).
+		Where("project_id = ? AND deleted_at IS NULL AND archived_at IS NOT NULL", projectID).
+		Order("archived_at DESC")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
+	err := q.Find(&list).Error
+	return list, err
+}
+
+// SetArchived archives (sets archived_at) or restores (clears archived_at) an
+// issue. archived_at is the source of truth for archived state.
+func (s *IssueStore) SetArchived(ctx context.Context, id uuid.UUID, archived bool) error {
+	updates := map[string]any{"archived_at": nil}
+	if archived {
+		updates["archived_at"] = time.Now()
+	}
+	return s.db.WithContext(ctx).
+		Model(&model.Issue{}).
+		Where("id = ? AND deleted_at IS NULL", id).
+		Updates(updates).Error
 }
 
 func (s *IssueStore) ListDraftsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int) ([]model.Issue, error) {

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Archive } from 'lucide-react';
 import { Button, Card, CardContent, CardHeader, Avatar } from '../components/ui';
 import { useAuth } from '../contexts/AuthContext';
 import { Dropdown, DatePickerTrigger, CommentEditor } from '../components/work-item';
@@ -269,6 +270,7 @@ const BotGitHubIcon = () => (
 
 export function IssueDetailPage() {
   const { user: currentUser } = useAuth();
+  const navigate = useNavigate();
   const { workspaceSlug, projectId, issueId } = useParams<{
     workspaceSlug: string;
     projectId: string;
@@ -439,6 +441,17 @@ export function IssueDetailPage() {
 
   const baseUrl = `/${workspace.slug}/projects/${project.id}`;
   const displayId = `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`;
+
+  const handleArchive = async () => {
+    if (!workspaceSlug || !projectId || !issueId) return;
+    if (!window.confirm('Archive this work item? It will be hidden from active lists.')) return;
+    try {
+      await issueService.archive(workspaceSlug, projectId, issueId);
+      navigate(`${baseUrl}/issues`);
+    } catch {
+      setErrorMessage('Failed to archive work item.');
+    }
+  };
   const descriptionHtml =
     issue.description_html && typeof issue.description_html === 'string'
       ? issue.description_html
@@ -598,16 +611,26 @@ export function IssueDetailPage() {
           {errorMessage}
         </div>
       )}
-      <div className="flex items-center gap-2 text-sm text-(--txt-tertiary)">
-        <Link to={baseUrl} className="text-(--txt-accent-primary) hover:underline">
-          {project.name}
-        </Link>
-        <span>/</span>
-        <Link to={`${baseUrl}/issues`} className="text-(--txt-accent-primary) hover:underline">
-          Issues
-        </Link>
-        <span>/</span>
-        <span className="text-(--txt-secondary)">{displayId}</span>
+      <div className="flex items-center justify-between gap-2 text-sm text-(--txt-tertiary)">
+        <div className="flex min-w-0 items-center gap-2">
+          <Link to={baseUrl} className="text-(--txt-accent-primary) hover:underline">
+            {project.name}
+          </Link>
+          <span>/</span>
+          <Link to={`${baseUrl}/issues`} className="text-(--txt-accent-primary) hover:underline">
+            Issues
+          </Link>
+          <span>/</span>
+          <span className="text-(--txt-secondary)">{displayId}</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleArchive()}
+          className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+        >
+          <Archive className="h-3.5 w-3.5" />
+          Archive
+        </button>
       </div>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { Archive } from 'lucide-react';
+import { Archive, ArchiveRestore } from 'lucide-react';
 import { Button, Card, CardContent, CardHeader, Avatar } from '../components/ui';
 import { useAuth } from '../contexts/AuthContext';
 import { Dropdown, DatePickerTrigger, CommentEditor } from '../components/work-item';
@@ -452,6 +452,16 @@ export function IssueDetailPage() {
       setErrorMessage('Failed to archive work item.');
     }
   };
+
+  const handleRestore = async () => {
+    if (!workspaceSlug || !projectId || !issueId) return;
+    try {
+      await issueService.restore(workspaceSlug, projectId, issueId);
+      setIssue((prev) => (prev ? { ...prev, archived_at: null } : prev));
+    } catch {
+      setErrorMessage('Failed to restore work item.');
+    }
+  };
   const descriptionHtml =
     issue.description_html && typeof issue.description_html === 'string'
       ? issue.description_html
@@ -623,14 +633,25 @@ export function IssueDetailPage() {
           <span>/</span>
           <span className="text-(--txt-secondary)">{displayId}</span>
         </div>
-        <button
-          type="button"
-          onClick={() => void handleArchive()}
-          className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
-        >
-          <Archive className="h-3.5 w-3.5" />
-          Archive
-        </button>
+        {issue.archived_at ? (
+          <button
+            type="button"
+            onClick={() => void handleRestore()}
+            className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+          >
+            <ArchiveRestore className="h-3.5 w-3.5" />
+            Restore
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleArchive()}
+            className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+          >
+            <Archive className="h-3.5 w-3.5" />
+            Archive
+          </button>
+        )}
       </div>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -294,4 +294,26 @@ export const issueService = {
       `${base(workspaceSlug, projectId, issueId)}/reactions/${encodeURIComponent(reaction)}/`,
     );
   },
+
+  async archive(workspaceSlug: string, projectId: string, issueId: string): Promise<void> {
+    await apiClient.post(`${base(workspaceSlug, projectId, issueId)}/archive/`);
+  },
+
+  async restore(workspaceSlug: string, projectId: string, issueId: string): Promise<void> {
+    await apiClient.delete(`${base(workspaceSlug, projectId, issueId)}/archive/`);
+  },
+
+  async listArchived(
+    workspaceSlug: string,
+    projectId: string,
+    params: ListIssuesParams = {},
+  ): Promise<IssueApiResponse[]> {
+    const search = new URLSearchParams();
+    if (params.limit != null) search.set('limit', String(params.limit));
+    if (params.offset != null) search.set('offset', String(params.offset));
+    const qs = search.toString();
+    const url = `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/archived-issues/${qs ? `?${qs}` : ''}`;
+    const { data } = await apiClient.get<IssueApiResponse[]>(url);
+    return data;
+  },
 };


### PR DESCRIPTION
## Summary

Closes #166. Adds the ability to archive and restore individual work items. `archived_at` is the source of truth: active project lists now exclude archived issues, and a new endpoint lists archived ones.

## What changed

### API (`apps/api/`)
- `store/issue.go`: `ListByProjectID` now filters `archived_at IS NULL`; new `ListArchivedByProjectID` (`archived_at IS NOT NULL`) and `SetArchived` (sets/clears `archived_at`).
- `service/issue.go`: `Archive` / `Restore` / `ListArchived` with workspace+project+issue access checks. Renamed the shared access helper to `issueForAccess` (reused by reactions and archive).
- `handler/issue_archive.go`: `POST /issues/:pk/archive/` (archive), `DELETE /issues/:pk/archive/` (restore), `GET /archived-issues/` (list). Renamed the shared not-found helper to `issueAccessNotFound`.

### UI (`apps/web/`)
- `issueService`: `archive` / `restore` / `listArchived`.
- An **Archive** action on the work-item detail page that archives the item and returns to the issue list.

## Notes
- `archived_at` is the real column; the model's latent `is_archived` field (no column on `issues`) is intentionally left untouched.
- The full archived-items management view (and a restore UI there) is tracked by #128; this PR delivers the archive/restore actions + backend it builds on.

## Test plan
- [x] New handler test `TestIssue_ArchiveRestore` (active list → archive → absent from active / present in archived → restore → back in active).
- [x] `npm run validate` green.
- [x] Browser end-to-end: archived a work item via the UI (it vanished from the active list, appeared in `/archived-issues/`), then restored it via the API (returned to the active list).

## AI assistance
- [x] AI tools were used — tool: Claude Code (Opus 4.8) — and the commit includes a `Co-Authored-By:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added archive/restore actions to the issue detail view, with confirmation and redirect after completion.
  * Added support for viewing archived issues (including pagination) via the new archived-issues API.
* **Bug Fixes**
  * Archived issues are now excluded from the default project issue list.
  * Reaction/archiving-related authorization failures now map to accurate “not found” (404) responses.
* **Tests**
  * Added API test coverage for archiving and restoring issues end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->