### PR TITLE
feat(epic): add child-completion progress rollup

### DIFF
--- a/apps/api/internal/handler/epic.go
+++ b/apps/api/internal/handler/epic.go
@@ -53,6 +53,37 @@ func (h *EpicHandler) ListEpics(c *gin.Context) {
 	c.JSON(http.StatusOK, list)
 }
 
+// EpicsProgress returns, per epic in the project, child-issue counts grouped by
+// state group (plus a total), keyed by epic id.
+// GET /api/workspaces/:slug/projects/:projectId/epics-progress/
+func (h *EpicHandler) EpicsProgress(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	prog, err := h.Issue.EpicProgressBulk(c.Request.Context(), slug, projectID, user.ID)
+	if err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load epic progress"})
+		return
+	}
+	if prog == nil {
+		c.JSON(http.StatusOK, gin.H{})
+		return
+	}
+	c.JSON(http.StatusOK, prog)
+}
+
 // CreateEpic creates a new epic.
 // POST /api/workspaces/:slug/projects/:projectId/epics/
 func (h *EpicHandler) CreateEpic(c *gin.Context) {

--- a/apps/api/internal/handler/epic_progress_test.go
+++ b/apps/api/internal/handler/epic_progress_test.go
@@ -1,0 +1,32 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEpic_Progress(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+
+	// An epic with two child work items.
+	epic := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(&model.Issue{}).Where("id = ?", epic.ID).Update("is_epic", true).Error)
+	c1 := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	c2 := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(&model.Issue{}).
+		Where("id IN ?", []uuid.UUID{c1.ID, c2.ID}).
+		Update("parent_id", epic.ID).Error)
+
+	url := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/epics-progress/"
+	rr := ts.GET(url, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	// The epic appears in the map and totals its two children.
+	require.Contains(t, rr.Body.String(), epic.ID.String())
+	require.Contains(t, rr.Body.String(), "\"total\":2")
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -357,6 +357,7 @@ func New(cfg Config) *gin.Engine {
 
 		// Epics (is_epic=true issues with dedicated routes)
 		api.GET("/workspaces/:slug/projects/:projectId/epics/", epicHandler.ListEpics)
+		api.GET("/workspaces/:slug/projects/:projectId/epics-progress/", epicHandler.EpicsProgress)
 		api.POST("/workspaces/:slug/projects/:projectId/epics/", epicHandler.CreateEpic)
 		api.GET("/workspaces/:slug/projects/:projectId/epics/:epicId/", epicHandler.GetEpic)
 		api.PATCH("/workspaces/:slug/projects/:projectId/epics/:epicId/", epicHandler.UpdateEpic)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -1007,6 +1007,26 @@ func (s *IssueService) ListEpics(ctx context.Context, workspaceSlug string, proj
 	return list, nil
 }
 
+// EpicProgressBulk returns child-issue state-group counts (plus a total) for
+// every epic in the project, keyed by epic id. Used to render epic progress.
+func (s *IssueService) EpicProgressBulk(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID) (map[uuid.UUID]map[string]int, error) {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	dist, err := s.is.EpicStateDistributionBulk(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range dist {
+		total := 0
+		for _, c := range m {
+			total += c
+		}
+		m["total"] = total
+	}
+	return dist, nil
+}
+
 // CreateEpic creates a new epic in the project.
 func (s *IssueService) CreateEpic(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, description, priority string, stateID *uuid.UUID, assigneeIDs, labelIDs []uuid.UUID) (*model.Issue, error) {
 	epic, err := s.Create(ctx, workspaceSlug, projectID, userID, name, description, priority, stateID, assigneeIDs, labelIDs, nil, nil, nil, false)

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -164,6 +164,42 @@ func (s *IssueStore) BulkSetArchived(ctx context.Context, projectID uuid.UUID, i
 	return s.BulkUpdateFields(ctx, projectID, ids, updates)
 }
 
+// EpicStateDistributionBulk returns, for every epic in the project, the count of
+// its (non-deleted, non-epic) child issues grouped by state group. The result is
+// keyed by epic id; epics with no children are absent (callers default to zero).
+func (s *IssueStore) EpicStateDistributionBulk(ctx context.Context, projectID uuid.UUID) (map[uuid.UUID]map[string]int, error) {
+	var rows []struct {
+		Epic  uuid.UUID `gorm:"column:epic"`
+		Group string    `gorm:"column:grp"`
+		Count int       `gorm:"column:count"`
+	}
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT i.parent_id AS epic, COALESCE(st.group, 'backlog') AS grp, COUNT(i.id) AS count
+		FROM issues i
+		JOIN issues p ON p.id = i.parent_id AND p.is_epic = TRUE AND p.deleted_at IS NULL
+		LEFT JOIN states st ON st.id = i.state_id
+		WHERE i.project_id = ? AND i.deleted_at IS NULL AND i.is_epic = FALSE
+		GROUP BY i.parent_id, COALESCE(st.group, 'backlog')
+	`, projectID).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[uuid.UUID]map[string]int)
+	for _, r := range rows {
+		m := out[r.Epic]
+		if m == nil {
+			m = map[string]int{"backlog": 0, "unstarted": 0, "started": 0, "completed": 0, "cancelled": 0}
+			out[r.Epic] = m
+		}
+		if _, ok := m[r.Group]; ok {
+			m[r.Group] += r.Count
+		} else {
+			m["backlog"] += r.Count
+		}
+	}
+	return out, nil
+}
+
 func (s *IssueStore) AddAssignee(ctx context.Context, a *model.IssueAssignee) error {
 	return s.db.WithContext(ctx).Create(a).Error
 }

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -174,12 +174,12 @@ func (s *IssueStore) EpicStateDistributionBulk(ctx context.Context, projectID uu
 		Count int       `gorm:"column:count"`
 	}
 	err := s.db.WithContext(ctx).Raw(`
-		SELECT i.parent_id AS epic, COALESCE(st.group, 'backlog') AS grp, COUNT(i.id) AS count
+		SELECT i.parent_id AS epic, COALESCE(st."group", 'backlog') AS grp, COUNT(i.id) AS count
 		FROM issues i
 		JOIN issues p ON p.id = i.parent_id AND p.is_epic = TRUE AND p.deleted_at IS NULL
 		LEFT JOIN states st ON st.id = i.state_id
 		WHERE i.project_id = ? AND i.deleted_at IS NULL AND i.is_epic = FALSE
-		GROUP BY i.parent_id, COALESCE(st.group, 'backlog')
+		GROUP BY i.parent_id, COALESCE(st."group", 'backlog')
 	`, projectID).Scan(&rows).Error
 	if err != nil {
 		return nil, err

--- a/apps/web/src/components/work-item/EpicProgressBar.tsx
+++ b/apps/web/src/components/work-item/EpicProgressBar.tsx
@@ -1,0 +1,25 @@
+import type { EpicProgress } from '../../services/epicService';
+
+/**
+ * Compact completion bar for an epic: a fill proportional to completed/total
+ * child work items, plus a count label. Renders a neutral "No items" state when
+ * the epic has no children.
+ */
+export function EpicProgressBar({ progress }: { progress?: EpicProgress }) {
+  const total = progress?.total ?? 0;
+  const done = progress?.completed ?? 0;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  return (
+    <div className="flex items-center gap-2" title={`${done} of ${total} completed`}>
+      <div className="h-1.5 w-24 overflow-hidden rounded-full bg-(--border-subtle)">
+        <div
+          className="h-full rounded-full bg-(--bg-accent-primary)"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="shrink-0 text-[11px] text-(--txt-tertiary)">
+        {total === 0 ? 'No items' : `${done}/${total}`}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/pages/EpicDetailPage.tsx
+++ b/apps/web/src/pages/EpicDetailPage.tsx
@@ -3,7 +3,8 @@ import { Link, useParams } from 'react-router-dom';
 import { Badge, Card, CardContent, CardHeader } from '../components/ui';
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
-import { epicService } from '../services/epicService';
+import { epicService, type EpicProgress } from '../services/epicService';
+import { EpicProgressBar } from '../components/work-item/EpicProgressBar';
 import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
 import { safeUrl } from '../lib/sanitize';
@@ -39,6 +40,7 @@ export function EpicDetailPage() {
   const [allIssues, setAllIssues] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [links, setLinks] = useState<IssueLinkApiResponse[]>([]);
+  const [progress, setProgress] = useState<Record<string, EpicProgress>>({});
   const [addIssueSearch, setAddIssueSearch] = useState('');
   const [addIssueOpen, setAddIssueOpen] = useState(false);
   const [addLinkOpen, setAddLinkOpen] = useState(false);
@@ -60,8 +62,9 @@ export function EpicDetailPage() {
       issueService.list(workspaceSlug, projectId, { limit: 250 }),
       stateService.list(workspaceSlug, projectId),
       epicService.listLinks(workspaceSlug, projectId, epicId).catch(() => []),
+      epicService.listProgress(workspaceSlug, projectId).catch(() => ({})),
     ])
-      .then(([w, p, ep, eis, all, st, lnks]) => {
+      .then(([w, p, ep, eis, all, st, lnks, prog]) => {
         if (cancelled) return;
         setWorkspace(w ?? null);
         setProject(p ?? null);
@@ -70,6 +73,7 @@ export function EpicDetailPage() {
         setAllIssues(all ?? []);
         setStates(st ?? []);
         setLinks((lnks as IssueLinkApiResponse[]) ?? []);
+        setProgress((prog as Record<string, EpicProgress>) ?? {});
       })
       .catch(() => {
         if (!cancelled) {
@@ -116,6 +120,9 @@ export function EpicDetailPage() {
           {project.identifier ?? project.id.slice(0, 6)}-{epic.sequence_id} ·{' '}
           {stateName(epic.state_id)} · {epic.priority ?? 'no priority'}
         </p>
+        <div className="mt-2">
+          <EpicProgressBar progress={epicId ? progress[epicId] : undefined} />
+        </div>
       </div>
 
       {error && (

--- a/apps/web/src/pages/EpicsPage.tsx
+++ b/apps/web/src/pages/EpicsPage.tsx
@@ -3,8 +3,9 @@ import { Link, useParams } from 'react-router-dom';
 import { Button, Card, CardContent } from '../components/ui';
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
-import { epicService } from '../services/epicService';
+import { epicService, type EpicProgress } from '../services/epicService';
 import { stateService } from '../services/stateService';
+import { EpicProgressBar } from '../components/work-item/EpicProgressBar';
 import type {
   IssueApiResponse,
   ProjectApiResponse,
@@ -19,6 +20,7 @@ export function EpicsPage() {
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [epics, setEpics] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
+  const [progress, setProgress] = useState<Record<string, EpicProgress>>({});
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState('');
   const [creating, setCreating] = useState(false);
@@ -35,13 +37,15 @@ export function EpicsPage() {
       projectService.get(workspaceSlug, projectId),
       epicService.list(workspaceSlug, projectId),
       stateService.list(workspaceSlug, projectId),
+      epicService.listProgress(workspaceSlug, projectId).catch(() => ({})),
     ])
-      .then(([w, p, eps, st]) => {
+      .then(([w, p, eps, st, prog]) => {
         if (cancelled) return;
         setWorkspace(w ?? null);
         setProject(p ?? null);
         setEpics(eps ?? []);
         setStates(st ?? []);
+        setProgress(prog ?? {});
       })
       .catch(() => {
         if (!cancelled) {
@@ -151,6 +155,7 @@ export function EpicsPage() {
                     {stateName(epic.state_id)} · {epic.priority ?? 'no priority'}
                   </p>
                 </div>
+                <EpicProgressBar progress={progress[epic.id]} />
                 <Link
                   to={`${baseUrl}/epics/${epic.id}`}
                   className="shrink-0 rounded-(--radius-md) px-2 py-1 text-xs text-(--txt-secondary) hover:bg-(--bg-layer-1-hover)"

--- a/apps/web/src/services/epicService.ts
+++ b/apps/web/src/services/epicService.ts
@@ -4,10 +4,31 @@ import type { IssueApiResponse, IssueLinkApiResponse } from '../api/types';
 const base = (slug: string, pid: string) =>
   `/api/workspaces/${encodeURIComponent(slug)}/projects/${encodeURIComponent(pid)}/epics`;
 
+/** Child-issue counts for an epic, grouped by state group (plus a total). */
+export interface EpicProgress {
+  backlog: number;
+  unstarted: number;
+  started: number;
+  completed: number;
+  cancelled: number;
+  total: number;
+}
+
 export const epicService = {
   async list(workspaceSlug: string, projectId: string): Promise<IssueApiResponse[]> {
     const { data } = await apiClient.get<IssueApiResponse[]>(`${base(workspaceSlug, projectId)}/`);
     return data ?? [];
+  },
+
+  /** Per-epic progress for the whole project, keyed by epic id. */
+  async listProgress(
+    workspaceSlug: string,
+    projectId: string,
+  ): Promise<Record<string, EpicProgress>> {
+    const { data } = await apiClient.get<Record<string, EpicProgress>>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/epics-progress/`,
+    );
+    return data ?? {};
   },
 
   async get(workspaceSlug: string, projectId: string, epicId: string): Promise<IssueApiResponse> {


### PR DESCRIPTION
## Summary
Closes #191. Epics now show how complete they are: a progress bar driven by their child work items' state groups, on both the epics list cards and the epic detail header.

## What changed
### API (`apps/api/`)
- `store/issue.go` `EpicStateDistributionBulk`: one query returns, per epic in the project, child-issue counts grouped by state group (mirrors `CycleStateDistribution`, joined by `parent_id` with `parent.is_epic = true`).
- `service/issue.go` `EpicProgressBulk`: access-checks and adds a `total`.
- `handler/epic.go` + route: `GET .../epics-progress/` returns `{ "<epicId>": { backlog, unstarted, started, completed, cancelled, total } }`.

### UI (`apps/web/`)
- `epicService.listProgress` + `EpicProgress` type.
- `EpicProgressBar` component (completed/total fill + count), rendered on epic list cards and the epic detail header.

## Test plan
- [x] `TestEpic_Progress` (epic with two children totals 2).
- [x] `npm run validate` green.
- [x] Browser: created an epic + linked one child → epics list shows the epic with a `0/1` progress bar; the API returns `{backlog:1,total:1}`.

## AI assistance
- [x] AI tools were used — tool: Claude Code (Opus 4.8) — and the commit includes a `Co-Authored-By:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “epics progress” API endpoint to provide per-epic state-group counts and totals.
  * Added an `EpicProgressBar` and integrated it into epic cards and the epic detail page for quick completion visibility.

* **Bug Fixes**
  * Improved resilience when progress data is missing or fails to load, ensuring pages still render.

* **Tests**
  * Added coverage for the epic progress API response, including totals derived from linked child items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->