### PR TITLE
feat(module): implement module members (resolves #139)

### DIFF
--- a/apps/api/internal/handler/module.go
+++ b/apps/api/internal/handler/module.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"time"
 
@@ -190,7 +192,11 @@ func (h *ModuleHandler) Update(c *gin.Context) {
 		LeadID      *string   `json:"lead_id"`
 		MemberIDs   *[]string `json:"member_ids"`
 	}
-	_ = c.ShouldBindJSON(&body)
+	// An empty PATCH body is allowed (a no-op patch); other parse errors are not.
+	if err := c.ShouldBindJSON(&body); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
 	leadIDPtr, ok := parseOptionalUUID(c, body.LeadID, "lead_id")
 	if !ok {
 		return

--- a/apps/api/internal/handler/module.go
+++ b/apps/api/internal/handler/module.go
@@ -26,6 +26,38 @@ func parseOptionalDate(s string) *time.Time {
 	return &t
 }
 
+// parseOptionalUUID parses an optional UUID string field. A nil or empty value
+// yields (nil, true); an invalid value writes a 400 and returns ok=false.
+func parseOptionalUUID(c *gin.Context, s *string, field string) (*uuid.UUID, bool) {
+	if s == nil || *s == "" {
+		return nil, true
+	}
+	id, err := uuid.Parse(*s)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid " + field, "detail": "must be a valid UUID"})
+		return nil, false
+	}
+	return &id, true
+}
+
+// parseUUIDList parses a list of UUID strings; an invalid entry writes a 400 and
+// returns ok=false.
+func parseUUIDList(c *gin.Context, ss []string, field string) ([]uuid.UUID, bool) {
+	out := make([]uuid.UUID, 0, len(ss))
+	for _, s := range ss {
+		if s == "" {
+			continue
+		}
+		id, err := uuid.Parse(s)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid " + field, "detail": "must be valid UUIDs"})
+			return nil, false
+		}
+		out = append(out, id)
+	}
+	return out, true
+}
+
 // List returns modules for the project.
 // GET /api/workspaces/:slug/projects/:projectId/modules/
 func (h *ModuleHandler) List(c *gin.Context) {
@@ -67,17 +99,27 @@ func (h *ModuleHandler) Create(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name        string `json:"name" binding:"required"`
-		Description string `json:"description"`
-		Status      string `json:"status"`
-		StartDate   string `json:"start_date"`
-		TargetDate  string `json:"target_date"`
+		Name        string   `json:"name" binding:"required"`
+		Description string   `json:"description"`
+		Status      string   `json:"status"`
+		StartDate   string   `json:"start_date"`
+		TargetDate  string   `json:"target_date"`
+		LeadID      *string  `json:"lead_id"`
+		MemberIDs   []string `json:"member_ids"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
 		return
 	}
-	mod, err := h.Module.Create(c.Request.Context(), slug, projectID, user.ID, body.Name, body.Description, body.Status, parseOptionalDate(body.StartDate), parseOptionalDate(body.TargetDate))
+	leadIDPtr, ok := parseOptionalUUID(c, body.LeadID, "lead_id")
+	if !ok {
+		return
+	}
+	memberIDs, ok := parseUUIDList(c, body.MemberIDs, "member_ids")
+	if !ok {
+		return
+	}
+	mod, err := h.Module.Create(c.Request.Context(), slug, projectID, user.ID, body.Name, body.Description, body.Status, parseOptionalDate(body.StartDate), parseOptionalDate(body.TargetDate), leadIDPtr, memberIDs)
 	if err != nil {
 		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
@@ -140,26 +182,27 @@ func (h *ModuleHandler) Update(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name        string  `json:"name"`
-		Description string  `json:"description"`
-		Status      string  `json:"status"`
-		StartDate   string  `json:"start_date"`
-		TargetDate  string  `json:"target_date"`
-		LeadID      *string `json:"lead_id"`
+		Name        string    `json:"name"`
+		Description string    `json:"description"`
+		Status      string    `json:"status"`
+		StartDate   string    `json:"start_date"`
+		TargetDate  string    `json:"target_date"`
+		LeadID      *string   `json:"lead_id"`
+		MemberIDs   *[]string `json:"member_ids"`
 	}
 	_ = c.ShouldBindJSON(&body)
-	var leadIDPtr *uuid.UUID
-	if body.LeadID != nil {
-		if *body.LeadID != "" {
-			id, parseErr := uuid.Parse(*body.LeadID)
-			if parseErr != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid lead_id", "detail": "must be a valid UUID"})
-				return
-			}
-			leadIDPtr = &id
+	leadIDPtr, ok := parseOptionalUUID(c, body.LeadID, "lead_id")
+	if !ok {
+		return
+	}
+	var memberIDs []uuid.UUID
+	if body.MemberIDs != nil {
+		memberIDs, ok = parseUUIDList(c, *body.MemberIDs, "member_ids")
+		if !ok {
+			return
 		}
 	}
-	mod, err := h.Module.Update(c.Request.Context(), slug, projectID, moduleID, user.ID, body.Name, body.Description, body.Status, parseOptionalDate(body.StartDate), parseOptionalDate(body.TargetDate), body.LeadID != nil, leadIDPtr)
+	mod, err := h.Module.Update(c.Request.Context(), slug, projectID, moduleID, user.ID, body.Name, body.Description, body.Status, parseOptionalDate(body.StartDate), parseOptionalDate(body.TargetDate), body.LeadID != nil, leadIDPtr, body.MemberIDs != nil, memberIDs)
 	if err != nil {
 		if err == service.ErrModuleNotFound || err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})

--- a/apps/api/internal/handler/module_member_test.go
+++ b/apps/api/internal/handler/module_member_test.go
@@ -1,0 +1,43 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModule_Members(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/modules/"
+	uid := w.User.ID.String()
+
+	// Create with a lead and one member.
+	rr := ts.POST(base, map[string]any{
+		"name":       "Sprint M",
+		"lead_id":    uid,
+		"member_ids": []string{uid},
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	created := testutil.MustJSONMap(t, rr)
+	id, _ := created["id"].(string)
+	require.NotEmpty(t, id)
+	require.Equal(t, uid, created["lead_id"])
+	members, _ := created["member_ids"].([]any)
+	require.Len(t, members, 1)
+	require.Equal(t, uid, members[0])
+
+	// Get returns the member.
+	got := ts.GET(base+id+"/", w.Session)
+	require.Equal(t, http.StatusOK, got.Code, "body=%s", got.Body.String())
+	gm, _ := testutil.MustJSONMap(t, got)["member_ids"].([]any)
+	require.Len(t, gm, 1)
+
+	// Update clears members.
+	upd := ts.PATCH(base+id+"/", map[string]any{"member_ids": []string{}}, w.Session)
+	require.Equal(t, http.StatusOK, upd.Code, "body=%s", upd.Body.String())
+	um, _ := testutil.MustJSONMap(t, upd)["member_ids"].([]any)
+	require.Len(t, um, 0)
+}

--- a/apps/api/internal/model/module.go
+++ b/apps/api/internal/model/module.go
@@ -19,6 +19,7 @@ type Module struct {
 	WorkspaceID uuid.UUID      `gorm:"type:uuid;not null" json:"workspace_id"`
 	IssueCount  int            `gorm:"-" json:"issue_count,omitempty"`
 	LeadID      *uuid.UUID     `gorm:"type:uuid" json:"lead_id,omitempty"`
+	MemberIDs   []uuid.UUID    `gorm:"-" json:"member_ids"`
 	SortOrder   float64        `gorm:"column:sort_order;default:65535" json:"sort_order"`
 	CreatedAt   time.Time      `json:"created_at"`
 	UpdatedAt   time.Time      `json:"updated_at"`
@@ -30,6 +31,26 @@ type Module struct {
 func (Module) TableName() string { return "modules" }
 
 func (m *Module) BeforeCreate(tx *gorm.DB) error {
+	if m.ID == uuid.Nil {
+		m.ID = uuid.New()
+	}
+	return nil
+}
+
+// ModuleMember matches module_members (M2M between modules and users).
+type ModuleMember struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	ModuleID    uuid.UUID  `gorm:"type:uuid;not null" json:"module_id"`
+	MemberID    uuid.UUID  `gorm:"type:uuid;not null" json:"member_id"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CreatedByID *uuid.UUID `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	UpdatedByID *uuid.UUID `gorm:"type:uuid" json:"updated_by_id,omitempty"`
+}
+
+func (ModuleMember) TableName() string { return "module_members" }
+
+func (m *ModuleMember) BeforeCreate(tx *gorm.DB) error {
 	if m.ID == uuid.Nil {
 		m.ID = uuid.New()
 	}

--- a/apps/api/internal/service/module.go
+++ b/apps/api/internal/service/module.go
@@ -63,13 +63,14 @@ func (s *ModuleService) List(ctx context.Context, workspaceSlug string, projectI
 		}
 	}
 	members, err := s.ms.ListMemberIDsByModuleIDs(ctx, ids)
-	if err == nil {
-		for i := range list {
-			if m := members[list[i].ID]; m != nil {
-				list[i].MemberIDs = m
-			} else {
-				list[i].MemberIDs = []uuid.UUID{}
-			}
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		if m := members[list[i].ID]; m != nil {
+			list[i].MemberIDs = m
+		} else {
+			list[i].MemberIDs = []uuid.UUID{}
 		}
 	}
 	return list, nil
@@ -93,25 +94,37 @@ func (s *ModuleService) Create(ctx context.Context, workspaceSlug string, projec
 		WorkspaceID: wrk.ID,
 		LeadID:      leadID,
 	}
-	if err := s.ms.Create(ctx, mod); err != nil {
+	// Keep the module insert and its member set atomic.
+	if err := s.ms.Tx(ctx, func(tx *store.ModuleStore) error {
+		if err := tx.Create(ctx, mod); err != nil {
+			return err
+		}
+		if len(memberIDs) > 0 {
+			return tx.SetMembers(ctx, mod.ID, memberIDs, userID)
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-	if len(memberIDs) > 0 {
-		if err := s.ms.SetMembers(ctx, mod.ID, memberIDs, userID); err != nil {
-			return nil, err
-		}
+	ids, err := s.memberIDs(ctx, mod.ID)
+	if err != nil {
+		return nil, err
 	}
-	mod.MemberIDs = s.memberIDsOrEmpty(ctx, mod.ID)
+	mod.MemberIDs = ids
 	return mod, nil
 }
 
-// memberIDsOrEmpty returns a module's member ids, never nil (so JSON renders []).
-func (s *ModuleService) memberIDsOrEmpty(ctx context.Context, moduleID uuid.UUID) []uuid.UUID {
+// memberIDs returns a module's member ids as a non-nil slice (so JSON renders
+// []), surfacing read errors rather than masking them as an empty team.
+func (s *ModuleService) memberIDs(ctx context.Context, moduleID uuid.UUID) ([]uuid.UUID, error) {
 	ids, err := s.ms.ListMemberIDs(ctx, moduleID)
-	if err != nil || ids == nil {
-		return []uuid.UUID{}
+	if err != nil {
+		return nil, err
 	}
-	return ids
+	if ids == nil {
+		return []uuid.UUID{}, nil
+	}
+	return ids, nil
 }
 
 func (s *ModuleService) Get(ctx context.Context, workspaceSlug string, projectID, moduleID uuid.UUID, userID uuid.UUID) (*model.Module, error) {
@@ -128,7 +141,11 @@ func (s *ModuleService) Get(ctx context.Context, workspaceSlug string, projectID
 	if counts, err := s.ms.CountIssuesByModuleIDs(ctx, []uuid.UUID{mod.ID}); err == nil {
 		mod.IssueCount = counts[mod.ID]
 	}
-	mod.MemberIDs = s.memberIDsOrEmpty(ctx, mod.ID)
+	ids, err := s.memberIDs(ctx, mod.ID)
+	if err != nil {
+		return nil, err
+	}
+	mod.MemberIDs = ids
 	return mod, nil
 }
 
@@ -155,15 +172,22 @@ func (s *ModuleService) Update(ctx context.Context, workspaceSlug string, projec
 	if leadIDSet {
 		mod.LeadID = leadID
 	}
-	if err := s.ms.Update(ctx, mod); err != nil {
+	if err := s.ms.Tx(ctx, func(tx *store.ModuleStore) error {
+		if err := tx.Update(ctx, mod); err != nil {
+			return err
+		}
+		if memberIDsSet {
+			return tx.SetMembers(ctx, mod.ID, memberIDs, userID)
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-	if memberIDsSet {
-		if err := s.ms.SetMembers(ctx, mod.ID, memberIDs, userID); err != nil {
-			return nil, err
-		}
+	ids, err := s.memberIDs(ctx, mod.ID)
+	if err != nil {
+		return nil, err
 	}
-	mod.MemberIDs = s.memberIDsOrEmpty(ctx, mod.ID)
+	mod.MemberIDs = ids
 	return mod, nil
 }
 

--- a/apps/api/internal/service/module.go
+++ b/apps/api/internal/service/module.go
@@ -62,10 +62,20 @@ func (s *ModuleService) List(ctx context.Context, workspaceSlug string, projectI
 			list[i].IssueCount = counts[list[i].ID]
 		}
 	}
+	members, err := s.ms.ListMemberIDsByModuleIDs(ctx, ids)
+	if err == nil {
+		for i := range list {
+			if m := members[list[i].ID]; m != nil {
+				list[i].MemberIDs = m
+			} else {
+				list[i].MemberIDs = []uuid.UUID{}
+			}
+		}
+	}
 	return list, nil
 }
 
-func (s *ModuleService) Create(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, description, status string, startDate, targetDate *time.Time) (*model.Module, error) {
+func (s *ModuleService) Create(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, description, status string, startDate, targetDate *time.Time, leadID *uuid.UUID, memberIDs []uuid.UUID) (*model.Module, error) {
 	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
 		return nil, err
 	}
@@ -81,11 +91,27 @@ func (s *ModuleService) Create(ctx context.Context, workspaceSlug string, projec
 		TargetDate:  targetDate,
 		ProjectID:   projectID,
 		WorkspaceID: wrk.ID,
+		LeadID:      leadID,
 	}
 	if err := s.ms.Create(ctx, mod); err != nil {
 		return nil, err
 	}
+	if len(memberIDs) > 0 {
+		if err := s.ms.SetMembers(ctx, mod.ID, memberIDs, userID); err != nil {
+			return nil, err
+		}
+	}
+	mod.MemberIDs = s.memberIDsOrEmpty(ctx, mod.ID)
 	return mod, nil
+}
+
+// memberIDsOrEmpty returns a module's member ids, never nil (so JSON renders []).
+func (s *ModuleService) memberIDsOrEmpty(ctx context.Context, moduleID uuid.UUID) []uuid.UUID {
+	ids, err := s.ms.ListMemberIDs(ctx, moduleID)
+	if err != nil || ids == nil {
+		return []uuid.UUID{}
+	}
+	return ids
 }
 
 func (s *ModuleService) Get(ctx context.Context, workspaceSlug string, projectID, moduleID uuid.UUID, userID uuid.UUID) (*model.Module, error) {
@@ -102,10 +128,11 @@ func (s *ModuleService) Get(ctx context.Context, workspaceSlug string, projectID
 	if counts, err := s.ms.CountIssuesByModuleIDs(ctx, []uuid.UUID{mod.ID}); err == nil {
 		mod.IssueCount = counts[mod.ID]
 	}
+	mod.MemberIDs = s.memberIDsOrEmpty(ctx, mod.ID)
 	return mod, nil
 }
 
-func (s *ModuleService) Update(ctx context.Context, workspaceSlug string, projectID, moduleID uuid.UUID, userID uuid.UUID, name, description, status string, startDate, targetDate *time.Time, leadIDSet bool, leadID *uuid.UUID) (*model.Module, error) {
+func (s *ModuleService) Update(ctx context.Context, workspaceSlug string, projectID, moduleID uuid.UUID, userID uuid.UUID, name, description, status string, startDate, targetDate *time.Time, leadIDSet bool, leadID *uuid.UUID, memberIDsSet bool, memberIDs []uuid.UUID) (*model.Module, error) {
 	mod, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
 	if err != nil {
 		return nil, err
@@ -131,6 +158,12 @@ func (s *ModuleService) Update(ctx context.Context, workspaceSlug string, projec
 	if err := s.ms.Update(ctx, mod); err != nil {
 		return nil, err
 	}
+	if memberIDsSet {
+		if err := s.ms.SetMembers(ctx, mod.ID, memberIDs, userID); err != nil {
+			return nil, err
+		}
+	}
+	mod.MemberIDs = s.memberIDsOrEmpty(ctx, mod.ID)
 	return mod, nil
 }
 

--- a/apps/api/internal/store/module.go
+++ b/apps/api/internal/store/module.go
@@ -17,6 +17,14 @@ func (s *ModuleStore) Create(ctx context.Context, m *model.Module) error {
 	return s.db.WithContext(ctx).Create(m).Error
 }
 
+// Tx runs fn inside a database transaction, passing a transaction-scoped store.
+// Used to keep a module write and its member replacement atomic.
+func (s *ModuleStore) Tx(ctx context.Context, fn func(tx *ModuleStore) error) error {
+	return s.db.WithContext(ctx).Transaction(func(txdb *gorm.DB) error {
+		return fn(&ModuleStore{db: txdb})
+	})
+}
+
 func (s *ModuleStore) GetByID(ctx context.Context, id uuid.UUID) (*model.Module, error) {
 	var mod model.Module
 	err := s.db.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", id).First(&mod).Error

--- a/apps/api/internal/store/module.go
+++ b/apps/api/internal/store/module.go
@@ -64,6 +64,75 @@ func (s *ModuleStore) ListModuleIssueIDs(ctx context.Context, moduleID uuid.UUID
 	return ids, nil
 }
 
+// SetMembers replaces a module's member set with memberIDs (in a transaction).
+func (s *ModuleStore) SetMembers(ctx context.Context, moduleID uuid.UUID, memberIDs []uuid.UUID, actorID uuid.UUID) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("module_id = ?", moduleID).Delete(&model.ModuleMember{}).Error; err != nil {
+			return err
+		}
+		if len(memberIDs) == 0 {
+			return nil
+		}
+		// De-dupe to respect the (module_id, member_id) unique constraint.
+		seen := make(map[uuid.UUID]bool, len(memberIDs))
+		rows := make([]model.ModuleMember, 0, len(memberIDs))
+		for _, mid := range memberIDs {
+			if mid == uuid.Nil || seen[mid] {
+				continue
+			}
+			seen[mid] = true
+			actor := actorID
+			rows = append(rows, model.ModuleMember{
+				ModuleID:    moduleID,
+				MemberID:    mid,
+				CreatedByID: &actor,
+				UpdatedByID: &actor,
+			})
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		return tx.Create(&rows).Error
+	})
+}
+
+// ListMemberIDs returns the member ids for a module.
+func (s *ModuleStore) ListMemberIDs(ctx context.Context, moduleID uuid.UUID) ([]uuid.UUID, error) {
+	var rows []struct{ MemberID uuid.UUID }
+	err := s.db.WithContext(ctx).Model(&model.ModuleMember{}).
+		Where("module_id = ?", moduleID).Select("member_id").Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.MemberID)
+	}
+	return ids, nil
+}
+
+// ListMemberIDsByModuleIDs returns member ids for many modules, keyed by module id.
+func (s *ModuleStore) ListMemberIDsByModuleIDs(ctx context.Context, moduleIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	out := make(map[uuid.UUID][]uuid.UUID)
+	if len(moduleIDs) == 0 {
+		return out, nil
+	}
+	var rows []struct {
+		ModuleID uuid.UUID `gorm:"column:module_id"`
+		MemberID uuid.UUID `gorm:"column:member_id"`
+	}
+	err := s.db.WithContext(ctx).Model(&model.ModuleMember{}).
+		Select("module_id, member_id").
+		Where("module_id IN ?", moduleIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.ModuleID] = append(out[r.ModuleID], r.MemberID)
+	}
+	return out, nil
+}
+
 func (s *ModuleStore) CountIssuesByModuleIDs(ctx context.Context, moduleIDs []uuid.UUID) (map[uuid.UUID]int, error) {
 	out := make(map[uuid.UUID]int)
 	if len(moduleIDs) == 0 {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -631,6 +631,7 @@ export interface ModuleApiResponse {
   project_id: string;
   workspace_id: string;
   lead_id?: string | null;
+  member_ids?: string[];
   sort_order?: number;
   issue_count?: number;
   created_at: string;

--- a/apps/web/src/components/CreateModuleModal.tsx
+++ b/apps/web/src/components/CreateModuleModal.tsx
@@ -119,6 +119,8 @@ export function CreateModuleModal({
         status: status || 'backlog',
         start_date: startDate || undefined,
         target_date: endDate || undefined,
+        lead_id: leadId || undefined,
+        member_ids: memberIds.length > 0 ? memberIds : undefined,
       });
       onClose();
       onCreated?.(created);

--- a/apps/web/src/components/UpdateModuleModal.tsx
+++ b/apps/web/src/components/UpdateModuleModal.tsx
@@ -48,10 +48,14 @@ export function UpdateModuleModal({
   const [leadDropdownOpen, setLeadDropdownOpen] = useState(false);
   const [leadSearch, setLeadSearch] = useState('');
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
+  const [memberIds, setMemberIds] = useState<string[]>([]);
+  const [membersDropdownOpen, setMembersDropdownOpen] = useState(false);
+  const [membersSearch, setMembersSearch] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const statusRef = useRef<HTMLDivElement>(null);
   const leadRef = useRef<HTMLDivElement>(null);
+  const membersRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -69,7 +73,10 @@ export function UpdateModuleModal({
     setEndDate(module.target_date ?? null);
     setStatus(module.status ?? 'backlog');
     setLeadId(module.lead_id ?? null);
+    setMemberIds(module.member_ids ?? []);
     setLeadSearch('');
+    setMembersSearch('');
+    setMembersDropdownOpen(false);
     setError(null);
     setDateModalOpen(Boolean(openDatePickerOnOpen));
     setStatusDropdownOpen(false);
@@ -81,8 +88,10 @@ export function UpdateModuleModal({
       const target = e.target as Node;
       if (statusRef.current?.contains(target)) return;
       if (leadRef.current?.contains(target)) return;
+      if (membersRef.current?.contains(target)) return;
       setStatusDropdownOpen(false);
       setLeadDropdownOpen(false);
+      setMembersDropdownOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -93,6 +102,12 @@ export function UpdateModuleModal({
     q(m.member_display_name ?? m.member_email ?? m.member_id).includes(q(leadSearch)),
   );
   const leadMember = leadId ? (members.find((m) => m.member_id === leadId) ?? null) : null;
+  const filteredMembers = members.filter((m) =>
+    q(m.member_display_name ?? m.member_email ?? m.member_id).includes(q(membersSearch)),
+  );
+  const selectedMembers = memberIds
+    .map((id) => members.find((m) => m.member_id === id))
+    .filter((m): m is WorkspaceMemberApiResponse => Boolean(m));
 
   const statusLabel = MODULE_STATUSES.find((s) => s.id === status)?.label ?? status;
 
@@ -108,6 +123,7 @@ export function UpdateModuleModal({
         start_date: startDate ?? '',
         target_date: endDate ?? '',
         lead_id: leadId ?? '',
+        member_ids: memberIds,
       });
       onUpdated?.(updated);
       onClose();
@@ -275,6 +291,79 @@ export function UpdateModuleModal({
                         )}
                       </button>
                     ))}
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="relative" ref={membersRef}>
+              <button
+                type="button"
+                onClick={() => setMembersDropdownOpen((v) => !v)}
+                className="flex items-center gap-2 rounded-md border border-(--border-subtle) bg-(--bg-layer-2) px-2.5 py-1 text-[13px] font-medium text-(--txt-secondary) hover:bg-(--bg-layer-2-hover)"
+              >
+                <span>Members</span>
+                {selectedMembers.length > 0 && (
+                  <span className="flex -space-x-1.5">
+                    {selectedMembers.map((m) => (
+                      <Avatar
+                        key={m.member_id}
+                        name={m.member_display_name ?? m.member_email ?? m.member_id}
+                        src={getImageUrl(m.member_avatar) ?? undefined}
+                        size="sm"
+                        className="h-6 w-6 border-2 border-(--bg-layer-2) text-xs"
+                      />
+                    ))}
+                  </span>
+                )}
+                <span className="text-(--txt-icon-tertiary)" aria-hidden>
+                  ▾
+                </span>
+              </button>
+              {membersDropdownOpen && (
+                <div className="absolute left-0 top-full z-20 mt-1 w-64 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-1.5 shadow-(--shadow-raised)">
+                  <div className="mb-1.5 flex items-center gap-2 rounded border border-(--border-subtle) bg-(--bg-layer-1) px-2 py-1.5">
+                    <span className="text-(--txt-icon-tertiary)" aria-hidden>
+                      🔎
+                    </span>
+                    <input
+                      type="text"
+                      placeholder="Search"
+                      value={membersSearch}
+                      onChange={(e) => setMembersSearch(e.target.value)}
+                      className="min-w-0 flex-1 bg-transparent text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none"
+                    />
+                  </div>
+                  <div className="max-h-48 overflow-y-auto">
+                    {filteredMembers.map((m) => {
+                      const selected = memberIds.includes(m.member_id);
+                      return (
+                        <button
+                          key={m.member_id}
+                          type="button"
+                          onClick={() =>
+                            setMemberIds(
+                              selected
+                                ? memberIds.filter((id) => id !== m.member_id)
+                                : [...memberIds, m.member_id],
+                            )
+                          }
+                          className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+                        >
+                          <span className="flex items-center gap-2 truncate">
+                            <Avatar
+                              name={m.member_display_name ?? m.member_email ?? m.member_id}
+                              src={getImageUrl(m.member_avatar) ?? undefined}
+                              size="sm"
+                              className="h-6 w-6 text-xs"
+                            />
+                            {m.member_display_name?.trim() ??
+                              m.member_email ??
+                              m.member_id.slice(0, 8)}
+                          </span>
+                          {selected && <span className="text-(--txt-icon-tertiary)">✓</span>}
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/apps/web/src/services/moduleService.ts
+++ b/apps/web/src/services/moduleService.ts
@@ -8,6 +8,7 @@ export interface CreateModulePayload {
   start_date?: string;
   target_date?: string;
   lead_id?: string;
+  member_ids?: string[];
 }
 
 export const moduleService = {


### PR DESCRIPTION
## Summary
Closes #182 and #139. Wires the orphaned `module_members` table end-to-end so a module can have a team, and fixes the create-module modal silently dropping the selected lead + members.

## What changed
### API (`apps/api/`)
- `model/module.go`: `ModuleMember` + a computed `member_ids` on `Module`.
- `store/module.go`: `SetMembers` (transactional replace, de-duped), `ListMemberIDs`, `ListMemberIDsByModuleIDs`.
- `service/module.go`: `Create` now accepts a lead + `member_ids`; `Update` accepts `member_ids` (only touched when provided, so other edits preserve members); `Get`/`List` populate `member_ids`.
- `handler/module.go`: binds `lead_id` + `member_ids` on create/update with UUID-validation helpers.

### UI (`apps/web/`)
- **CreateModuleModal** now sends the selected lead + members (previously dropped — #139).
- **UpdateModuleModal** gains a members multi-select.
- `moduleService` payloads + `ModuleApiResponse` carry `member_ids`.

## Test plan
- [x] `TestModule_Members` (create with lead+member → echoed; Get returns; Update clears).
- [x] `npm run validate` green.
- [x] Browser: created a module with a lead + member via the modal — the request body now includes `lead_id` + `member_ids` and returns 201 (previously both were dropped).

## AI assistance
- [x] AI tools were used — tool: Claude Code (Opus 4.8) — and the commit includes a `Co-Authored-By:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning an optional lead and multiple members when creating or updating modules.
  * Module responses now include `member_ids` so member assignments are reflected across the app.
  * The module edit screen now provides a searchable multi-select member picker.
* **Bug Fixes**
  * Improved UUID validation for `lead_id` and `member_ids`, including clearer field-level errors.
  * Member assignments now update correctly when members are cleared or changed.
  * An empty PATCH body is treated as a safe no-op instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->