### PR TITLE
feat(module): add external links to modules

### DIFF
--- a/apps/api/internal/handler/module_link.go
+++ b/apps/api/internal/handler/module_link.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func moduleLinkNotFound(err error) bool {
+	return err == service.ErrModuleNotFound || err == service.ErrProjectForbidden || err == service.ErrProjectNotFound
+}
+
+// moduleCtx parses slug + projectId + moduleId + authenticated user.
+func (h *ModuleHandler) moduleCtx(c *gin.Context) (slug string, projectID, moduleID, userID uuid.UUID, ok bool) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug = c.Param("slug")
+	var err error
+	if projectID, err = uuid.Parse(c.Param("projectId")); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	if moduleID, err = uuid.Parse(c.Param("moduleId")); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid module ID"})
+		return
+	}
+	return slug, projectID, moduleID, user.ID, true
+}
+
+// ListLinks returns a module's external links.
+// GET /api/workspaces/:slug/projects/:projectId/modules/:moduleId/links/
+func (h *ModuleHandler) ListLinks(c *gin.Context) {
+	slug, projectID, moduleID, userID, ok := h.moduleCtx(c)
+	if !ok {
+		return
+	}
+	links, err := h.Module.ListLinks(c.Request.Context(), slug, projectID, moduleID, userID)
+	if err != nil {
+		if moduleLinkNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list links"})
+		return
+	}
+	if links == nil {
+		c.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	c.JSON(http.StatusOK, links)
+}
+
+// CreateLink adds an external link to a module.
+// POST /api/workspaces/:slug/projects/:projectId/modules/:moduleId/links/
+func (h *ModuleHandler) CreateLink(c *gin.Context) {
+	slug, projectID, moduleID, userID, ok := h.moduleCtx(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Title string `json:"title"`
+		URL   string `json:"url" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	l, err := h.Module.CreateLink(c.Request.Context(), slug, projectID, moduleID, userID, body.Title, body.URL)
+	if err != nil {
+		if moduleLinkNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create link"})
+		return
+	}
+	c.JSON(http.StatusCreated, l)
+}
+
+// UpdateLink edits a module link's title or URL.
+// PATCH /api/workspaces/:slug/projects/:projectId/modules/:moduleId/links/:linkId/
+func (h *ModuleHandler) UpdateLink(c *gin.Context) {
+	slug, projectID, moduleID, userID, ok := h.moduleCtx(c)
+	if !ok {
+		return
+	}
+	linkID, err := uuid.Parse(c.Param("linkId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid link ID"})
+		return
+	}
+	var body struct {
+		Title string `json:"title"`
+		URL   string `json:"url"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	l, err := h.Module.UpdateLink(c.Request.Context(), slug, projectID, moduleID, linkID, userID, body.Title, body.URL)
+	if err != nil {
+		if moduleLinkNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update link"})
+		return
+	}
+	c.JSON(http.StatusOK, l)
+}
+
+// DeleteLink removes a module link.
+// DELETE /api/workspaces/:slug/projects/:projectId/modules/:moduleId/links/:linkId/
+func (h *ModuleHandler) DeleteLink(c *gin.Context) {
+	slug, projectID, moduleID, userID, ok := h.moduleCtx(c)
+	if !ok {
+		return
+	}
+	linkID, err := uuid.Parse(c.Param("linkId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid link ID"})
+		return
+	}
+	if err := h.Module.DeleteLink(c.Request.Context(), slug, projectID, moduleID, linkID, userID); err != nil {
+		if moduleLinkNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete link"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/apps/api/internal/handler/module_link_test.go
+++ b/apps/api/internal/handler/module_link_test.go
@@ -1,0 +1,44 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModule_Links(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	modBase := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/modules/"
+
+	rr := ts.POST(modBase, map[string]any{"name": "M"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	id, _ := testutil.MustJSONMap(t, rr)["id"].(string)
+	require.NotEmpty(t, id)
+	links := modBase + id + "/links/"
+
+	// Empty list.
+	rr0 := ts.GET(links, w.Session)
+	require.Equal(t, http.StatusOK, rr0.Code, "body=%s", rr0.Body.String())
+
+	// Create.
+	rr2 := ts.POST(links, map[string]any{"title": "Docs", "url": "https://example.com/"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
+	linkID, _ := testutil.MustJSONMap(t, rr2)["id"].(string)
+	require.NotEmpty(t, linkID)
+	require.Contains(t, rr2.Body.String(), "https://example.com/")
+
+	// List contains it.
+	require.Contains(t, ts.GET(links, w.Session).Body.String(), "Docs")
+
+	// Update.
+	rr3 := ts.PATCH(links+linkID+"/", map[string]any{"title": "Docs v2"}, w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code, "body=%s", rr3.Body.String())
+	require.Contains(t, rr3.Body.String(), "Docs v2")
+
+	// Delete.
+	rr4 := ts.DELETE(links+linkID+"/", w.Session)
+	require.Equal(t, http.StatusNoContent, rr4.Code, "body=%s", rr4.Body.String())
+}

--- a/apps/api/internal/model/module.go
+++ b/apps/api/internal/model/module.go
@@ -57,6 +57,29 @@ func (m *ModuleMember) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
+// ModuleLink matches module_links (external URLs attached to a module).
+type ModuleLink struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Title       string     `gorm:"type:varchar(255);not null" json:"title"`
+	URL         string     `gorm:"type:text;not null" json:"url"`
+	ModuleID    uuid.UUID  `gorm:"type:uuid;not null" json:"module_id"`
+	ProjectID   uuid.UUID  `gorm:"type:uuid;not null" json:"project_id"`
+	WorkspaceID uuid.UUID  `gorm:"type:uuid;not null" json:"workspace_id"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CreatedByID *uuid.UUID `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	UpdatedByID *uuid.UUID `gorm:"type:uuid" json:"updated_by_id,omitempty"`
+}
+
+func (ModuleLink) TableName() string { return "module_links" }
+
+func (m *ModuleLink) BeforeCreate(tx *gorm.DB) error {
+	if m.ID == uuid.Nil {
+		m.ID = uuid.New()
+	}
+	return nil
+}
+
 // ModuleIssue matches module_issues (M2M).
 type ModuleIssue struct {
 	ID          uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -354,6 +354,10 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/modules/:moduleId/issues/", moduleHandler.ListIssues)
 		api.POST("/workspaces/:slug/projects/:projectId/modules/:moduleId/issues/", moduleHandler.AddIssue)
 		api.DELETE("/workspaces/:slug/projects/:projectId/modules/:moduleId/issues/:issueId/", moduleHandler.RemoveIssue)
+		api.GET("/workspaces/:slug/projects/:projectId/modules/:moduleId/links/", moduleHandler.ListLinks)
+		api.POST("/workspaces/:slug/projects/:projectId/modules/:moduleId/links/", moduleHandler.CreateLink)
+		api.PATCH("/workspaces/:slug/projects/:projectId/modules/:moduleId/links/:linkId/", moduleHandler.UpdateLink)
+		api.DELETE("/workspaces/:slug/projects/:projectId/modules/:moduleId/links/:linkId/", moduleHandler.DeleteLink)
 
 		// Epics (is_epic=true issues with dedicated routes)
 		api.GET("/workspaces/:slug/projects/:projectId/epics/", epicHandler.ListEpics)

--- a/apps/api/internal/service/module.go
+++ b/apps/api/internal/service/module.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 var ErrModuleNotFound = errors.New("module not found")
@@ -235,15 +236,31 @@ func (s *ModuleService) CreateLink(ctx context.Context, workspaceSlug string, pr
 	return l, nil
 }
 
+// resolveModuleLink fetches a link and verifies it belongs to the module,
+// distinguishing a missing link (ErrModuleNotFound -> 404) from a real DB error.
+func (s *ModuleService) resolveModuleLink(ctx context.Context, linkID, moduleID uuid.UUID) (*model.ModuleLink, error) {
+	l, err := s.ms.GetLinkByID(ctx, linkID)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrModuleNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if l.ModuleID != moduleID {
+		return nil, ErrModuleNotFound
+	}
+	return l, nil
+}
+
 // UpdateLink edits a module link's title/URL.
 func (s *ModuleService) UpdateLink(ctx context.Context, workspaceSlug string, projectID, moduleID, linkID, userID uuid.UUID, title, url string) (*model.ModuleLink, error) {
 	mod, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
 	if err != nil {
 		return nil, err
 	}
-	l, err := s.ms.GetLinkByID(ctx, linkID)
-	if err != nil || l.ModuleID != mod.ID {
-		return nil, ErrModuleNotFound
+	l, err := s.resolveModuleLink(ctx, linkID, mod.ID)
+	if err != nil {
+		return nil, err
 	}
 	if title != "" {
 		l.Title = title
@@ -264,9 +281,8 @@ func (s *ModuleService) DeleteLink(ctx context.Context, workspaceSlug string, pr
 	if err != nil {
 		return err
 	}
-	l, err := s.ms.GetLinkByID(ctx, linkID)
-	if err != nil || l.ModuleID != mod.ID {
-		return ErrModuleNotFound
+	if _, err := s.resolveModuleLink(ctx, linkID, mod.ID); err != nil {
+		return err
 	}
 	return s.ms.DeleteLink(ctx, linkID)
 }

--- a/apps/api/internal/service/module.go
+++ b/apps/api/internal/service/module.go
@@ -202,6 +202,75 @@ func (s *ModuleService) Delete(ctx context.Context, workspaceSlug string, projec
 	return s.ms.Delete(ctx, moduleID)
 }
 
+// ListLinks returns the module's external links after auth-checking.
+func (s *ModuleService) ListLinks(ctx context.Context, workspaceSlug string, projectID, moduleID, userID uuid.UUID) ([]model.ModuleLink, error) {
+	mod, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	return s.ms.ListLinksForModule(ctx, mod.ID)
+}
+
+// CreateLink attaches an external link to the module.
+func (s *ModuleService) CreateLink(ctx context.Context, workspaceSlug string, projectID, moduleID, userID uuid.UUID, title, url string) (*model.ModuleLink, error) {
+	mod, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if title == "" {
+		title = url
+	}
+	l := &model.ModuleLink{
+		Title:       title,
+		URL:         url,
+		ModuleID:    mod.ID,
+		ProjectID:   mod.ProjectID,
+		WorkspaceID: mod.WorkspaceID,
+		CreatedByID: &userID,
+		UpdatedByID: &userID,
+	}
+	if err := s.ms.CreateLink(ctx, l); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// UpdateLink edits a module link's title/URL.
+func (s *ModuleService) UpdateLink(ctx context.Context, workspaceSlug string, projectID, moduleID, linkID, userID uuid.UUID, title, url string) (*model.ModuleLink, error) {
+	mod, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
+	if err != nil {
+		return nil, err
+	}
+	l, err := s.ms.GetLinkByID(ctx, linkID)
+	if err != nil || l.ModuleID != mod.ID {
+		return nil, ErrModuleNotFound
+	}
+	if title != "" {
+		l.Title = title
+	}
+	if url != "" {
+		l.URL = url
+	}
+	l.UpdatedByID = &userID
+	if err := s.ms.UpdateLink(ctx, l); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// DeleteLink removes a module link.
+func (s *ModuleService) DeleteLink(ctx context.Context, workspaceSlug string, projectID, moduleID, linkID, userID uuid.UUID) error {
+	mod, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
+	if err != nil {
+		return err
+	}
+	l, err := s.ms.GetLinkByID(ctx, linkID)
+	if err != nil || l.ModuleID != mod.ID {
+		return ErrModuleNotFound
+	}
+	return s.ms.DeleteLink(ctx, linkID)
+}
+
 func (s *ModuleService) ListModuleIssueIDs(ctx context.Context, workspaceSlug string, projectID, moduleID uuid.UUID, userID uuid.UUID) ([]uuid.UUID, error) {
 	_, err := s.Get(ctx, workspaceSlug, projectID, moduleID, userID)
 	if err != nil {

--- a/apps/api/internal/store/module.go
+++ b/apps/api/internal/store/module.go
@@ -72,6 +72,35 @@ func (s *ModuleStore) ListModuleIssueIDs(ctx context.Context, moduleID uuid.UUID
 	return ids, nil
 }
 
+// ListLinksForModule returns a module's links, newest first.
+func (s *ModuleStore) ListLinksForModule(ctx context.Context, moduleID uuid.UUID) ([]model.ModuleLink, error) {
+	var list []model.ModuleLink
+	err := s.db.WithContext(ctx).Where("module_id = ?", moduleID).
+		Order("created_at DESC").Find(&list).Error
+	return list, err
+}
+
+func (s *ModuleStore) CreateLink(ctx context.Context, l *model.ModuleLink) error {
+	return s.db.WithContext(ctx).Create(l).Error
+}
+
+func (s *ModuleStore) GetLinkByID(ctx context.Context, linkID uuid.UUID) (*model.ModuleLink, error) {
+	var l model.ModuleLink
+	err := s.db.WithContext(ctx).Where("id = ?", linkID).First(&l).Error
+	if err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+func (s *ModuleStore) UpdateLink(ctx context.Context, l *model.ModuleLink) error {
+	return s.db.WithContext(ctx).Save(l).Error
+}
+
+func (s *ModuleStore) DeleteLink(ctx context.Context, linkID uuid.UUID) error {
+	return s.db.WithContext(ctx).Where("id = ?", linkID).Delete(&model.ModuleLink{}).Error
+}
+
 // SetMembers replaces a module's member set with memberIDs (in a transaction).
 func (s *ModuleStore) SetMembers(ctx context.Context, moduleID uuid.UUID, memberIDs []uuid.UUID, actorID uuid.UUID) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/apps/web/src/components/module-work-items/ModuleLinkModal.tsx
+++ b/apps/web/src/components/module-work-items/ModuleLinkModal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { Modal, Button, Input } from '../ui';
+import type { ModuleLinkApiResponse } from '../../services/moduleService';
+
+interface ModuleLinkModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** When set, the modal edits this link; otherwise it creates a new one. */
+  initial?: ModuleLinkApiResponse | null;
+  onSubmit: (data: { url: string; title: string }, id?: string) => Promise<void>;
+}
+
+/** Add / edit a module link. Mirrors the create-update link modal layout. */
+export function ModuleLinkModal({ open, onClose, initial, onSubmit }: ModuleLinkModalProps) {
+  const [url, setUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setUrl(initial?.url ?? '');
+      setTitle(initial?.title ?? '');
+    }
+  }, [open, initial]);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed || submitting) return;
+    const parsed = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+    setSubmitting(true);
+    try {
+      await onSubmit({ url: parsed, title: title.trim() }, initial?.id);
+      onClose();
+    } catch {
+      // surfaced by the caller
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title={initial ? 'Update link' : 'Add link'}>
+      <form onSubmit={submit} className="space-y-4">
+        <Input
+          label="URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="Type or paste a URL"
+          autoFocus
+        />
+        <Input
+          label="Display title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="What you'd like to see this link as"
+        />
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" disabled={!url.trim() || submitting}>
+            {initial ? 'Update link' : 'Add link'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/module-work-items/ModuleLinksSection.tsx
+++ b/apps/web/src/components/module-work-items/ModuleLinksSection.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { Trash2, Plus, LinkIcon } from 'lucide-react';
+import { Copy, Pencil, Trash2, Link as LinkIcon, Plus } from 'lucide-react';
 import { moduleService, type ModuleLinkApiResponse } from '../../services/moduleService';
 import { safeUrl } from '../../lib/sanitize';
+import { ModuleLinkModal } from './ModuleLinkModal';
 
 interface ModuleLinksSectionProps {
   workspaceSlug: string;
@@ -9,10 +10,51 @@ interface ModuleLinksSectionProps {
   moduleId: string;
 }
 
+function timeAgo(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  const sec = Math.max(1, Math.floor((Date.now() - t) / 1000));
+  const units: [number, string][] = [
+    [31536000, 'year'],
+    [2592000, 'month'],
+    [604800, 'week'],
+    [86400, 'day'],
+    [3600, 'hour'],
+    [60, 'minute'],
+  ];
+  for (const [s, label] of units) {
+    const v = Math.floor(sec / s);
+    if (v >= 1) return `${v} ${label}${v > 1 ? 's' : ''} ago`;
+  }
+  return 'just now';
+}
+
+/** Small favicon for a link, falling back to a generic icon. */
+function LinkFavicon({ url }: { url: string }) {
+  const [failed, setFailed] = useState(false);
+  let host = '';
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    host = '';
+  }
+  if (failed || !host) {
+    return <LinkIcon className="size-3.5 shrink-0 text-(--txt-icon-tertiary)" />;
+  }
+  return (
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`}
+      alt=""
+      className="size-3.5 shrink-0 rounded-sm"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 /**
- * Self-contained "Links" panel for a module: lists external links and lets the
- * user add or remove them. Fetches its own data so it can drop into the module
- * detail page without threading state through the parent.
+ * "Links" panel for a module: a list of link cards (favicon + title, with copy /
+ * edit / delete on hover and an "added … ago" line) plus an add button that
+ * opens the create/edit modal. Fetches its own data.
  */
 export function ModuleLinksSection({
   workspaceSlug,
@@ -20,9 +62,8 @@ export function ModuleLinksSection({
   moduleId,
 }: ModuleLinksSectionProps) {
   const [links, setLinks] = useState<ModuleLinkApiResponse[]>([]);
-  const [url, setUrl] = useState('');
-  const [title, setTitle] = useState('');
-  const [busy, setBusy] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ModuleLinkApiResponse | null>(null);
 
   const load = () => {
     moduleService
@@ -46,24 +87,13 @@ export function ModuleLinksSection({
     };
   }, [workspaceSlug, projectId, moduleId]);
 
-  const add = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const trimmed = url.trim();
-    if (!trimmed || busy) return;
-    setBusy(true);
-    try {
-      await moduleService.createLink(workspaceSlug, projectId, moduleId, {
-        url: trimmed,
-        title: title.trim() || undefined,
-      });
-      setUrl('');
-      setTitle('');
-      load();
-    } catch {
-      // best-effort
-    } finally {
-      setBusy(false);
+  const submit = async (data: { url: string; title: string }, id?: string) => {
+    if (id) {
+      await moduleService.updateLink(workspaceSlug, projectId, moduleId, id, data);
+    } else {
+      await moduleService.createLink(workspaceSlug, projectId, moduleId, data);
     }
+    load();
   };
 
   const remove = async (id: string) => {
@@ -75,64 +105,96 @@ export function ModuleLinksSection({
     }
   };
 
+  const copy = (url: string) => {
+    void navigator.clipboard?.writeText(url);
+  };
+
+  const actionBtn =
+    'grid place-items-center rounded-sm p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover)';
+
   return (
     <section className="space-y-2">
-      <h3 className="flex items-center gap-1.5 text-sm font-medium text-(--txt-secondary)">
-        <LinkIcon className="h-3.5 w-3.5" />
-        Links
-      </h3>
-      {links.length > 0 && (
-        <ul className="space-y-1">
-          {links.map((l) => (
-            <li
-              key={l.id}
-              className="group flex items-center justify-between gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5"
-            >
-              <a
-                href={safeUrl(l.url)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="truncate text-sm text-(--txt-accent-primary) hover:underline"
-                title={l.url}
-              >
-                {l.title || l.url}
-              </a>
-              <button
-                type="button"
-                onClick={() => void remove(l.id)}
-                className="shrink-0 text-(--txt-icon-tertiary) opacity-0 transition-opacity group-hover:opacity-100 hover:text-(--txt-danger-primary)"
-                aria-label="Remove link"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-      <form onSubmit={add} className="flex items-center gap-2">
-        <input
-          type="url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://…"
-          className="min-w-0 flex-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:ring-1 focus:ring-(--border-focus)"
-        />
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Title (optional)"
-          className="w-32 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:ring-1 focus:ring-(--border-focus)"
-        />
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-(--txt-secondary)">Links</h3>
         <button
-          type="submit"
-          disabled={!url.trim() || busy}
-          className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) disabled:opacity-50"
+          type="button"
+          aria-label="Add link"
+          onClick={() => {
+            setEditing(null);
+            setModalOpen(true);
+          }}
+          className="grid place-items-center rounded-sm p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
         >
-          <Plus className="h-3.5 w-3.5" />
-          Add
+          <Plus className="size-4" />
         </button>
-      </form>
+      </div>
+
+      {links.length > 0 && (
+        <div className="space-y-2">
+          {links.map((l) => (
+            <div
+              key={l.id}
+              className="group relative flex flex-col rounded-(--radius-md) bg-(--bg-layer-2) p-2.5"
+            >
+              <div className="flex w-full items-start justify-between gap-2">
+                <div className="flex min-w-0 items-start gap-2">
+                  <span className="py-0.5">
+                    <LinkFavicon url={l.url} />
+                  </span>
+                  <a
+                    href={safeUrl(l.url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={l.title || l.url}
+                    className="truncate text-[11px] text-(--txt-accent-primary) hover:underline"
+                  >
+                    {l.title || l.url}
+                  </a>
+                </div>
+                <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100">
+                  <button
+                    type="button"
+                    aria-label="Edit link"
+                    className={actionBtn}
+                    onClick={() => {
+                      setEditing(l);
+                      setModalOpen(true);
+                    }}
+                  >
+                    <Pencil className="size-3" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Copy link"
+                    className={actionBtn}
+                    onClick={() => copy(l.url)}
+                  >
+                    <Copy className="size-3" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Remove link"
+                    className="grid place-items-center rounded-sm p-1 text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-danger-primary)"
+                    onClick={() => void remove(l.id)}
+                  >
+                    <Trash2 className="size-3" />
+                  </button>
+                </div>
+              </div>
+              <p className="mt-0.5 pl-5 text-[11px] text-(--txt-tertiary)">
+                Added {timeAgo(l.created_at)}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ModuleLinkModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        initial={editing}
+        onSubmit={submit}
+      />
     </section>
   );
 }

--- a/apps/web/src/components/module-work-items/ModuleLinksSection.tsx
+++ b/apps/web/src/components/module-work-items/ModuleLinksSection.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { Trash2, Plus, LinkIcon } from 'lucide-react';
+import { moduleService, type ModuleLinkApiResponse } from '../../services/moduleService';
+import { safeUrl } from '../../lib/sanitize';
+
+interface ModuleLinksSectionProps {
+  workspaceSlug: string;
+  projectId: string;
+  moduleId: string;
+}
+
+/**
+ * Self-contained "Links" panel for a module: lists external links and lets the
+ * user add or remove them. Fetches its own data so it can drop into the module
+ * detail page without threading state through the parent.
+ */
+export function ModuleLinksSection({
+  workspaceSlug,
+  projectId,
+  moduleId,
+}: ModuleLinksSectionProps) {
+  const [links, setLinks] = useState<ModuleLinkApiResponse[]>([]);
+  const [url, setUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const load = () => {
+    moduleService
+      .listLinks(workspaceSlug, projectId, moduleId)
+      .then(setLinks)
+      .catch(() => setLinks([]));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    moduleService
+      .listLinks(workspaceSlug, projectId, moduleId)
+      .then((l) => {
+        if (!cancelled) setLinks(l);
+      })
+      .catch(() => {
+        if (!cancelled) setLinks([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId, moduleId]);
+
+  const add = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed || busy) return;
+    setBusy(true);
+    try {
+      await moduleService.createLink(workspaceSlug, projectId, moduleId, {
+        url: trimmed,
+        title: title.trim() || undefined,
+      });
+      setUrl('');
+      setTitle('');
+      load();
+    } catch {
+      // best-effort
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await moduleService.deleteLink(workspaceSlug, projectId, moduleId, id);
+      load();
+    } catch {
+      // best-effort
+    }
+  };
+
+  return (
+    <section className="space-y-2">
+      <h3 className="flex items-center gap-1.5 text-sm font-medium text-(--txt-secondary)">
+        <LinkIcon className="h-3.5 w-3.5" />
+        Links
+      </h3>
+      {links.length > 0 && (
+        <ul className="space-y-1">
+          {links.map((l) => (
+            <li
+              key={l.id}
+              className="group flex items-center justify-between gap-2 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2.5 py-1.5"
+            >
+              <a
+                href={safeUrl(l.url)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="truncate text-sm text-(--txt-accent-primary) hover:underline"
+                title={l.url}
+              >
+                {l.title || l.url}
+              </a>
+              <button
+                type="button"
+                onClick={() => void remove(l.id)}
+                className="shrink-0 text-(--txt-icon-tertiary) opacity-0 transition-opacity group-hover:opacity-100 hover:text-(--txt-danger-primary)"
+                aria-label="Remove link"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <form onSubmit={add} className="flex items-center gap-2">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://…"
+          className="min-w-0 flex-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:ring-1 focus:ring-(--border-focus)"
+        />
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title (optional)"
+          className="w-32 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-2 py-1 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:ring-1 focus:ring-(--border-focus)"
+        />
+        <button
+          type="submit"
+          disabled={!url.trim() || busy}
+          className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) hover:bg-(--bg-layer-1-hover) disabled:opacity-50"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/components/module-work-items/ModuleLinksSection.tsx
+++ b/apps/web/src/components/module-work-items/ModuleLinksSection.tsx
@@ -151,7 +151,7 @@ export function ModuleLinksSection({
                     {l.title || l.url}
                   </a>
                 </div>
-                <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100">
+                <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                   <button
                     type="button"
                     aria-label="Edit link"

--- a/apps/web/src/pages/ModuleDetailPage.tsx
+++ b/apps/web/src/pages/ModuleDetailPage.tsx
@@ -23,6 +23,7 @@ import type {
 import type { Priority } from '../types';
 import type { SavedViewDisplayPropertyId } from '../lib/projectSavedViewDisplay';
 import { getImageUrl } from '../lib/utils';
+import { ModuleLinksSection } from '../components/module-work-items/ModuleLinksSection';
 import { slugify } from '../lib/slug';
 import { buildGroupedIssues } from '../lib/issueListGroupAndSort';
 import {
@@ -650,6 +651,13 @@ export function ModuleDetailPage() {
 
   return (
     <div className="flex flex-col gap-6">
+      {workspaceSlug && projectId && moduleId && (
+        <ModuleLinksSection
+          workspaceSlug={workspaceSlug}
+          projectId={projectId}
+          moduleId={moduleId}
+        />
+      )}
       {issues.length === 0 && (
         <section className="space-y-4">
           <div>

--- a/apps/web/src/pages/ModuleDetailPage.tsx
+++ b/apps/web/src/pages/ModuleDetailPage.tsx
@@ -651,11 +651,11 @@ export function ModuleDetailPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      {workspaceSlug && projectId && moduleId && (
+      {workspaceSlug && projectId && resolvedModuleId && (
         <ModuleLinksSection
           workspaceSlug={workspaceSlug}
           projectId={projectId}
-          moduleId={moduleId}
+          moduleId={resolvedModuleId}
         />
       )}
       {issues.length === 0 && (

--- a/apps/web/src/services/moduleService.ts
+++ b/apps/web/src/services/moduleService.ts
@@ -121,6 +121,20 @@ export const moduleService = {
     return data;
   },
 
+  async updateLink(
+    workspaceSlug: string,
+    projectId: string,
+    moduleId: string,
+    linkId: string,
+    payload: { url?: string; title?: string },
+  ): Promise<ModuleLinkApiResponse> {
+    const { data } = await apiClient.patch<ModuleLinkApiResponse>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/links/${encodeURIComponent(linkId)}/`,
+      payload,
+    );
+    return data;
+  },
+
   async deleteLink(
     workspaceSlug: string,
     projectId: string,

--- a/apps/web/src/services/moduleService.ts
+++ b/apps/web/src/services/moduleService.ts
@@ -1,6 +1,14 @@
 import { apiClient } from '../api/client';
 import type { ModuleApiResponse } from '../api/types';
 
+export interface ModuleLinkApiResponse {
+  id: string;
+  title: string;
+  url: string;
+  module_id: string;
+  created_at: string;
+}
+
 export interface CreateModulePayload {
   name: string;
   description?: string;
@@ -86,6 +94,41 @@ export const moduleService = {
   ): Promise<void> {
     await apiClient.delete(
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/issues/${encodeURIComponent(issueId)}/`,
+    );
+  },
+
+  async listLinks(
+    workspaceSlug: string,
+    projectId: string,
+    moduleId: string,
+  ): Promise<ModuleLinkApiResponse[]> {
+    const { data } = await apiClient.get<ModuleLinkApiResponse[]>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/links/`,
+    );
+    return Array.isArray(data) ? data : [];
+  },
+
+  async createLink(
+    workspaceSlug: string,
+    projectId: string,
+    moduleId: string,
+    payload: { url: string; title?: string },
+  ): Promise<ModuleLinkApiResponse> {
+    const { data } = await apiClient.post<ModuleLinkApiResponse>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/links/`,
+      payload,
+    );
+    return data;
+  },
+
+  async deleteLink(
+    workspaceSlug: string,
+    projectId: string,
+    moduleId: string,
+    linkId: string,
+  ): Promise<void> {
+    await apiClient.delete(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/modules/${encodeURIComponent(moduleId)}/links/${encodeURIComponent(linkId)}/`,
     );
   },
 };


### PR DESCRIPTION
## Summary
Closes #183. Wires the orphaned `module_links` table end-to-end so external links can be attached to a module (mirrors the existing issue-links feature).

## What changed
### API (`apps/api/`)
- `model/module.go`: `ModuleLink`.
- `store/module.go`: `ListLinksForModule` / `CreateLink` / `GetLinkByID` / `UpdateLink` / `DeleteLink`.
- `service/module.go`: `ListLinks` / `CreateLink` / `UpdateLink` / `DeleteLink` (auth-checked; link verified to belong to the module).
- routes: `GET`/`POST .../modules/:moduleId/links/`, `PATCH`/`DELETE .../modules/:moduleId/links/:linkId/`.

### UI (`apps/web/`)
- `moduleService` link methods + `ModuleLinkApiResponse`.
- `ModuleLinksSection` — a self-contained list/add/remove panel mounted on the module detail page.

## Test plan
- [x] `TestModule_Links` (list empty → create → list → update → delete).
- [x] `npm run validate` green.
- [x] Browser: opened a module, added a link via the section — it rendered and persisted (`GET .../links/` returns it).

## AI assistance
- [x] AI tools were used — tool: Claude Code (Opus 4.8) — and the commit includes a `Co-Authored-By:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added module external links support to view, create, edit, and remove links.
  * Introduced a “Links” section on the module detail page with add/edit in a modal, plus quick actions to copy or remove.
* **Bug Fixes**
  * Improved robustness for empty link results and input validation/error handling across link operations.
  * Kept link actions protected and scoped to the correct module context.
* **Tests**
  * Added API coverage for listing, creating, updating, and deleting module links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->