### PR TITLE
feat(web): set per-route browser tab titles

### DIFF
--- a/apps/web/src/hooks/useDocumentTitle.ts
+++ b/apps/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+/** App name shown as the browser tab title suffix. */
+export const APP_NAME = 'Devlane';
+
+/** Builds a tab title of the form `"<title> — Devlane"`, or just the app name. */
+export function formatDocumentTitle(title?: string | null): string {
+  const trimmed = title?.trim();
+  return trimmed ? `${trimmed} — ${APP_NAME}` : APP_NAME;
+}
+
+/**
+ * Sets `document.title` to `"<title> — Devlane"` while the calling page is
+ * mounted, falling back to just "Devlane" when no title is given. The title is
+ * recomputed whenever `title` changes, so detail pages can pass a value that
+ * arrives asynchronously (e.g. once the work item or project has loaded).
+ */
+export function useDocumentTitle(title?: string | null): void {
+  useEffect(() => {
+    document.title = formatDocumentTitle(title);
+  }, [title]);
+}

--- a/apps/web/src/pages/AnalyticsOverviewPage.tsx
+++ b/apps/web/src/pages/AnalyticsOverviewPage.tsx
@@ -11,6 +11,7 @@ import {
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
 import { issueService } from '../services/issueService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -25,6 +26,8 @@ export function AnalyticsOverviewPage() {
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
+
+  useDocumentTitle('Analytics');
 
   useEffect(() => {
     if (!workspaceSlug) {

--- a/apps/web/src/pages/AnalyticsWorkItemsPage.tsx
+++ b/apps/web/src/pages/AnalyticsWorkItemsPage.tsx
@@ -15,6 +15,7 @@ import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
 import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -101,6 +102,8 @@ export function AnalyticsWorkItemsPage() {
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
+
+  useDocumentTitle('Analytics');
 
   useEffect(() => {
     if (!workspaceSlug) {

--- a/apps/web/src/pages/ArchivesPage.tsx
+++ b/apps/web/src/pages/ArchivesPage.tsx
@@ -1,7 +1,9 @@
 import { useParams } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 export function ArchivesPage() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+  useDocumentTitle('Archives');
   return (
     <div className="mx-auto max-w-4xl space-y-6 pb-8">
       <h1 className="text-2xl font-semibold text-(--txt-primary)">Archives</h1>

--- a/apps/web/src/pages/BoardPage.tsx
+++ b/apps/web/src/pages/BoardPage.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useParams } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 /**
  * Legacy `/board` route. The kanban now renders inside the issues page via
@@ -10,6 +11,7 @@ export function BoardPage() {
     workspaceSlug: string;
     projectId: string;
   }>();
+  useDocumentTitle('Board');
   if (!workspaceSlug || !projectId) {
     return <Navigate to="/" replace />;
   }

--- a/apps/web/src/pages/CreateWorkspacePage.tsx
+++ b/apps/web/src/pages/CreateWorkspacePage.tsx
@@ -6,6 +6,7 @@ import { workspaceService } from '../services/workspaceService';
 import { getApiErrorMessage } from '../api/client';
 import { slugFromName, validateWorkspaceSlug } from '../utils/workspace';
 import { ORGANIZATION_SIZE_OPTIONS } from '../constants/workspace';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 const IconChevronDown = () => (
   <svg
@@ -31,6 +32,8 @@ export function CreateWorkspacePage() {
   const [organizationSize, setOrganizationSize] = useState('');
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useDocumentTitle('Create workspace');
 
   const baseUrl = typeof window !== 'undefined' ? `${window.location.origin}/` : '';
 

--- a/apps/web/src/pages/CycleDetailPage.tsx
+++ b/apps/web/src/pages/CycleDetailPage.tsx
@@ -7,6 +7,7 @@ import { cycleService, type CycleProgressResponse } from '../services/cycleServi
 import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
 import { cycleMatchesPathSegment } from '../lib/cycle';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   CycleApiResponse,
   IssueApiResponse,
@@ -109,6 +110,8 @@ export function CycleDetailPage() {
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [progress, setProgress] = useState<CycleProgressResponse | null>(null);
+
+  useDocumentTitle(cycle?.name ?? 'Cycle');
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !cycleId) return;

--- a/apps/web/src/pages/CycleDetailPage.tsx
+++ b/apps/web/src/pages/CycleDetailPage.tsx
@@ -111,7 +111,7 @@ export function CycleDetailPage() {
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [progress, setProgress] = useState<CycleProgressResponse | null>(null);
 
-  useDocumentTitle(cycle?.name ?? 'Cycle');
+  useDocumentTitle(loading ? 'Cycle' : (cycle?.name ?? 'Cycle'));
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !cycleId) return;

--- a/apps/web/src/pages/CyclesPage.tsx
+++ b/apps/web/src/pages/CyclesPage.tsx
@@ -26,6 +26,7 @@ import { useCycleFavorites } from '../hooks/useCycleFavorites';
 import { parseISODateForDisplay, parseISODateLocal } from '../lib/dateOnly';
 import { cyclePathSegment } from '../lib/cycle';
 import { cn, getImageUrl } from '../lib/utils';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
@@ -335,6 +336,7 @@ export function CyclesPage() {
     dueAfter: null,
     dueBefore: null,
   });
+  useDocumentTitle('Cycles');
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) {

--- a/apps/web/src/pages/DraftsPage.tsx
+++ b/apps/web/src/pages/DraftsPage.tsx
@@ -11,6 +11,7 @@ import { cycleService } from '../services/cycleService';
 import { moduleService } from '../services/moduleService';
 import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -110,6 +111,8 @@ export function DraftsPage() {
   const [rowBusy, setRowBusy] = useState<string | null>(null);
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [propDropdownId, setPropDropdownId] = useState<string | null>(null);
+
+  useDocumentTitle('Drafts');
 
   const projectById = useMemo(() => {
     const m = new Map<string, ProjectApiResponse>();

--- a/apps/web/src/pages/EpicDetailPage.tsx
+++ b/apps/web/src/pages/EpicDetailPage.tsx
@@ -8,6 +8,7 @@ import { EpicProgressBar } from '../components/work-item/EpicProgressBar';
 import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
 import { safeUrl } from '../lib/sanitize';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   IssueLinkApiResponse,
   IssueApiResponse,
@@ -47,6 +48,8 @@ export function EpicDetailPage() {
   const [addLinkUrl, setAddLinkUrl] = useState('');
   const [addLinkTitle, setAddLinkTitle] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  useDocumentTitle(epic?.name ?? 'Epic');
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !epicId) return;

--- a/apps/web/src/pages/EpicDetailPage.tsx
+++ b/apps/web/src/pages/EpicDetailPage.tsx
@@ -49,7 +49,7 @@ export function EpicDetailPage() {
   const [addLinkTitle, setAddLinkTitle] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useDocumentTitle(epic?.name ?? 'Epic');
+  useDocumentTitle(loading ? 'Epic' : (epic?.name ?? 'Epic'));
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !epicId) return;

--- a/apps/web/src/pages/EpicsPage.tsx
+++ b/apps/web/src/pages/EpicsPage.tsx
@@ -6,6 +6,7 @@ import { projectService } from '../services/projectService';
 import { epicService, type EpicProgress } from '../services/epicService';
 import { stateService } from '../services/stateService';
 import { EpicProgressBar } from '../components/work-item/EpicProgressBar';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   IssueApiResponse,
   ProjectApiResponse,
@@ -25,6 +26,7 @@ export function EpicsPage() {
   const [createName, setCreateName] = useState('');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  useDocumentTitle('Epics');
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) return;

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -5,6 +5,7 @@ import { authService } from '../services/authService';
 import { getApiErrorMessage } from '../api/client';
 import { CircleAlert, CircleCheck, ArrowLeft } from 'lucide-react';
 import { AuthPageShell } from '../components/auth/AuthPageShell';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 const RESEND_COOLDOWN_SECONDS = 30;
 
@@ -17,6 +18,8 @@ export function ForgotPasswordPage() {
   const [success, setSuccess] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [cooldown, setCooldown] = useState(0);
+
+  useDocumentTitle('Forgot password');
 
   useEffect(() => {
     if (cooldown <= 0) return;

--- a/apps/web/src/pages/IntakePage.tsx
+++ b/apps/web/src/pages/IntakePage.tsx
@@ -4,6 +4,7 @@ import { Badge } from '../components/ui';
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
 import { issueService } from '../services/issueService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type { IssueApiResponse, ProjectApiResponse, WorkspaceApiResponse } from '../api/types';
 import type { Priority } from '../types';
 
@@ -24,6 +25,7 @@ export function IntakePage() {
   const [error, setError] = useState<string | null>(null);
   const [accepting, setAccepting] = useState<string | null>(null);
   const [discarding, setDiscarding] = useState<string | null>(null);
+  useDocumentTitle('Intake');
 
   useEffect(() => {
     if (!workspaceSlug || !projectId) return;

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, Button } from '../components/ui';
 import { useAuth } from '../contexts/AuthContext';
 import { invitationService } from '../services/invitationService';
 import { workspaceService } from '../services/workspaceService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 const IconCheck = () => (
   <svg
@@ -109,6 +110,8 @@ export function InviteAcceptPage() {
   const [step, setStep] = useState<'invite' | 'join'>('invite');
   const [joinEmail, setJoinEmail] = useState('');
   const autoAcceptDone = useRef(false);
+
+  useDocumentTitle('Accept invite');
 
   useEffect(() => {
     if (!token.trim()) {

--- a/apps/web/src/pages/InviteSignUpPage.tsx
+++ b/apps/web/src/pages/InviteSignUpPage.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, Button } from '../components/ui';
 import { useAuth } from '../contexts/AuthContext';
 import { authService } from '../services/authService';
 import { workspaceService } from '../services/workspaceService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 const IconGlobe = () => (
   <svg
@@ -134,6 +135,8 @@ export function InviteSignUpPage() {
   const req = usePasswordRequirements(password);
   const allMet = req.minLength && req.upper && req.lower && req.number && req.special;
   const passwordsMatch = password === confirmPassword && confirmPassword.length > 0;
+
+  useDocumentTitle('Sign up');
 
   useEffect(() => {
     if (!email || !token) {

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -28,6 +28,7 @@ import {
 } from '../components/work-item/IssueRowCells';
 import { membersFromAssigneeIds } from '../lib/issueRowHelpers';
 import { getImageUrl } from '../lib/utils';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -318,6 +319,8 @@ export function IssueDetailPage() {
   // Attachments
   const [attachments, setAttachments] = useState<IssueAttachmentApiResponse[]>([]);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
+
+  useDocumentTitle(issue?.name ?? 'Work item');
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !issueId) {

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -320,7 +320,7 @@ export function IssueDetailPage() {
   const [attachments, setAttachments] = useState<IssueAttachmentApiResponse[]>([]);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
 
-  useDocumentTitle(issue?.name ?? 'Work item');
+  useDocumentTitle(loading ? 'Work item' : (issue?.name ?? 'Work item'));
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !issueId) {

--- a/apps/web/src/pages/IssueListPage.tsx
+++ b/apps/web/src/pages/IssueListPage.tsx
@@ -44,6 +44,7 @@ import {
   type ProjectIssuesFiltersState,
 } from '../lib/projectIssuesEvents';
 import { normalizeUuidKey } from '../lib/utils';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 function issueMentionSearchBlob(issue: IssueApiResponse): string {
   const parts: string[] = [];
@@ -109,6 +110,7 @@ export function IssueListPage() {
   const [listDisplay, setListDisplay] = useState<ProjectIssuesDisplayState>(() =>
     cloneDefaultProjectIssuesDisplay(),
   );
+  useDocumentTitle('Work items');
 
   const refetchIssues = () => {
     if (!workspaceSlug || !projectId) return;

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import { authService } from '../services/authService';
 import { API_BASE, getApiErrorMessage } from '../api/client';
 import { Eye, EyeOff, CircleAlert } from 'lucide-react';
 import { AuthPageShell } from '../components/auth/AuthPageShell';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 type AuthStep = 'email' | 'password' | 'code';
 type AuthMode = 'sign-in' | 'sign-up';
@@ -49,6 +50,8 @@ export function LoginPage() {
     github: false,
     gitlab: false,
   });
+
+  useDocumentTitle('Sign in');
 
   useEffect(() => {
     if (oauthError) {

--- a/apps/web/src/pages/ModuleDetailPage.tsx
+++ b/apps/web/src/pages/ModuleDetailPage.tsx
@@ -41,6 +41,7 @@ import {
   type ModuleWorkItemsFiltersState,
 } from '../lib/moduleWorkItemsPrefs';
 import { applyModuleSubWorkFilter, filterModuleIssues } from '../lib/moduleWorkItemsApply';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 const priorityVariant: Record<Priority, 'danger' | 'warning' | 'default' | 'neutral'> = {
   urgent: 'danger',
@@ -203,6 +204,8 @@ export function ModuleDetailPage() {
   const [listDisplay, setListDisplay] = useState<ProjectIssuesDisplayState>(() =>
     cloneDefaultProjectIssuesDisplay(),
   );
+
+  useDocumentTitle(module?.name ?? 'Module');
 
   const createParam = searchParams.get('create') === '1';
 

--- a/apps/web/src/pages/ModuleDetailPage.tsx
+++ b/apps/web/src/pages/ModuleDetailPage.tsx
@@ -205,7 +205,7 @@ export function ModuleDetailPage() {
     cloneDefaultProjectIssuesDisplay(),
   );
 
-  useDocumentTitle(module?.name ?? 'Module');
+  useDocumentTitle(loading ? 'Module' : (module?.name ?? 'Module'));
 
   const createParam = searchParams.get('create') === '1';
 

--- a/apps/web/src/pages/ModulesPage.tsx
+++ b/apps/web/src/pages/ModulesPage.tsx
@@ -18,6 +18,7 @@ import { findWorkspaceMemberByUserId, getImageUrl } from '../lib/utils';
 import { slugify } from '../lib/slug';
 import { parseISODateLocal } from '../lib/dateOnly';
 import { MODULE_STATUSES } from '../lib/moduleStatuses';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
@@ -179,6 +180,7 @@ export function ModulesPage() {
     workspaceSlug,
     projectId,
   );
+  useDocumentTitle('Modules');
 
   const searchQuery = (filter.search ?? '').trim().toLowerCase();
   const favoritesFilter = filter.favorites;

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -6,6 +6,7 @@ import { workspaceService } from '../services/workspaceService';
 import { notificationService } from '../services/notificationService';
 import { NotificationContent } from '../components/notifications/NotificationContent';
 import { SnoozeMenu } from '../components/notifications/SnoozeMenu';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type { WorkspaceApiResponse, NotificationApiResponse } from '../api/types';
 
 type InboxTab = 'all' | 'mentions' | 'archived';
@@ -53,6 +54,8 @@ export function NotificationsPage() {
   // IDs the user explicitly marked unread in this session; the auto-mark-read
   // effect below skips them so the toggle actually sticks.
   const [explicitUnreadIds, setExplicitUnreadIds] = useState<Set<string>>(new Set());
+
+  useDocumentTitle('Inbox');
 
   useEffect(() => {
     if (!workspaceSlug) {

--- a/apps/web/src/pages/PageDetailPage.tsx
+++ b/apps/web/src/pages/PageDetailPage.tsx
@@ -32,6 +32,7 @@ import { projectService } from '../services/projectService';
 import { pageService } from '../services/pageService';
 import { cn } from '../lib/utils';
 import { sanitizeHtml } from '../lib/sanitize';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   PageApiResponse,
   PageVersionApiResponse,
@@ -82,6 +83,8 @@ export function PageDetailPage() {
   const [page, setPage] = useState<PageApiResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+
+  useDocumentTitle(page?.name ?? 'Page');
 
   const [titleInput, setTitleInput] = useState('');
   const [titleStatus, setTitleStatus] = useState<SaveStatus>({ kind: 'idle' });

--- a/apps/web/src/pages/PageDetailPage.tsx
+++ b/apps/web/src/pages/PageDetailPage.tsx
@@ -84,7 +84,7 @@ export function PageDetailPage() {
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
 
-  useDocumentTitle(page?.name ?? 'Page');
+  useDocumentTitle(loading ? 'Page' : (page?.name ?? 'Page'));
 
   const [titleInput, setTitleInput] = useState('');
   const [titleStatus, setTitleStatus] = useState<SaveStatus>({ kind: 'idle' });

--- a/apps/web/src/pages/PagesPage.tsx
+++ b/apps/web/src/pages/PagesPage.tsx
@@ -27,6 +27,7 @@ import { pageService } from '../services/pageService';
 import { useAuth } from '../contexts/AuthContext';
 import { cn, getImageUrl } from '../lib/utils';
 import { PROJECT_PAGES_CREATE_EVENT } from '../lib/projectPagesEvents';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   PageApiResponse,
   ProjectApiResponse,
@@ -99,6 +100,7 @@ export function PagesPage() {
   const filterRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  useDocumentTitle('Pages');
 
   // ----- Initial load ------------------------------------------------------
   useEffect(() => {

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -7,6 +7,7 @@ import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
 import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -105,6 +106,8 @@ export function ProfilePage() {
     if (userId && user?.id === userId) return user;
     return user ?? null; // Only current user supported until user-by-id API exists
   }, [userId, user]);
+
+  useDocumentTitle(profileUser?.name ?? 'Profile');
 
   const member = profileUser ? (members.find((m) => m.member_id === profileUser.id) ?? null) : null;
   const joinedAt = member?.created_at ?? new Date().toISOString();

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -107,7 +107,7 @@ export function ProfilePage() {
     return user ?? null; // Only current user supported until user-by-id API exists
   }, [userId, user]);
 
-  useDocumentTitle(profileUser?.name ?? 'Profile');
+  useDocumentTitle(loading ? 'Profile' : (profileUser?.name ?? 'Profile'));
 
   const member = profileUser ? (members.find((m) => m.member_id === profileUser.id) ?? null) : null;
   const joinedAt = member?.created_at ?? new Date().toISOString();

--- a/apps/web/src/pages/ProjectsListPage.tsx
+++ b/apps/web/src/pages/ProjectsListPage.tsx
@@ -11,6 +11,7 @@ import { useFavorites } from '../contexts/FavoritesContext';
 import { useAuth } from '../contexts/AuthContext';
 import { parseISODateLocal } from '../lib/dateOnly';
 import { parseProjectsListSearchParams } from '../lib/projectsListSearchParams';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type { WorkspaceApiResponse, ProjectApiResponse } from '../api/types';
 
 const MAX_AVATARS = 3;
@@ -81,6 +82,9 @@ export function ProjectsListPage() {
     {},
   );
   const [loading, setLoading] = useState(true);
+
+  useDocumentTitle('Projects');
+
   const createProjectOpen = searchParams.get('createProject') === '1';
 
   const closeCreateModal = () => {

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -5,6 +5,7 @@ import { authService } from '../services/authService';
 import { Eye, EyeOff, CircleAlert, CircleCheck } from 'lucide-react';
 import { AuthPageShell } from '../components/auth/AuthPageShell';
 import { getApiErrorMessage } from '../api/client';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 interface PasswordCriteria {
   minLength: boolean;
@@ -75,6 +76,8 @@ export function ResetPasswordPage() {
     () => confirmPassword.length > 0 && password === confirmPassword,
     [password, confirmPassword],
   );
+
+  useDocumentTitle('Reset password');
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {

--- a/apps/web/src/pages/SetPasswordPage.tsx
+++ b/apps/web/src/pages/SetPasswordPage.tsx
@@ -6,6 +6,7 @@ import { authService } from '../services/authService';
 import { getApiErrorMessage } from '../api/client';
 import { Eye, EyeOff, CircleAlert, CircleCheck } from 'lucide-react';
 import { AuthPageShell } from '../components/auth/AuthPageShell';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 interface PasswordCriteria {
   minLength: boolean;
@@ -73,6 +74,8 @@ export function SetPasswordPage() {
     () => confirmPassword.length > 0 && password === confirmPassword,
     [password, confirmPassword],
   );
+
+  useDocumentTitle('Set password');
 
   const isDisabled = !isPasswordStrong(password) || !passwordsMatch || isSubmitting;
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import { labelService } from '../services/labelService';
 import { stateService } from '../services/stateService';
 import { userService } from '../services/userService';
 import { authService } from '../services/authService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   LabelApiResponse,
   ProjectApiResponse,
@@ -719,6 +720,8 @@ export function SettingsPage() {
   const [projectMembers, setProjectMembers] = useState<ProjectMemberApiResponse[]>([]);
   const [projectLabels, setProjectLabels] = useState<LabelApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
+
+  useDocumentTitle('Settings');
 
   useEffect(() => {
     if (!workspaceSlug) {

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -6,6 +6,7 @@ import { authService } from '../services/authService';
 import { API_BASE, getApiErrorMessage } from '../api/client';
 import { Eye, EyeOff, CircleAlert, CircleCheck } from 'lucide-react';
 import { AuthPageShell } from '../components/auth/AuthPageShell';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 type AuthStep = 'email' | 'password' | 'code';
 
@@ -102,6 +103,8 @@ export function SignUpPage() {
     github: false,
     gitlab: false,
   });
+
+  useDocumentTitle('Sign up');
 
   useEffect(() => {
     if (oauthError) {

--- a/apps/web/src/pages/ViewDetailPage.tsx
+++ b/apps/web/src/pages/ViewDetailPage.tsx
@@ -28,6 +28,7 @@ import type { Priority } from '../types';
 import type { SavedViewDisplayPropertyId, SavedViewOrderBy } from '../lib/projectSavedViewDisplay';
 import { getImageUrl } from '../lib/utils';
 import { parseWorkspaceViewFiltersFromSearchParams } from '../types/workspaceViewFilters';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 
 const priorityVariant: Record<Priority, 'danger' | 'warning' | 'default' | 'neutral'> = {
   urgent: 'danger',
@@ -216,6 +217,8 @@ export function ViewDetailPage() {
   const [loading, setLoading] = useState(true);
   const [issuesLoading, setIssuesLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useDocumentTitle(view?.name ?? 'View');
 
   const refetchIssues = () => {
     if (!workspaceSlug || !projectId) return;

--- a/apps/web/src/pages/ViewDetailPage.tsx
+++ b/apps/web/src/pages/ViewDetailPage.tsx
@@ -218,7 +218,7 @@ export function ViewDetailPage() {
   const [issuesLoading, setIssuesLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useDocumentTitle(view?.name ?? 'View');
+  useDocumentTitle(loading ? 'View' : (view?.name ?? 'View'));
 
   const refetchIssues = () => {
     if (!workspaceSlug || !projectId) return;

--- a/apps/web/src/pages/ViewsPage.tsx
+++ b/apps/web/src/pages/ViewsPage.tsx
@@ -17,6 +17,7 @@ import {
   PROJECT_VIEWS_REFRESH_EVENT,
 } from '../lib/projectViewsEvents';
 import { findWorkspaceMemberByUserId, getImageUrl } from '../lib/utils';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -292,6 +293,7 @@ export function ViewsPage() {
   });
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [favoriteIds, setFavoriteIds] = useState<string[]>([]);
+  useDocumentTitle('Views');
 
   const loadPageData = useCallback(() => {
     if (!workspaceSlug || !projectId) {

--- a/apps/web/src/pages/WorkspaceHomePage.tsx
+++ b/apps/web/src/pages/WorkspaceHomePage.tsx
@@ -10,6 +10,7 @@ import { StickyNoteCard } from '../components/stickies/StickyNoteCard';
 import { pickRandomStickyBackground } from '../components/stickies/stickyPalette';
 import { OPEN_HOME_WIDGETS } from '../lib/homeWidgetsEvents';
 import { recentsService } from '../services/recentsService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -613,6 +614,8 @@ export function WorkspaceHomePage() {
   const [widgets, setWidgets] = useState<HomeWidget[]>(DEFAULT_HOME_WIDGETS);
   const [draggingWidgetId, setDraggingWidgetId] = useState<HomeWidgetId | null>(null);
   const [widgetsHydrated, setWidgetsHydrated] = useState(false);
+
+  useDocumentTitle('Home');
 
   const widgetsStorageKey = workspaceSlug ? `devlane:home-widgets:${workspaceSlug}` : '';
 

--- a/apps/web/src/pages/WorkspaceViewsPage.tsx
+++ b/apps/web/src/pages/WorkspaceViewsPage.tsx
@@ -10,6 +10,7 @@ import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
 import { viewService } from '../services/viewService';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -164,6 +165,8 @@ export function WorkspaceViewsPage() {
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const { user: currentUser } = useAuth();
+
+  useDocumentTitle('Views');
 
   // When viewing a saved view, fetch it and apply its filters/display to state once (not driven by URL).
   useEffect(() => {

--- a/apps/web/src/pages/instance-admin/InstanceAdminAIPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminAIPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, IconEye, IconEyeOff, Skeleton } from '../../components/ui';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceAISection } from '../../api/types';
 
 export function InstanceAdminAIPage() {
@@ -14,6 +15,7 @@ export function InstanceAdminAIPage() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [apiKeyLocal, setApiKeyLocal] = useState<string | undefined>(undefined);
   const [error, setError] = useState('');
+  useDocumentTitle('Artificial intelligence');
 
   const apiKeyDisplay = apiKeyLocal !== undefined ? apiKeyLocal : (ai.api_key ?? '');
 

--- a/apps/web/src/pages/instance-admin/InstanceAdminAdminsPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminAdminsPage.tsx
@@ -3,6 +3,7 @@ import { Avatar, Button, Modal, Skeleton } from '../../components/ui';
 import { instanceAdminService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
 import { useAuth } from '../../contexts/AuthContext';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceAdminApiResponse } from '../../api/types';
 
 export function InstanceAdminAdminsPage() {
@@ -14,6 +15,7 @@ export function InstanceAdminAdminsPage() {
   const [adding, setAdding] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<{ id: string; name: string } | null>(null);
   const [removing, setRemoving] = useState(false);
+  useDocumentTitle('Admins');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminAuthGitHubPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminAuthGitHubPage.tsx
@@ -7,6 +7,7 @@ import { authService } from '../../services/authService';
 import { getApiErrorMessage } from '../../api/client';
 import type { InstanceAuthSection, InstanceOAuthSection } from '../../api/types';
 import { Eye, EyeOff } from 'lucide-react';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 const IconGitHub = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
@@ -33,6 +34,7 @@ export function InstanceAdminAuthGitHubPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  useDocumentTitle('GitHub authentication');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminAuthGitLabPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminAuthGitLabPage.tsx
@@ -7,6 +7,7 @@ import { authService } from '../../services/authService';
 import { getApiErrorMessage } from '../../api/client';
 import type { InstanceAuthSection, InstanceOAuthSection } from '../../api/types';
 import { Eye, EyeOff } from 'lucide-react';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 const IconGitLab = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="#E24329" aria-hidden>
@@ -34,6 +35,7 @@ export function InstanceAdminAuthGitLabPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  useDocumentTitle('GitLab authentication');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminAuthGooglePage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminAuthGooglePage.tsx
@@ -7,6 +7,7 @@ import { authService } from '../../services/authService';
 import { getApiErrorMessage } from '../../api/client';
 import type { InstanceAuthSection, InstanceOAuthSection } from '../../api/types';
 import { Eye, EyeOff } from 'lucide-react';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 const IconGoogle = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden>
@@ -48,6 +49,7 @@ export function InstanceAdminAuthGooglePage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  useDocumentTitle('Google authentication');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminAuthenticationPage.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '../../components/ui';
 import { InstanceAdminToggleSwitch } from '../../components/instance-admin';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceAuthSection, InstanceOAuthSection } from '../../api/types';
 
 const IconEnvelope = () => (
@@ -157,6 +158,7 @@ export function InstanceAdminAuthenticationPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  useDocumentTitle('Authentication');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminCreateWorkspacePage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminCreateWorkspacePage.tsx
@@ -7,6 +7,7 @@ import { workspaceService } from '../../services/workspaceService';
 import { getApiErrorMessage } from '../../api/client';
 import { slugFromName, validateWorkspaceSlug } from '../../utils/workspace';
 import { ORGANIZATION_SIZE_OPTIONS } from '../../constants/workspace';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 const IconChevronDown = () => (
   <svg
@@ -34,6 +35,7 @@ export function InstanceAdminCreateWorkspacePage() {
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSetupHint, setShowSetupHint] = useState(false);
+  useDocumentTitle('Create workspace');
 
   const baseUrl = typeof window !== 'undefined' ? `${window.location.origin}/` : '';
 

--- a/apps/web/src/pages/instance-admin/InstanceAdminEmailPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminEmailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, IconEye, IconEyeOff, Skeleton } from '../../components/ui';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceEmailSection } from '../../api/types';
 
 export function InstanceAdminEmailPage() {
@@ -18,6 +19,7 @@ export function InstanceAdminEmailPage() {
   const [showSmtpPassword, setShowSmtpPassword] = useState(false);
   const [smtpPasswordLocal, setSmtpPasswordLocal] = useState<string | undefined>(undefined); // undefined = show stored mask, '' = user cleared, string = user typed
   const [error, setError] = useState('');
+  useDocumentTitle('Email');
 
   const smtpPasswordDisplay =
     smtpPasswordLocal !== undefined ? smtpPasswordLocal : (email.password ?? '');

--- a/apps/web/src/pages/instance-admin/InstanceAdminGeneralPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminGeneralPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, Skeleton } from '../../components/ui';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceGeneralSection } from '../../api/types';
 
 export function InstanceAdminGeneralPage() {
@@ -11,6 +12,7 @@ export function InstanceAdminGeneralPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  useDocumentTitle('General settings');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminImagePage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminImagePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, IconEye, IconEyeOff, Skeleton } from '../../components/ui';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceImageSection } from '../../api/types';
 
 export function InstanceAdminImagePage() {
@@ -13,6 +14,7 @@ export function InstanceAdminImagePage() {
   const [showAccessKey, setShowAccessKey] = useState(false);
   const [accessKeyLocal, setAccessKeyLocal] = useState<string | undefined>(undefined);
   const [error, setError] = useState('');
+  useDocumentTitle('Images');
 
   const accessKeyDisplay =
     accessKeyLocal !== undefined ? accessKeyLocal : (image.unsplash_access_key ?? '');

--- a/apps/web/src/pages/instance-admin/InstanceAdminIntegrationGitHubPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminIntegrationGitHubPage.tsx
@@ -6,6 +6,7 @@ import { InstanceAdminCopyRow } from '../../components/instance-admin';
 import { instanceSettingsService } from '../../services/instanceService';
 import { authService } from '../../services/authService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceGitHubAppSection } from '../../api/types';
 
 const IconGitHub = () => (
@@ -54,6 +55,7 @@ export function InstanceAdminIntegrationGitHubPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  useDocumentTitle('GitHub integration');
 
   const callbackUrl = useMemo(
     () => (oauthRedirectBase ? `${oauthRedirectBase}/auth/github-app/callback` : ''),

--- a/apps/web/src/pages/instance-admin/InstanceAdminIntegrationsPage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminIntegrationsPage.tsx
@@ -4,6 +4,7 @@ import { Settings2 } from 'lucide-react';
 import { Skeleton } from '../../components/ui';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceGitHubAppSection } from '../../api/types';
 
 const IconGitHub = () => (
@@ -36,6 +37,7 @@ export function InstanceAdminIntegrationsPage() {
   const [github, setGithub] = useState<InstanceGitHubAppSection>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  useDocumentTitle('Integrations');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/instance-admin/InstanceAdminWorkspacePage.tsx
+++ b/apps/web/src/pages/instance-admin/InstanceAdminWorkspacePage.tsx
@@ -4,6 +4,7 @@ import { Button, Skeleton } from '../../components/ui';
 import { workspaceService } from '../../services/workspaceService';
 import { instanceSettingsService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import type { InstanceGeneralSection } from '../../api/types';
 
 export function InstanceAdminWorkspacePage() {
@@ -16,6 +17,7 @@ export function InstanceAdminWorkspacePage() {
   const [settingsLoading, setSettingsLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  useDocumentTitle('Workspaces');
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/setup/InstanceSetupCompletePage.tsx
+++ b/apps/web/src/pages/setup/InstanceSetupCompletePage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Button, Card, CardContent } from '../../components/ui';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 const IconWorkspace = () => (
   <svg
@@ -21,6 +22,7 @@ const IconWorkspace = () => (
 
 export function InstanceSetupCompletePage() {
   const navigate = useNavigate();
+  useDocumentTitle('Setup complete');
 
   const handleCreateWorkspace = () => {
     navigate('/instance-admin/workspace/create', {

--- a/apps/web/src/pages/setup/InstanceSetupConfigurePage.tsx
+++ b/apps/web/src/pages/setup/InstanceSetupConfigurePage.tsx
@@ -4,6 +4,7 @@ import { Button, Input } from '../../components/ui';
 import { useAuth } from '../../contexts/AuthContext';
 import { instanceService } from '../../services/instanceService';
 import { getApiErrorMessage } from '../../api/client';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 const LogoMark = () => (
   <span
@@ -121,6 +122,7 @@ export function InstanceSetupConfigurePage() {
   const [allowUsageData, setAllowUsageData] = useState(true);
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  useDocumentTitle('Configure your instance');
 
   const req = usePasswordRequirements(password);
   const allMet = req.minLength && req.upper && req.lower && req.number && req.special;

--- a/apps/web/src/pages/setup/InstanceSetupWelcomePage.tsx
+++ b/apps/web/src/pages/setup/InstanceSetupWelcomePage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../../components/ui';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 
 /** Devlane logo mark: blue square with white star */
 const LogoMark = () => (
@@ -74,6 +75,7 @@ const WelcomeIllustration = () => (
 
 export function InstanceSetupWelcomePage() {
   const navigate = useNavigate();
+  useDocumentTitle('Get started');
 
   return (
     <div className="flex min-h-screen flex-col bg-(--bg-canvas)">


### PR DESCRIPTION
## Summary

Closes #16.

The SPA previously had a single static `<title>Devlane</title>`, so every route
showed the same browser tab label. This adds per-route page titles.

- New `useDocumentTitle(title)` hook (`apps/web/src/hooks/useDocumentTitle.ts`)
  sets `document.title` to `"<page> — Devlane"`, falling back to just `Devlane`
  when no title is given, and recomputes whenever the title changes.
- Every page calls it:
  - **Detail pages** derive the title from the loaded entity (work item, epic,
    cycle, module, page, view, profile) and fall back to the section name while
    loading.
  - **List / section, auth, setup, and instance-admin pages** use static
    section titles that match the in-app navigation labels (e.g. "Work items",
    "Inbox", "Analytics", "General settings").

## Testing

- `npm --prefix apps/web run typecheck` — pass
- `npm --prefix apps/web run lint` — pass
- `npm --prefix apps/web run format:check` — pass
- Verified in-browser (Playwright): tab title is `Sign in — Devlane` on
  `/login` and updates correctly on client-side navigation to `/sign-up`
  (`Sign up — Devlane`) and `/forgot-password` (`Forgot password — Devlane`).

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8). The bulk
per-page hook application was carried out by AI and verified via typecheck,
lint, and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic browser tab title updates across many pages, including workspace, analytics, work items, issues, modules, pages, settings, auth, setup, and admin screens.
  * Page titles now reflect the current section or loaded item name, with sensible fallbacks during loading.
  * Standardized tab title formatting so the app name consistently appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->