### PR TITLE
feat(search): implement global cross-entity search modal

### DIFF
--- a/apps/api/internal/handler/search.go
+++ b/apps/api/internal/handler/search.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// SearchHandler exposes cross-entity workspace search.
+type SearchHandler struct {
+	Svc *service.SearchService
+}
+
+// Search handles GET /api/workspaces/:slug/search/?query=...&project_id=...
+func (h *SearchHandler) Search(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+
+	var projectID *uuid.UUID
+	if raw := c.Query("project_id"); raw != "" {
+		pid, err := uuid.Parse(raw)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+			return
+		}
+		projectID = &pid
+	}
+
+	results, err := h.Svc.Search(c.Request.Context(), slug, c.Query("query"), projectID, user.ID)
+	if err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Search failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"results": results})
+}

--- a/apps/api/internal/handler/search_test.go
+++ b/apps/api/internal/handler/search_test.go
@@ -1,0 +1,117 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type searchResponse struct {
+	Results struct {
+		Issue   []map[string]any `json:"issue"`
+		Epic    []map[string]any `json:"epic"`
+		Cycle   []map[string]any `json:"cycle"`
+		Module  []map[string]any `json:"module"`
+		View    []map[string]any `json:"view"`
+		Page    []map[string]any `json:"page"`
+		Project []map[string]any `json:"project"`
+	} `json:"results"`
+}
+
+func parseSearch(t *testing.T, rr *httptest.ResponseRecorder) searchResponse {
+	t.Helper()
+	var resp searchResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "body=%s", rr.Body.String())
+	return resp
+}
+
+func names(rows []map[string]any) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if n, ok := r["name"].(string); ok {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func TestSearch_AcrossEntities(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+
+	// Seed one of each entity with a distinctive name.
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(issue).Update("name", "Login flow bug").Error)
+
+	require.NoError(t, ts.DB.Create(&model.Cycle{
+		Name: "Sprint Alpha", ProjectID: w.Project.ID, WorkspaceID: w.Workspace.ID,
+		OwnedByID: w.User.ID, CreatedByID: &w.User.ID,
+	}).Error)
+	require.NoError(t, ts.DB.Create(&model.Module{
+		Name: "Payments service", ProjectID: w.Project.ID, WorkspaceID: w.Workspace.ID,
+		CreatedByID: &w.User.ID,
+	}).Error)
+	require.NoError(t, ts.DB.Create(&model.View{
+		Name: "My open items", ProjectID: w.Project.ID, WorkspaceID: w.Workspace.ID,
+		Query: model.JSONMap{}, CreatedByID: &w.User.ID,
+	}).Error)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/search/"
+
+	// Match the issue by name; nothing else should match "login".
+	r1 := ts.GET(base+"?query=login", w.Session)
+	require.Equal(t, http.StatusOK, r1.Code, "body=%s", r1.Body.String())
+	resp1 := parseSearch(t, r1)
+	require.Contains(t, names(resp1.Results.Issue), "Login flow bug")
+	require.Empty(t, resp1.Results.Cycle)
+	require.Empty(t, resp1.Results.Module)
+
+	// Match the cycle.
+	resp2 := parseSearch(t, ts.GET(base+"?query=sprint", w.Session))
+	require.Contains(t, names(resp2.Results.Cycle), "Sprint Alpha")
+
+	// Match the module.
+	resp3 := parseSearch(t, ts.GET(base+"?query=payments", w.Session))
+	require.Contains(t, names(resp3.Results.Module), "Payments service")
+
+	// Match the view.
+	resp4 := parseSearch(t, ts.GET(base+"?query=open+items", w.Session))
+	require.Contains(t, names(resp4.Results.View), "My open items")
+
+	// Match the seeded project by its name.
+	resp5 := parseSearch(t, ts.GET(base+"?query="+url.QueryEscape(w.Project.Name), w.Session))
+	require.Contains(t, names(resp5.Results.Project), w.Project.Name)
+}
+
+func TestSearch_BlankQueryReturnsEmpty(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(issue).Update("name", "Findable").Error)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/search/"
+	rr := ts.GET(base+"?query=%20%20", w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	resp := parseSearch(t, rr)
+	require.Empty(t, resp.Results.Issue)
+	require.Empty(t, resp.Results.Project)
+}
+
+func TestSearch_NonMemberForbidden(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+
+	// A second user who is not a member of w.Workspace.
+	outsider := testutil.CreateUser(t, ts.DB)
+	session := testutil.LoginAs(t, ts.DB, outsider)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/search/?query=anything"
+	rr := ts.GET(base, session)
+	require.Equal(t, http.StatusForbidden, rr.Code, "body=%s", rr.Body.String())
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -65,6 +65,7 @@ func New(cfg Config) *gin.Engine {
 	cycleStore := store.NewCycleStore(cfg.DB)
 	moduleStore := store.NewModuleStore(cfg.DB)
 	issueViewStore := store.NewIssueViewStore(cfg.DB)
+	searchStore := store.NewSearchStore(cfg.DB)
 	pageStore := store.NewPageStore(cfg.DB)
 	notificationStore := store.NewNotificationStore(cfg.DB)
 	issueSubscriberStore := store.NewIssueSubscriberStore(cfg.DB)
@@ -138,6 +139,7 @@ func New(cfg Config) *gin.Engine {
 	moduleSvc := service.NewModuleService(moduleStore, projectStore, workspaceStore)
 	moduleSvc.SetIssueStore(issueStore)
 	issueViewSvc := service.NewIssueViewService(issueViewStore, projectStore, workspaceStore, userFavoriteStore)
+	searchSvc := service.NewSearchService(searchStore, workspaceStore)
 	pageSvc := service.NewPageService(pageStore, projectStore, workspaceStore)
 	pageSvc.SetFavoriteStore(userFavoriteStore)
 	notificationSvc := service.NewNotificationService(notificationStore, workspaceStore, issueStore, projectStore, userStore, stateStore)
@@ -212,6 +214,7 @@ func New(cfg Config) *gin.Engine {
 	favoriteHandler := &handler.FavoriteHandler{Project: projectSvc, Favorites: userFavoriteStore}
 	stateHandler := &handler.StateHandler{State: stateSvc}
 	labelHandler := &handler.LabelHandler{Label: labelSvc}
+	searchHandler := &handler.SearchHandler{Svc: searchSvc}
 	issueHandler := &handler.IssueHandler{Issue: issueSvc}
 	issueLinkHandler := &handler.IssueLinkHandler{Issue: issueSvc}
 	attachmentHandler := &handler.AttachmentHandler{Attachment: attachmentSvc}
@@ -275,6 +278,7 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/users/me/workspaces/:slug/projects/invitations/", projectHandler.ListUserProjectInvitations)
 		api.POST("/workspaces/:slug/projects/join/", projectHandler.JoinByToken)
 		api.GET("/workspaces/:slug/draft-issues/", issueHandler.ListWorkspaceDrafts)
+		api.GET("/workspaces/:slug/search/", searchHandler.Search)
 
 		api.GET("/workspaces/:slug/projects/", projectHandler.List)
 		api.POST("/workspaces/:slug/projects/", projectHandler.Create)

--- a/apps/api/internal/service/search.go
+++ b/apps/api/internal/service/search.go
@@ -27,9 +27,14 @@ func NewSearchService(ss *store.SearchStore, ws *store.WorkspaceStore) *SearchSe
 func (s *SearchService) Search(ctx context.Context, workspaceSlug, query string, projectID *uuid.UUID, userID uuid.UUID) (store.SearchResults, error) {
 	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
 	if err != nil {
+		// Treat an unknown workspace as forbidden so we don't leak existence.
 		return store.EmptyResults(), ErrProjectForbidden
 	}
-	ok, _ := s.ws.IsMember(ctx, wrk.ID, userID)
+	ok, err := s.ws.IsMember(ctx, wrk.ID, userID)
+	if err != nil {
+		// Surface infrastructure errors as 500s instead of masking them as 403.
+		return store.EmptyResults(), err
+	}
 	if !ok {
 		return store.EmptyResults(), ErrProjectForbidden
 	}

--- a/apps/api/internal/service/search.go
+++ b/apps/api/internal/service/search.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Devlaner/devlane/api/internal/store"
+	"github.com/google/uuid"
+)
+
+// Per-group hit cap for a search response.
+const searchPerGroupLimit = 25
+
+// SearchService runs cross-entity search after authorizing the workspace member.
+type SearchService struct {
+	ss *store.SearchStore
+	ws *store.WorkspaceStore
+}
+
+func NewSearchService(ss *store.SearchStore, ws *store.WorkspaceStore) *SearchService {
+	return &SearchService{ss: ss, ws: ws}
+}
+
+// Search resolves the workspace, verifies the caller is a member, then queries.
+// A blank query short-circuits to empty results without touching entity tables.
+// When projectID is non-nil, results are scoped to that project.
+func (s *SearchService) Search(ctx context.Context, workspaceSlug, query string, projectID *uuid.UUID, userID uuid.UUID) (store.SearchResults, error) {
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return store.EmptyResults(), ErrProjectForbidden
+	}
+	ok, _ := s.ws.IsMember(ctx, wrk.ID, userID)
+	if !ok {
+		return store.EmptyResults(), ErrProjectForbidden
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return store.EmptyResults(), nil
+	}
+	return s.ss.Search(ctx, wrk.ID, q, projectID, searchPerGroupLimit)
+}

--- a/apps/api/internal/store/search.go
+++ b/apps/api/internal/store/search.go
@@ -1,0 +1,140 @@
+package store
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// SearchStore runs cross-entity text search within a workspace. It is pure DB:
+// callers are responsible for authorizing the workspace/user first.
+type SearchStore struct{ db *gorm.DB }
+
+func NewSearchStore(db *gorm.DB) *SearchStore { return &SearchStore{db: db} }
+
+// SearchHit is a single match. ProjectID/ProjectIdentifier/SequenceID are set
+// only for entity types where they apply (e.g. work items carry all three;
+// projects carry their own id + identifier).
+type SearchHit struct {
+	ID                uuid.UUID  `json:"id"`
+	Name              string     `json:"name"`
+	ProjectID         *uuid.UUID `json:"project_id,omitempty"`
+	ProjectIdentifier string     `json:"project_identifier,omitempty"`
+	SequenceID        *int       `json:"sequence_id,omitempty"`
+}
+
+// SearchResults groups hits by entity type. Every slice is non-nil so the JSON
+// response always renders stable, empty arrays.
+type SearchResults struct {
+	Issues   []SearchHit `json:"issue"`
+	Epics    []SearchHit `json:"epic"`
+	Cycles   []SearchHit `json:"cycle"`
+	Modules  []SearchHit `json:"module"`
+	Views    []SearchHit `json:"view"`
+	Pages    []SearchHit `json:"page"`
+	Projects []SearchHit `json:"project"`
+}
+
+// EmptyResults returns a SearchResults with every group initialized to a
+// non-nil empty slice (used for blank queries so the API shape stays stable).
+func EmptyResults() SearchResults {
+	return SearchResults{
+		Issues:   []SearchHit{},
+		Epics:    []SearchHit{},
+		Cycles:   []SearchHit{},
+		Modules:  []SearchHit{},
+		Views:    []SearchHit{},
+		Pages:    []SearchHit{},
+		Projects: []SearchHit{},
+	}
+}
+
+// likePattern builds a case-insensitive "contains" pattern, escaping the LIKE
+// wildcards so user input can't broaden the match (Postgres ILIKE uses '\' as
+// the default escape character).
+func likePattern(q string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return "%" + r.Replace(q) + "%"
+}
+
+// Search returns matches across the workspace's entities. When projectID is
+// non-nil the project-owned entities (issues, epics, cycles, modules, views)
+// are scoped to that project and the workspace-level groups (pages, projects)
+// are left empty. limit caps the number of hits per group.
+func (s *SearchStore) Search(ctx context.Context, workspaceID uuid.UUID, query string, projectID *uuid.UUID, limit int) (SearchResults, error) {
+	res := EmptyResults()
+	pat := likePattern(query)
+
+	// Work items / epics: match by name or "IDENTIFIER-seq" (e.g. "DEV-42").
+	searchIssues := func(epic bool, dst *[]SearchHit) error {
+		q := s.db.WithContext(ctx).Table("issues AS i").
+			Select("i.id, i.name, i.project_id, i.sequence_id, p.identifier AS project_identifier").
+			Joins("JOIN projects p ON p.id = i.project_id AND p.deleted_at IS NULL").
+			Where("i.workspace_id = ? AND i.deleted_at IS NULL AND i.archived_at IS NULL AND i.is_epic = ?", workspaceID, epic).
+			Where("(i.name ILIKE ? OR (p.identifier || '-' || i.sequence_id::text) ILIKE ?)", pat, pat)
+		if projectID != nil {
+			q = q.Where("i.project_id = ?", *projectID)
+		}
+		return q.Order("i.updated_at DESC").Limit(limit).Scan(dst).Error
+	}
+	if err := searchIssues(false, &res.Issues); err != nil {
+		return res, err
+	}
+	if err := searchIssues(true, &res.Epics); err != nil {
+		return res, err
+	}
+
+	// Project-owned, name-only entities. hasArchived gates the archived_at
+	// filter for tables that have the column.
+	searchNamed := func(table string, hasArchived bool, dst *[]SearchHit) error {
+		q := s.db.WithContext(ctx).Table(table+" AS e").
+			Select("e.id, e.name, e.project_id, p.identifier AS project_identifier").
+			Joins("JOIN projects p ON p.id = e.project_id AND p.deleted_at IS NULL").
+			Where("e.workspace_id = ? AND e.deleted_at IS NULL AND e.name ILIKE ?", workspaceID, pat)
+		if hasArchived {
+			q = q.Where("e.archived_at IS NULL")
+		}
+		if projectID != nil {
+			q = q.Where("e.project_id = ?", *projectID)
+		}
+		return q.Order("e.name ASC").Limit(limit).Scan(dst).Error
+	}
+	if err := searchNamed("cycles", true, &res.Cycles); err != nil {
+		return res, err
+	}
+	if err := searchNamed("modules", false, &res.Modules); err != nil {
+		return res, err
+	}
+	if err := searchNamed("views", false, &res.Views); err != nil {
+		return res, err
+	}
+
+	// Workspace-level groups are only searched for unscoped (workspace) search.
+	if projectID != nil {
+		return res, nil
+	}
+
+	// Pages are workspace-level but navigated within a project; pick the first
+	// linked project for the result link.
+	if err := s.db.WithContext(ctx).Table("pages AS pg").
+		Select(`pg.id, pg.name,
+			(SELECT pp.project_id FROM project_pages pp WHERE pp.page_id = pg.id AND pp.deleted_at IS NULL ORDER BY pp.created_at ASC LIMIT 1) AS project_id,
+			(SELECT p2.identifier FROM project_pages pp JOIN projects p2 ON p2.id = pp.project_id WHERE pp.page_id = pg.id AND pp.deleted_at IS NULL ORDER BY pp.created_at ASC LIMIT 1) AS project_identifier`).
+		Where("pg.workspace_id = ? AND pg.deleted_at IS NULL AND pg.archived_at IS NULL AND pg.name ILIKE ?", workspaceID, pat).
+		Where("EXISTS (SELECT 1 FROM project_pages pp WHERE pp.page_id = pg.id AND pp.deleted_at IS NULL)").
+		Order("pg.name ASC").Limit(limit).Scan(&res.Pages).Error; err != nil {
+		return res, err
+	}
+
+	// Projects: match by name or identifier; project_id mirrors id for linking.
+	if err := s.db.WithContext(ctx).Table("projects AS p").
+		Select("p.id, p.name, p.id AS project_id, p.identifier AS project_identifier").
+		Where("p.workspace_id = ? AND p.deleted_at IS NULL AND (p.name ILIKE ? OR p.identifier ILIKE ?)", workspaceID, pat, pat).
+		Order("p.name ASC").Limit(limit).Scan(&res.Projects).Error; err != nil {
+		return res, err
+	}
+
+	return res, nil
+}

--- a/apps/web/src/components/layout/GlobalCommandPalette.tsx
+++ b/apps/web/src/components/layout/GlobalCommandPalette.tsx
@@ -104,7 +104,12 @@ export function GlobalCommandPalette({
   });
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [entered, setEntered] = useState(false);
-  const [searchResults, setSearchResults] = useState<SearchResults | null>(null);
+  // Results are stored together with the query they belong to, so stale results
+  // from a previous query are ignored during render (see entityEntries) without
+  // needing a synchronous reset inside the search effect.
+  const [searchState, setSearchState] = useState<{ q: string; results: SearchResults } | null>(
+    null,
+  );
   const [searching, setSearching] = useState(false);
 
   const persistWorkspaceLevel = useCallback((next: boolean) => {
@@ -285,23 +290,28 @@ export function GlobalCommandPalette({
   }, [baseUrl, navigate, onRequestCreateWorkItem, projectId, projects, runAndClose, workspaceSlug]);
 
   const entityEntries = useMemo((): CommandEntry[] => {
-    if (!query.trim() || !searchResults || !baseUrl) return [];
-    const projectBase = (pid?: string) => `${baseUrl}/projects/${pid ?? ''}`;
+    const q = query.trim();
+    // Ignore results that belong to a previous query (cleared on query change).
+    if (!q || !baseUrl || !searchState || searchState.q !== q) return [];
+    const results = searchState.results;
     const out: CommandEntry[] = [];
     const push = (
       hits: SearchHit[],
+      key: string,
       category: string,
       icon: ReactNode,
       to: (h: SearchHit) => string,
-      withSeq = false,
+      opts?: { withSeq?: boolean; needsProject?: boolean },
     ) => {
       for (const h of hits) {
+        // Skip project-owned hits without a project so we never build /projects//…
+        if (opts?.needsProject && !h.project_id) continue;
         const prefix =
-          withSeq && h.project_identifier && h.sequence_id != null
+          opts?.withSeq && h.project_identifier && h.sequence_id != null
             ? `${h.project_identifier}-${h.sequence_id} `
             : '';
         out.push({
-          id: `search-${category}-${h.id}`,
+          id: `search-${key}-${h.id}`,
           category,
           label: `${prefix}${h.name || 'Untitled'}`,
           icon,
@@ -312,52 +322,64 @@ export function GlobalCommandPalette({
     const ic = (Icon: typeof CircleDot) => (
       <Icon className="size-[15px] shrink-0" strokeWidth={2} />
     );
+    const projectBase = (pid?: string) => `${baseUrl}/projects/${pid}`;
     push(
-      searchResults.issue,
+      results.issue,
+      'issue',
       'Work items',
       ic(CircleDot),
       (h) => `${projectBase(h.project_id)}/issues/${h.id}`,
-      true,
+      { withSeq: true, needsProject: true },
     );
     push(
-      searchResults.epic,
+      results.epic,
+      'epic',
       'Epics',
       ic(Boxes),
       (h) => `${projectBase(h.project_id)}/epics/${h.id}`,
-      true,
+      { withSeq: true, needsProject: true },
     );
     push(
-      searchResults.cycle,
+      results.cycle,
+      'cycle',
       'Cycles',
       ic(IterationCw),
       (h) => `${projectBase(h.project_id)}/cycles/${h.id}`,
+      { needsProject: true },
     );
     push(
-      searchResults.module,
+      results.module,
+      'module',
       'Modules',
       ic(Box),
       (h) => `${projectBase(h.project_id)}/modules/${h.id}`,
+      { needsProject: true },
     );
     push(
-      searchResults.view,
+      results.view,
+      'view',
       'Views',
       ic(Layers),
       (h) => `${projectBase(h.project_id)}/views/${h.id}`,
+      { needsProject: true },
     );
     push(
-      searchResults.page,
+      results.page,
+      'page',
       'Pages',
       ic(FileText),
       (h) => `${projectBase(h.project_id)}/pages/${h.id}`,
+      { needsProject: true },
     );
     push(
-      searchResults.project,
+      results.project,
+      'project',
       'Projects',
       ic(FolderKanban),
       (h) => `${baseUrl}/projects/${h.id}/issues`,
     );
     return out;
-  }, [query, searchResults, baseUrl, navigate, runAndClose]);
+  }, [query, searchState, baseUrl, navigate, runAndClose]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -389,7 +411,7 @@ export function GlobalCommandPalette({
         setEntered(false);
         setQuery('');
         setSelectedId(null);
-        setSearchResults(null);
+        setSearchState(null);
         setSearching(false);
       });
       return;
@@ -460,10 +482,10 @@ export function GlobalCommandPalette({
           signal: controller.signal,
         })
         .then((res) => {
-          if (!controller.signal.aborted) setSearchResults(res);
+          if (!controller.signal.aborted) setSearchState({ q, results: res });
         })
         .catch(() => {
-          if (!controller.signal.aborted) setSearchResults(null);
+          if (!controller.signal.aborted) setSearchState(null);
         })
         .finally(() => {
           if (!controller.signal.aborted) setSearching(false);
@@ -515,6 +537,11 @@ export function GlobalCommandPalette({
   if (!open || typeof document === 'undefined') return null;
 
   const modKey = isMac ? '⌘' : 'Ctrl';
+  // True while a search is in flight OR results for the current query haven't
+  // arrived yet (covers the debounce gap after the query changes).
+  const trimmedQuery = query.trim();
+  const pendingSearch =
+    trimmedQuery.length > 0 && (searching || !searchState || searchState.q !== trimmedQuery);
 
   return createPortal(
     <div
@@ -581,7 +608,7 @@ export function GlobalCommandPalette({
         >
           {filtered.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-1 px-4 py-10 text-center">
-              {searching ? (
+              {pendingSearch ? (
                 <p className="text-sm font-medium text-(--txt-secondary)">Searching…</p>
               ) : (
                 <>

--- a/apps/web/src/components/layout/GlobalCommandPalette.tsx
+++ b/apps/web/src/components/layout/GlobalCommandPalette.tsx
@@ -2,7 +2,9 @@ import { Switch } from '@headlessui/react';
 import {
   Archive,
   BarChart3,
+  Box,
   Boxes,
+  CircleDot,
   CirclePlus,
   FileEdit,
   FileText,
@@ -21,6 +23,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNod
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import type { ProjectApiResponse } from '../../api/types';
+import { searchService, type SearchHit, type SearchResults } from '../../services/searchService';
 import { cn } from '../../lib/utils';
 
 const WORKSPACE_LEVEL_STORAGE_KEY = 'devlane-command-palette-workspace-level';
@@ -101,6 +104,8 @@ export function GlobalCommandPalette({
   });
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [entered, setEntered] = useState(false);
+  const [searchResults, setSearchResults] = useState<SearchResults | null>(null);
+  const [searching, setSearching] = useState(false);
 
   const persistWorkspaceLevel = useCallback((next: boolean) => {
     setWorkspaceLevel(next);
@@ -279,15 +284,92 @@ export function GlobalCommandPalette({
     return list;
   }, [baseUrl, navigate, onRequestCreateWorkItem, projectId, projects, runAndClose, workspaceSlug]);
 
+  const entityEntries = useMemo((): CommandEntry[] => {
+    if (!query.trim() || !searchResults || !baseUrl) return [];
+    const projectBase = (pid?: string) => `${baseUrl}/projects/${pid ?? ''}`;
+    const out: CommandEntry[] = [];
+    const push = (
+      hits: SearchHit[],
+      category: string,
+      icon: ReactNode,
+      to: (h: SearchHit) => string,
+      withSeq = false,
+    ) => {
+      for (const h of hits) {
+        const prefix =
+          withSeq && h.project_identifier && h.sequence_id != null
+            ? `${h.project_identifier}-${h.sequence_id} `
+            : '';
+        out.push({
+          id: `search-${category}-${h.id}`,
+          category,
+          label: `${prefix}${h.name || 'Untitled'}`,
+          icon,
+          run: () => runAndClose(() => navigate(to(h))),
+        });
+      }
+    };
+    const ic = (Icon: typeof CircleDot) => (
+      <Icon className="size-[15px] shrink-0" strokeWidth={2} />
+    );
+    push(
+      searchResults.issue,
+      'Work items',
+      ic(CircleDot),
+      (h) => `${projectBase(h.project_id)}/issues/${h.id}`,
+      true,
+    );
+    push(
+      searchResults.epic,
+      'Epics',
+      ic(Boxes),
+      (h) => `${projectBase(h.project_id)}/epics/${h.id}`,
+      true,
+    );
+    push(
+      searchResults.cycle,
+      'Cycles',
+      ic(IterationCw),
+      (h) => `${projectBase(h.project_id)}/cycles/${h.id}`,
+    );
+    push(
+      searchResults.module,
+      'Modules',
+      ic(Box),
+      (h) => `${projectBase(h.project_id)}/modules/${h.id}`,
+    );
+    push(
+      searchResults.view,
+      'Views',
+      ic(Layers),
+      (h) => `${projectBase(h.project_id)}/views/${h.id}`,
+    );
+    push(
+      searchResults.page,
+      'Pages',
+      ic(FileText),
+      (h) => `${projectBase(h.project_id)}/pages/${h.id}`,
+    );
+    push(
+      searchResults.project,
+      'Projects',
+      ic(FolderKanban),
+      (h) => `${baseUrl}/projects/${h.id}/issues`,
+    );
+    return out;
+  }, [query, searchResults, baseUrl, navigate, runAndClose]);
+
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     const base = workspaceLevel ? commands.filter((c) => !c.projectScoped) : commands;
     if (!q) return base;
-    return base.filter((c) => {
+    const matchingCommands = base.filter((c) => {
       const hay = `${c.label} ${c.category} ${c.matchText ?? ''}`.toLowerCase();
       return hay.includes(q);
     });
-  }, [commands, query, workspaceLevel]);
+    // Entity results first so what the user is searching for is most prominent.
+    return [...entityEntries, ...matchingCommands];
+  }, [commands, query, workspaceLevel, entityEntries]);
 
   const grouped = useMemo(() => {
     const map = new Map<string, CommandEntry[]>();
@@ -307,6 +389,8 @@ export function GlobalCommandPalette({
         setEntered(false);
         setQuery('');
         setSelectedId(null);
+        setSearchResults(null);
+        setSearching(false);
       });
       return;
     }
@@ -359,6 +443,37 @@ export function GlobalCommandPalette({
       document.body.style.overflow = prev;
     };
   }, [open]);
+
+  // Debounced entity search against the backend while the user types. All
+  // state updates happen in async callbacks; an empty query is handled by
+  // deriving empty entity entries below (see entityEntries) rather than
+  // synchronously resetting state here.
+  useEffect(() => {
+    const q = query.trim();
+    if (!open || !q || !workspaceSlug) return;
+    const controller = new AbortController();
+    const handle = window.setTimeout(() => {
+      setSearching(true);
+      searchService
+        .search(workspaceSlug, q, {
+          projectId: workspaceLevel ? undefined : projectId,
+          signal: controller.signal,
+        })
+        .then((res) => {
+          if (!controller.signal.aborted) setSearchResults(res);
+        })
+        .catch(() => {
+          if (!controller.signal.aborted) setSearchResults(null);
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setSearching(false);
+        });
+    }, 250);
+    return () => {
+      controller.abort();
+      window.clearTimeout(handle);
+    };
+  }, [open, query, workspaceSlug, projectId, workspaceLevel]);
 
   const moveSelection = (delta: number) => {
     if (!flatIds.length) return;
@@ -466,10 +581,18 @@ export function GlobalCommandPalette({
         >
           {filtered.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-1 px-4 py-10 text-center">
-              <p className="text-sm font-medium text-(--txt-secondary)">No matching actions</p>
-              <p className="max-w-xs text-xs text-(--txt-tertiary)">
-                Try another keyword, or turn off workspace level to see project shortcuts.
-              </p>
+              {searching ? (
+                <p className="text-sm font-medium text-(--txt-secondary)">Searching…</p>
+              ) : (
+                <>
+                  <p className="text-sm font-medium text-(--txt-secondary)">
+                    {query.trim() ? 'No results' : 'No matching actions'}
+                  </p>
+                  <p className="max-w-xs text-xs text-(--txt-tertiary)">
+                    Try another keyword, or turn off workspace level to see project shortcuts.
+                  </p>
+                </>
+              )}
             </div>
           ) : (
             <>

--- a/apps/web/src/services/searchService.ts
+++ b/apps/web/src/services/searchService.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '../api/client';
+
+export interface SearchHit {
+  id: string;
+  name: string;
+  project_id?: string;
+  project_identifier?: string;
+  sequence_id?: number;
+}
+
+/** Entity-grouped search results. Keys mirror the backend response. */
+export interface SearchResults {
+  issue: SearchHit[];
+  epic: SearchHit[];
+  cycle: SearchHit[];
+  module: SearchHit[];
+  view: SearchHit[];
+  page: SearchHit[];
+  project: SearchHit[];
+}
+
+export function emptySearchResults(): SearchResults {
+  return { issue: [], epic: [], cycle: [], module: [], view: [], page: [], project: [] };
+}
+
+export const searchService = {
+  /**
+   * Cross-entity workspace search. Pass `projectId` to scope the project-owned
+   * entities to a single project; pass an `AbortSignal` to cancel in-flight
+   * requests when the query changes.
+   */
+  async search(
+    workspaceSlug: string,
+    query: string,
+    opts?: { projectId?: string; signal?: AbortSignal },
+  ): Promise<SearchResults> {
+    const params = new URLSearchParams({ query });
+    if (opts?.projectId) params.set('project_id', opts.projectId);
+    const { data } = await apiClient.get<{ results: SearchResults }>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/search/?${params.toString()}`,
+      { signal: opts?.signal },
+    );
+    return { ...emptySearchResults(), ...(data?.results ?? {}) };
+  },
+};


### PR DESCRIPTION
## Summary

Closes #45.

Implements the global search modal — a Cmd/Ctrl+K spotlight that searches
across the workspace's entities, not just static navigation commands.

### Backend
- New `GET /api/workspaces/:slug/search/?query=...&project_id=...`
  (`store.SearchStore` → `service.SearchService` → `handler.SearchHandler`).
- Searches **work items, epics, cycles, modules, views, pages, and projects**,
  returning results grouped by type (`{ "results": { "issue": [...], ... } }`).
- Scoped to workspace members (non-members get 403). Work items/epics match by
  name **or** `IDENTIFIER-seq` (e.g. `DEV-42`); projects match name or
  identifier. LIKE wildcards in user input are escaped.
- Optional `project_id` scopes the project-owned entities to one project (and
  omits the workspace-level groups). Blank queries short-circuit to empty
  results without touching the DB.

### Frontend
- New `searchService` + `SearchResults` type.
- The existing Cmd/Ctrl+K command palette now runs a **debounced** search as you
  type and shows entity results grouped above the matching actions, each
  navigating to the entity (work item, epic, cycle, module, view, page,
  project). Results reset on close; an in-flight request is aborted when the
  query changes.

## Testing

- `go test ./internal/handler -run TestSearch` — pass (real Postgres via
  testcontainers): cross-entity matches, blank-query empties, non-member 403.
- `go vet ./...`, UI `typecheck` / `lint` / `format:check` — all pass.
- Verified in-browser (Playwright) against the running stack: the endpoint
  returns grouped results for real data; the palette renders grouped results
  (`APO-4 Child of Alpha` under Work items, `APO-3 Epic Alpha` under Epics,
  `Sprint Alpha` under Modules) and selecting one navigates to the entity and
  closes the palette.

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8): backend
endpoint, frontend integration, and tests, verified via the test suite and
in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace search across multiple item types, including projects, pages, issues, cycles, modules, views, and epics.
  * Search is now available from the command palette with live, debounced results as you type.
  * Added optional project-scoped filtering for search.

* **Bug Fixes**
  * Blank search queries now return empty results instead of an error.
  * Unauthorized or non-member access to workspace search is now blocked with clear responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->