### PR TITLE
feat(estimates): manage estimate systems in project settings

### DIFF
--- a/apps/api/internal/handler/estimate.go
+++ b/apps/api/internal/handler/estimate.go
@@ -1,0 +1,195 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// EstimateHandler serves estimate systems (and their points) for a project.
+type EstimateHandler struct {
+	Estimate *service.EstimateService
+}
+
+type estimatePointBody struct {
+	Key         int    `json:"key"`
+	Value       string `json:"value"`
+	Description string `json:"description"`
+}
+
+func toPointInputs(in []estimatePointBody) []service.EstimatePointInput {
+	out := make([]service.EstimatePointInput, 0, len(in))
+	for _, p := range in {
+		out = append(out, service.EstimatePointInput{Key: p.Key, Value: p.Value, Description: p.Description})
+	}
+	return out
+}
+
+func estimateNotFound(err error) bool {
+	return err == service.ErrEstimateNotFound || err == service.ErrProjectForbidden || err == service.ErrProjectNotFound
+}
+
+// estimateCtx parses slug + projectId + authenticated user.
+func (h *EstimateHandler) estimateCtx(c *gin.Context) (slug string, projectID, userID uuid.UUID, ok bool) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug = c.Param("slug")
+	pid, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	return slug, pid, user.ID, true
+}
+
+func estimatePK(c *gin.Context) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param("pk"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid estimate ID"})
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// List returns the project's estimate systems with their points.
+// GET /api/workspaces/:slug/projects/:projectId/estimates/
+func (h *EstimateHandler) List(c *gin.Context) {
+	slug, projectID, userID, ok := h.estimateCtx(c)
+	if !ok {
+		return
+	}
+	list, err := h.Estimate.ListByProject(c.Request.Context(), slug, projectID, userID)
+	if err != nil {
+		if estimateNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list estimates"})
+		return
+	}
+	if list == nil {
+		c.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+// Get returns a single estimate system with its points.
+// GET /api/workspaces/:slug/projects/:projectId/estimates/:pk/
+func (h *EstimateHandler) Get(c *gin.Context) {
+	slug, projectID, userID, ok := h.estimateCtx(c)
+	if !ok {
+		return
+	}
+	id, ok := estimatePK(c)
+	if !ok {
+		return
+	}
+	e, err := h.Estimate.Get(c.Request.Context(), slug, projectID, id, userID)
+	if err != nil {
+		if estimateNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load estimate"})
+		return
+	}
+	c.JSON(http.StatusOK, e)
+}
+
+// Create adds an estimate system.
+// POST /api/workspaces/:slug/projects/:projectId/estimates/
+func (h *EstimateHandler) Create(c *gin.Context) {
+	slug, projectID, userID, ok := h.estimateCtx(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Name        string              `json:"name" binding:"required"`
+		Description string              `json:"description"`
+		Type        string              `json:"type"`
+		LastUsed    bool                `json:"last_used"`
+		Points      []estimatePointBody `json:"points"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	e, err := h.Estimate.Create(c.Request.Context(), slug, projectID, userID, body.Name, body.Description, body.Type, body.LastUsed, toPointInputs(body.Points))
+	if err != nil {
+		if estimateNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create estimate"})
+		return
+	}
+	c.JSON(http.StatusCreated, e)
+}
+
+// Update edits an estimate system; when "points" is present it replaces them.
+// PATCH /api/workspaces/:slug/projects/:projectId/estimates/:pk/
+func (h *EstimateHandler) Update(c *gin.Context) {
+	slug, projectID, userID, ok := h.estimateCtx(c)
+	if !ok {
+		return
+	}
+	id, ok := estimatePK(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		Name        *string              `json:"name"`
+		Description *string              `json:"description"`
+		Type        *string              `json:"type"`
+		LastUsed    *bool                `json:"last_used"`
+		Points      *[]estimatePointBody `json:"points"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	var points *[]service.EstimatePointInput
+	if body.Points != nil {
+		p := toPointInputs(*body.Points)
+		points = &p
+	}
+	e, err := h.Estimate.Update(c.Request.Context(), slug, projectID, id, userID, body.Name, body.Description, body.Type, body.LastUsed, points)
+	if err != nil {
+		if estimateNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update estimate"})
+		return
+	}
+	c.JSON(http.StatusOK, e)
+}
+
+// Delete removes an estimate system and its points.
+// DELETE /api/workspaces/:slug/projects/:projectId/estimates/:pk/
+func (h *EstimateHandler) Delete(c *gin.Context) {
+	slug, projectID, userID, ok := h.estimateCtx(c)
+	if !ok {
+		return
+	}
+	id, ok := estimatePK(c)
+	if !ok {
+		return
+	}
+	if err := h.Estimate.Delete(c.Request.Context(), slug, projectID, id, userID); err != nil {
+		if estimateNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete estimate"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/apps/api/internal/handler/estimate_test.go
+++ b/apps/api/internal/handler/estimate_test.go
@@ -1,0 +1,74 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimates_CRUD(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/estimates/"
+
+	// Empty list.
+	r0 := ts.GET(base, w.Session)
+	require.Equal(t, http.StatusOK, r0.Code, "body=%s", r0.Body.String())
+
+	// Create with points and mark it active.
+	rc := ts.POST(base, map[string]any{
+		"name":      "T-Shirt",
+		"type":      "categories",
+		"last_used": true,
+		"points": []map[string]any{
+			{"key": 0, "value": "S"},
+			{"key": 1, "value": "M"},
+			{"key": 2, "value": "L"},
+		},
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, rc.Code, "body=%s", rc.Body.String())
+	m := testutil.MustJSONMap(t, rc)
+	id, _ := m["id"].(string)
+	require.NotEmpty(t, id)
+	require.Equal(t, true, m["last_used"])
+	pts, _ := m["points"].([]any)
+	require.Len(t, pts, 3)
+
+	// List contains it.
+	require.Contains(t, ts.GET(base, w.Session).Body.String(), "T-Shirt")
+
+	// Get returns the points.
+	rg := ts.GET(base+id+"/", w.Session)
+	require.Equal(t, http.StatusOK, rg.Code, "body=%s", rg.Body.String())
+	require.Contains(t, rg.Body.String(), `"M"`)
+
+	// Update: rename and replace the points with two.
+	ru := ts.PATCH(base+id+"/", map[string]any{
+		"name":   "Sizes",
+		"points": []map[string]any{{"key": 0, "value": "1"}, {"key": 1, "value": "2"}},
+	}, w.Session)
+	require.Equal(t, http.StatusOK, ru.Code, "body=%s", ru.Body.String())
+	um := testutil.MustJSONMap(t, ru)
+	require.Equal(t, "Sizes", um["name"])
+	upts, _ := um["points"].([]any)
+	require.Len(t, upts, 2)
+
+	// Delete.
+	rd := ts.DELETE(base+id+"/", w.Session)
+	require.Equal(t, http.StatusNoContent, rd.Code, "body=%s", rd.Body.String())
+
+	// List is empty again.
+	require.NotContains(t, ts.GET(base, w.Session).Body.String(), "Sizes")
+}
+
+func TestEstimates_NonMemberForbidden(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	outsider := testutil.CreateUser(t, ts.DB)
+	session := testutil.LoginAs(t, ts.DB, outsider)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/estimates/"
+	rr := ts.GET(base, session)
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+}

--- a/apps/api/internal/model/estimate.go
+++ b/apps/api/internal/model/estimate.go
@@ -11,7 +11,9 @@ import (
 type Estimate struct {
 	ID          uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	Name        string         `gorm:"type:varchar(255);not null" json:"name"`
+	Description string         `gorm:"type:text;default:''" json:"description"`
 	Type        string         `gorm:"type:varchar(255);default:categories" json:"type"`
+	LastUsed    bool           `gorm:"column:last_used;not null;default:false" json:"last_used"`
 	ProjectID   uuid.UUID      `gorm:"type:uuid;not null" json:"project_id"`
 	WorkspaceID uuid.UUID      `gorm:"type:uuid;not null" json:"workspace_id"`
 	CreatedAt   time.Time      `json:"created_at"`
@@ -19,6 +21,8 @@ type Estimate struct {
 	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
 	CreatedByID *uuid.UUID     `gorm:"type:uuid" json:"created_by_id,omitempty"`
 	UpdatedByID *uuid.UUID     `gorm:"type:uuid" json:"updated_by_id,omitempty"`
+	// Points is populated by the service; never persisted directly here.
+	Points []EstimatePoint `gorm:"-" json:"points"`
 }
 
 func (Estimate) TableName() string { return "estimates" }
@@ -35,6 +39,7 @@ type EstimatePoint struct {
 	ID          uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	EstimateID  uuid.UUID      `gorm:"type:uuid;not null" json:"estimate_id"`
 	Key         int            `gorm:"default:0" json:"key"`
+	Description string         `gorm:"type:text;default:''" json:"description"`
 	Value       string         `gorm:"type:varchar(255);not null" json:"value"`
 	ProjectID   uuid.UUID      `gorm:"type:uuid;not null" json:"project_id"`
 	WorkspaceID uuid.UUID      `gorm:"type:uuid;not null" json:"workspace_id"`

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -66,6 +66,7 @@ func New(cfg Config) *gin.Engine {
 	moduleStore := store.NewModuleStore(cfg.DB)
 	issueViewStore := store.NewIssueViewStore(cfg.DB)
 	searchStore := store.NewSearchStore(cfg.DB)
+	estimateStore := store.NewEstimateStore(cfg.DB)
 	pageStore := store.NewPageStore(cfg.DB)
 	notificationStore := store.NewNotificationStore(cfg.DB)
 	issueSubscriberStore := store.NewIssueSubscriberStore(cfg.DB)
@@ -140,6 +141,7 @@ func New(cfg Config) *gin.Engine {
 	moduleSvc.SetIssueStore(issueStore)
 	issueViewSvc := service.NewIssueViewService(issueViewStore, projectStore, workspaceStore, userFavoriteStore)
 	searchSvc := service.NewSearchService(searchStore, workspaceStore)
+	estimateSvc := service.NewEstimateService(estimateStore, projectStore, workspaceStore)
 	pageSvc := service.NewPageService(pageStore, projectStore, workspaceStore)
 	pageSvc.SetFavoriteStore(userFavoriteStore)
 	notificationSvc := service.NewNotificationService(notificationStore, workspaceStore, issueStore, projectStore, userStore, stateStore)
@@ -215,6 +217,7 @@ func New(cfg Config) *gin.Engine {
 	stateHandler := &handler.StateHandler{State: stateSvc}
 	labelHandler := &handler.LabelHandler{Label: labelSvc}
 	searchHandler := &handler.SearchHandler{Svc: searchSvc}
+	estimateHandler := &handler.EstimateHandler{Estimate: estimateSvc}
 	issueHandler := &handler.IssueHandler{Issue: issueSvc}
 	issueLinkHandler := &handler.IssueLinkHandler{Issue: issueSvc}
 	attachmentHandler := &handler.AttachmentHandler{Attachment: attachmentSvc}
@@ -307,6 +310,12 @@ func New(cfg Config) *gin.Engine {
 		api.POST("/workspaces/:slug/projects/:projectId/issue-labels/", labelHandler.Create)
 		api.PATCH("/workspaces/:slug/projects/:projectId/issue-labels/:pk/", labelHandler.Update)
 		api.DELETE("/workspaces/:slug/projects/:projectId/issue-labels/:pk/", labelHandler.Delete)
+
+		api.GET("/workspaces/:slug/projects/:projectId/estimates/", estimateHandler.List)
+		api.POST("/workspaces/:slug/projects/:projectId/estimates/", estimateHandler.Create)
+		api.GET("/workspaces/:slug/projects/:projectId/estimates/:pk/", estimateHandler.Get)
+		api.PATCH("/workspaces/:slug/projects/:projectId/estimates/:pk/", estimateHandler.Update)
+		api.DELETE("/workspaces/:slug/projects/:projectId/estimates/:pk/", estimateHandler.Delete)
 
 		api.GET("/workspaces/:slug/projects/:projectId/issues/", issueHandler.List)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/", issueHandler.Create)

--- a/apps/api/internal/service/estimate.go
+++ b/apps/api/internal/service/estimate.go
@@ -1,0 +1,188 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/store"
+	"github.com/google/uuid"
+)
+
+var ErrEstimateNotFound = errors.New("estimate not found")
+
+// EstimatePointInput is a single point supplied when creating/updating an estimate.
+type EstimatePointInput struct {
+	Key         int
+	Value       string
+	Description string
+}
+
+// EstimateService handles estimate business logic.
+type EstimateService struct {
+	es *store.EstimateStore
+	ps *store.ProjectStore
+	ws *store.WorkspaceStore
+}
+
+func NewEstimateService(es *store.EstimateStore, ps *store.ProjectStore, ws *store.WorkspaceStore) *EstimateService {
+	return &EstimateService{es: es, ps: ps, ws: ws}
+}
+
+func (s *EstimateService) ensureProjectAccess(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID) (*model.Workspace, error) {
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return nil, ErrProjectForbidden
+	}
+	ok, _ := s.ws.IsMember(ctx, wrk.ID, userID)
+	if !ok {
+		return nil, ErrProjectForbidden
+	}
+	inWorkspace, _ := s.ps.IsInWorkspace(ctx, projectID, wrk.ID)
+	if !inWorkspace {
+		return nil, ErrProjectNotFound
+	}
+	return wrk, nil
+}
+
+func (s *EstimateService) buildPoints(e *model.Estimate, in []EstimatePointInput, userID uuid.UUID) []model.EstimatePoint {
+	pts := make([]model.EstimatePoint, 0, len(in))
+	for _, p := range in {
+		pts = append(pts, model.EstimatePoint{
+			EstimateID:  e.ID,
+			Key:         p.Key,
+			Value:       p.Value,
+			Description: p.Description,
+			ProjectID:   e.ProjectID,
+			WorkspaceID: e.WorkspaceID,
+			CreatedByID: &userID,
+			UpdatedByID: &userID,
+		})
+	}
+	return pts
+}
+
+func (s *EstimateService) ListByProject(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID) ([]model.Estimate, error) {
+	if _, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	list, err := s.es.ListByProjectID(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(list))
+	for _, e := range list {
+		ids = append(ids, e.ID)
+	}
+	pointsByEstimate, err := s.es.ListPointsByEstimateIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		if p := pointsByEstimate[list[i].ID]; p != nil {
+			list[i].Points = p
+		} else {
+			list[i].Points = []model.EstimatePoint{}
+		}
+	}
+	return list, nil
+}
+
+func (s *EstimateService) Get(ctx context.Context, workspaceSlug string, projectID, estimateID, userID uuid.UUID) (*model.Estimate, error) {
+	if _, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	e, err := s.es.GetByID(ctx, estimateID)
+	if err != nil || e.ProjectID != projectID {
+		return nil, ErrEstimateNotFound
+	}
+	pts, err := s.es.ListPointsByEstimateID(ctx, e.ID)
+	if err != nil {
+		return nil, err
+	}
+	e.Points = pts
+	return e, nil
+}
+
+func (s *EstimateService) Create(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID, name, description, etype string, lastUsed bool, points []EstimatePointInput) (*model.Estimate, error) {
+	wrk, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if etype == "" {
+		etype = "categories"
+	}
+	e := &model.Estimate{
+		Name:        name,
+		Description: description,
+		Type:        etype,
+		LastUsed:    lastUsed,
+		ProjectID:   projectID,
+		WorkspaceID: wrk.ID,
+		CreatedByID: &userID,
+		UpdatedByID: &userID,
+	}
+	if err := s.es.Create(ctx, e); err != nil {
+		return nil, err
+	}
+	if err := s.es.ReplacePoints(ctx, e.ID, s.buildPoints(e, points, userID)); err != nil {
+		return nil, err
+	}
+	if lastUsed {
+		if err := s.es.ClearLastUsedExcept(ctx, projectID, e.ID); err != nil {
+			return nil, err
+		}
+	}
+	pts, err := s.es.ListPointsByEstimateID(ctx, e.ID)
+	if err != nil {
+		return nil, err
+	}
+	e.Points = pts
+	return e, nil
+}
+
+func (s *EstimateService) Update(ctx context.Context, workspaceSlug string, projectID, estimateID, userID uuid.UUID, name, description, etype *string, lastUsed *bool, points *[]EstimatePointInput) (*model.Estimate, error) {
+	e, err := s.Get(ctx, workspaceSlug, projectID, estimateID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if name != nil {
+		e.Name = *name
+	}
+	if description != nil {
+		e.Description = *description
+	}
+	if etype != nil && *etype != "" {
+		e.Type = *etype
+	}
+	if lastUsed != nil {
+		e.LastUsed = *lastUsed
+	}
+	e.UpdatedByID = &userID
+	if err := s.es.Update(ctx, e); err != nil {
+		return nil, err
+	}
+	if points != nil {
+		if err := s.es.ReplacePoints(ctx, e.ID, s.buildPoints(e, *points, userID)); err != nil {
+			return nil, err
+		}
+	}
+	if lastUsed != nil && *lastUsed {
+		if err := s.es.ClearLastUsedExcept(ctx, projectID, e.ID); err != nil {
+			return nil, err
+		}
+	}
+	pts, err := s.es.ListPointsByEstimateID(ctx, e.ID)
+	if err != nil {
+		return nil, err
+	}
+	e.Points = pts
+	return e, nil
+}
+
+func (s *EstimateService) Delete(ctx context.Context, workspaceSlug string, projectID, estimateID, userID uuid.UUID) error {
+	if _, err := s.Get(ctx, workspaceSlug, projectID, estimateID, userID); err != nil {
+		return err
+	}
+	return s.es.Delete(ctx, estimateID)
+}

--- a/apps/api/internal/service/estimate.go
+++ b/apps/api/internal/service/estimate.go
@@ -96,12 +96,25 @@ func (s *EstimateService) Get(ctx context.Context, workspaceSlug string, project
 	if err != nil || e.ProjectID != projectID {
 		return nil, ErrEstimateNotFound
 	}
-	pts, err := s.es.ListPointsByEstimateID(ctx, e.ID)
+	pts, err := s.points(ctx, e.ID)
 	if err != nil {
 		return nil, err
 	}
 	e.Points = pts
 	return e, nil
+}
+
+// points returns an estimate's points as a non-nil slice so the JSON response
+// always renders an array rather than null.
+func (s *EstimateService) points(ctx context.Context, estimateID uuid.UUID) ([]model.EstimatePoint, error) {
+	pts, err := s.es.ListPointsByEstimateID(ctx, estimateID)
+	if err != nil {
+		return nil, err
+	}
+	if pts == nil {
+		return []model.EstimatePoint{}, nil
+	}
+	return pts, nil
 }
 
 func (s *EstimateService) Create(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID, name, description, etype string, lastUsed bool, points []EstimatePointInput) (*model.Estimate, error) {
@@ -133,7 +146,7 @@ func (s *EstimateService) Create(ctx context.Context, workspaceSlug string, proj
 			return nil, err
 		}
 	}
-	pts, err := s.es.ListPointsByEstimateID(ctx, e.ID)
+	pts, err := s.points(ctx, e.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +185,7 @@ func (s *EstimateService) Update(ctx context.Context, workspaceSlug string, proj
 			return nil, err
 		}
 	}
-	pts, err := s.es.ListPointsByEstimateID(ctx, e.ID)
+	pts, err := s.points(ctx, e.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/store/estimate.go
+++ b/apps/api/internal/store/estimate.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// EstimateStore handles estimate + estimate-point persistence.
+type EstimateStore struct{ db *gorm.DB }
+
+func NewEstimateStore(db *gorm.DB) *EstimateStore { return &EstimateStore{db: db} }
+
+func (s *EstimateStore) Create(ctx context.Context, e *model.Estimate) error {
+	return s.db.WithContext(ctx).Create(e).Error
+}
+
+func (s *EstimateStore) GetByID(ctx context.Context, id uuid.UUID) (*model.Estimate, error) {
+	var e model.Estimate
+	if err := s.db.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", id).First(&e).Error; err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (s *EstimateStore) ListByProjectID(ctx context.Context, projectID uuid.UUID) ([]model.Estimate, error) {
+	var list []model.Estimate
+	err := s.db.WithContext(ctx).
+		Where("project_id = ? AND deleted_at IS NULL", projectID).
+		Order("created_at ASC").Find(&list).Error
+	return list, err
+}
+
+func (s *EstimateStore) Update(ctx context.Context, e *model.Estimate) error {
+	return s.db.WithContext(ctx).Save(e).Error
+}
+
+// Delete soft-deletes the estimate and its points.
+func (s *EstimateStore) Delete(ctx context.Context, id uuid.UUID) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("estimate_id = ?", id).Delete(&model.EstimatePoint{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("id = ?", id).Delete(&model.Estimate{}).Error
+	})
+}
+
+func (s *EstimateStore) ListPointsByEstimateID(ctx context.Context, estimateID uuid.UUID) ([]model.EstimatePoint, error) {
+	var pts []model.EstimatePoint
+	err := s.db.WithContext(ctx).
+		Where("estimate_id = ? AND deleted_at IS NULL", estimateID).
+		Order("key ASC").Find(&pts).Error
+	return pts, err
+}
+
+func (s *EstimateStore) ListPointsByEstimateIDs(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]model.EstimatePoint, error) {
+	out := map[uuid.UUID][]model.EstimatePoint{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	var pts []model.EstimatePoint
+	if err := s.db.WithContext(ctx).
+		Where("estimate_id IN ? AND deleted_at IS NULL", ids).
+		Order("key ASC").Find(&pts).Error; err != nil {
+		return nil, err
+	}
+	for _, p := range pts {
+		out[p.EstimateID] = append(out[p.EstimateID], p)
+	}
+	return out, nil
+}
+
+// ReplacePoints atomically soft-deletes the estimate's existing points and
+// inserts the given ones.
+func (s *EstimateStore) ReplacePoints(ctx context.Context, estimateID uuid.UUID, points []model.EstimatePoint) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("estimate_id = ?", estimateID).Delete(&model.EstimatePoint{}).Error; err != nil {
+			return err
+		}
+		if len(points) > 0 {
+			if err := tx.Create(&points).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ClearLastUsedExcept marks every other estimate in the project inactive so at
+// most one is the active ("last used") system.
+func (s *EstimateStore) ClearLastUsedExcept(ctx context.Context, projectID, keepID uuid.UUID) error {
+	return s.db.WithContext(ctx).Model(&model.Estimate{}).
+		Where("project_id = ? AND id <> ? AND deleted_at IS NULL", projectID, keepID).
+		Update("last_used", false).Error
+}

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -159,6 +159,27 @@ export interface LabelApiResponse {
   updated_at?: string;
 }
 
+export interface EstimatePointApiResponse {
+  id: string;
+  estimate_id: string;
+  key: number;
+  value: string;
+  description?: string;
+}
+
+export interface EstimateApiResponse {
+  id: string;
+  project_id: string;
+  workspace_id: string;
+  name: string;
+  description?: string;
+  type: string;
+  last_used: boolean;
+  points: EstimatePointApiResponse[];
+  created_at?: string;
+  updated_at?: string;
+}
+
 /** Issue as returned by the API (backend uses `name` not `title`) */
 export interface IssueApiResponse {
   id: string;

--- a/apps/web/src/components/settings/ProjectEstimatesSettings.tsx
+++ b/apps/web/src/components/settings/ProjectEstimatesSettings.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { Plus, Pencil, Trash2, X, GripVertical } from 'lucide-react';
+import { Button, Card, Input, Modal } from '../ui';
+import { estimateService } from '../../services/estimateService';
+import type { EstimateApiResponse } from '../../api/types';
+
+interface ProjectEstimatesSettingsProps {
+  workspaceSlug: string;
+  projectId: string;
+}
+
+const ESTIMATE_TYPES: { value: string; label: string }[] = [
+  { value: 'points', label: 'Points' },
+  { value: 'categories', label: 'Categories' },
+];
+
+interface EstimateModalProps {
+  open: boolean;
+  onClose: () => void;
+  initial?: EstimateApiResponse | null;
+  onSubmit: (payload: {
+    name: string;
+    type: string;
+    last_used: boolean;
+    points: { key: number; value: string }[];
+  }) => Promise<void>;
+}
+
+/** Create / edit an estimate system: name, type, and an ordered list of points. */
+function EstimateModal({ open, onClose, initial, onSubmit }: EstimateModalProps) {
+  const [name, setName] = useState('');
+  const [type, setType] = useState('points');
+  const [active, setActive] = useState(false);
+  const [points, setPoints] = useState<string[]>(['', '', '']);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(initial?.name ?? '');
+    setType(initial?.type ?? 'points');
+    setActive(initial?.last_used ?? false);
+    setPoints(
+      initial && initial.points.length > 0 ? initial.points.map((p) => p.value) : ['', '', ''],
+    );
+    setError(null);
+  }, [open, initial]);
+
+  const setPointAt = (i: number, value: string) =>
+    setPoints((prev) => prev.map((p, idx) => (idx === i ? value : p)));
+  const addPoint = () => setPoints((prev) => [...prev, '']);
+  const removePoint = (i: number) => setPoints((prev) => prev.filter((_, idx) => idx !== i));
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    const values = points.map((p) => p.trim()).filter(Boolean);
+    if (!trimmedName || submitting) return;
+    if (values.length === 0) {
+      setError('Add at least one estimate point.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        name: trimmedName,
+        type,
+        last_used: active,
+        points: values.map((value, key) => ({ key, value })),
+      });
+      onClose();
+    } catch {
+      setError('Could not save the estimate system.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={initial ? 'Edit estimate system' : 'New estimate system'}
+    >
+      <form onSubmit={submit} className="space-y-4">
+        <Input
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. T-Shirt sizes"
+          autoFocus
+        />
+        <div>
+          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">Type</label>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:border-(--border-strong) focus:outline-none"
+          >
+            {ESTIMATE_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">Points</label>
+          <div className="space-y-2">
+            {points.map((p, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <GripVertical className="size-4 shrink-0 text-(--txt-icon-tertiary)" aria-hidden />
+                <input
+                  type="text"
+                  value={p}
+                  onChange={(e) => setPointAt(i, e.target.value)}
+                  placeholder={`Point ${i + 1}`}
+                  className="min-w-0 flex-1 rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-1.5 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:border-(--border-strong) focus:outline-none"
+                />
+                <button
+                  type="button"
+                  aria-label={`Remove point ${i + 1}`}
+                  onClick={() => removePoint(i)}
+                  disabled={points.length <= 1}
+                  className="grid size-7 place-items-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-danger-primary) disabled:opacity-40"
+                >
+                  <X className="size-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={addPoint}
+            className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-(--txt-accent-primary) hover:underline"
+          >
+            <Plus className="size-3.5" /> Add point
+          </button>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-(--txt-secondary)">
+          <input
+            type="checkbox"
+            checked={active}
+            onChange={(e) => setActive(e.target.checked)}
+            className="rounded border-(--border-subtle)"
+          />
+          Set as the active estimate system
+        </label>
+        {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
+        <div className="flex justify-end gap-2 pt-1">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!name.trim() || submitting}>
+            {initial ? 'Save changes' : 'Create'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+/**
+ * Project settings → Estimates. Lists the project's estimate systems and lets
+ * members create, edit, delete, and pick the active one.
+ */
+export function ProjectEstimatesSettings({
+  workspaceSlug,
+  projectId,
+}: ProjectEstimatesSettingsProps) {
+  const [estimates, setEstimates] = useState<EstimateApiResponse[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<EstimateApiResponse | null>(null);
+
+  const load = () => {
+    estimateService
+      .list(workspaceSlug, projectId)
+      .then(setEstimates)
+      .catch(() => setEstimates([]));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    estimateService
+      .list(workspaceSlug, projectId)
+      .then((list) => {
+        if (!cancelled) setEstimates(list);
+      })
+      .catch(() => {
+        if (!cancelled) setEstimates([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId]);
+
+  const submit = async (payload: {
+    name: string;
+    type: string;
+    last_used: boolean;
+    points: { key: number; value: string }[];
+  }) => {
+    if (editing) {
+      await estimateService.update(workspaceSlug, projectId, editing.id, payload);
+    } else {
+      await estimateService.create(workspaceSlug, projectId, payload);
+    }
+    load();
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await estimateService.remove(workspaceSlug, projectId, id);
+      load();
+    } catch {
+      // best-effort
+    }
+  };
+
+  const makeActive = async (e: EstimateApiResponse) => {
+    if (e.last_used) return;
+    try {
+      await estimateService.update(workspaceSlug, projectId, e.id, { last_used: true });
+      load();
+    } catch {
+      // best-effort
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-(--txt-primary)">Estimates</h2>
+          <p className="mt-0.5 text-sm text-(--txt-secondary)">
+            Set up estimation systems to track and communicate the effort required for each work
+            item.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          className="gap-1.5"
+          onClick={() => {
+            setEditing(null);
+            setModalOpen(true);
+          }}
+        >
+          <Plus className="size-4" /> Add estimate
+        </Button>
+      </div>
+
+      {estimates.length === 0 ? (
+        <Card variant="outlined" className="p-6 text-center">
+          <p className="text-sm text-(--txt-secondary)">No estimate systems yet.</p>
+          <p className="mt-1 text-xs text-(--txt-tertiary)">
+            Create one to assign effort estimates to work items.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {estimates.map((e) => (
+            <Card key={e.id} variant="outlined" className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-(--txt-primary)">
+                      {e.name}
+                    </span>
+                    {e.last_used && (
+                      <span className="rounded-full bg-(--bg-accent-subtle) px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-(--txt-accent-primary)">
+                        Active
+                      </span>
+                    )}
+                    <span className="text-[11px] capitalize text-(--txt-tertiary)">{e.type}</span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {e.points.map((p) => (
+                      <span
+                        key={p.id}
+                        className="rounded-(--radius-md) bg-(--bg-layer-2) px-2 py-0.5 text-xs text-(--txt-secondary)"
+                      >
+                        {p.value}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  {!e.last_used && (
+                    <Button variant="ghost" size="sm" onClick={() => void makeActive(e)}>
+                      Set active
+                    </Button>
+                  )}
+                  <button
+                    type="button"
+                    aria-label="Edit estimate"
+                    onClick={() => {
+                      setEditing(e);
+                      setModalOpen(true);
+                    }}
+                    className="grid size-7 place-items-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary)"
+                  >
+                    <Pencil className="size-4" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Delete estimate"
+                    onClick={() => void remove(e.id)}
+                    className="grid size-7 place-items-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-danger-primary)"
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <EstimateModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        initial={editing}
+        onSubmit={submit}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/ProjectEstimatesSettings.tsx
+++ b/apps/web/src/components/settings/ProjectEstimatesSettings.tsx
@@ -92,8 +92,14 @@ function EstimateModal({ open, onClose, initial, onSubmit }: EstimateModalProps)
           autoFocus
         />
         <div>
-          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">Type</label>
+          <label
+            htmlFor="estimate-type"
+            className="mb-1 block text-sm font-medium text-(--txt-secondary)"
+          >
+            Type
+          </label>
           <select
+            id="estimate-type"
             value={type}
             onChange={(e) => setType(e.target.value)}
             className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:border-(--border-strong) focus:outline-none"
@@ -105,8 +111,8 @@ function EstimateModal({ open, onClose, initial, onSubmit }: EstimateModalProps)
             ))}
           </select>
         </div>
-        <div>
-          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">Points</label>
+        <fieldset className="min-w-0">
+          <legend className="mb-1 block text-sm font-medium text-(--txt-secondary)">Points</legend>
           <div className="space-y-2">
             {points.map((p, i) => (
               <div key={i} className="flex items-center gap-2">
@@ -137,7 +143,7 @@ function EstimateModal({ open, onClose, initial, onSubmit }: EstimateModalProps)
           >
             <Plus className="size-3.5" /> Add point
           </button>
-        </div>
+        </fieldset>
         <label className="flex items-center gap-2 text-sm text-(--txt-secondary)">
           <input
             type="checkbox"

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'reac
 import { Card, CardContent, Button, Avatar, Modal } from '../components/ui';
 import { CoverImageModal } from '../components/CoverImageModal';
 import { IntegrationsSection } from '../components/integrations/IntegrationsSection';
+import { ProjectEstimatesSettings } from '../components/settings/ProjectEstimatesSettings';
 import { UploadImageModal } from '../components/UploadImageModal';
 import { ProjectIconModal, ProjectIconDisplay } from '../components/ProjectIconModal';
 import { getImageUrl } from '../lib/utils';
@@ -3255,73 +3256,16 @@ export function SettingsPage() {
             </div>
           )}
 
-          {isProjectsTab && selectedProject && projectSection === 'estimates' && (
-            <div className="space-y-6">
-              <div>
-                <h2 className="text-base font-semibold text-(--txt-primary)">Estimates</h2>
-                <p className="mt-0.5 text-sm text-(--txt-secondary)">
-                  Set up estimation systems to track and communicate the effort required for each
-                  work item.
-                </p>
-                <p className="mt-2 text-sm text-(--txt-tertiary)">
-                  Estimate systems will be available when the API is connected.
-                </p>
-              </div>
-              <div className="flex justify-end">
-                <Button size="sm" className="gap-1.5">
-                  <IconPlus /> Add Estimate
-                </Button>
-              </div>
-              <Card variant="outlined" className="p-4">
-                <p className="text-sm font-medium text-(--txt-primary) mb-3">New Estimate</p>
-                <div className="space-y-3">
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
-                      T-Shirt sizes
-                    </label>
-                    <input
-                      type="text"
-                      defaultValue="T-Shirt sizes"
-                      className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">
-                      Description
-                    </label>
-                    <textarea
-                      rows={2}
-                      placeholder="Description..."
-                      className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) placeholder:text-(--txt-placeholder) focus:outline-none focus:border-(--border-strong)"
-                    />
-                  </div>
-                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {['1 XS', '2 S', '3 M', '4 L', '5 XL', '6 XXL'].map((v) => (
-                      <input
-                        key={v}
-                        type="text"
-                        defaultValue={v}
-                        className="rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
-                      />
-                    ))}
-                  </div>
-                  <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
-                    <label className="flex items-center gap-2 text-sm text-(--txt-secondary)">
-                      <input type="checkbox" className="rounded border-(--border-subtle)" />
-                      Create more
-                    </label>
-                    <div className="flex gap-2">
-                      <Button variant="secondary">Cancel</Button>
-                      <Button>Create Work Item</Button>
-                    </div>
-                  </div>
-                </div>
-              </Card>
-              <Button variant="secondary" className="w-full sm:w-auto" onClick={() => {}}>
-                Add estimate system
-              </Button>
-            </div>
-          )}
+          {isProjectsTab &&
+            selectedProject &&
+            workspaceSlug &&
+            selectedProjectId &&
+            projectSection === 'estimates' && (
+              <ProjectEstimatesSettings
+                workspaceSlug={workspaceSlug}
+                projectId={selectedProjectId}
+              />
+            )}
 
           {isProjectsTab && selectedProject && projectSection === 'automations' && (
             <div className="space-y-6">

--- a/apps/web/src/services/estimateService.ts
+++ b/apps/web/src/services/estimateService.ts
@@ -1,0 +1,61 @@
+import { apiClient } from '../api/client';
+import type { EstimateApiResponse } from '../api/types';
+
+export interface EstimatePointInput {
+  key: number;
+  value: string;
+  description?: string;
+}
+
+export interface CreateEstimatePayload {
+  name: string;
+  description?: string;
+  type?: string;
+  last_used?: boolean;
+  points: EstimatePointInput[];
+}
+
+export type UpdateEstimatePayload = Partial<CreateEstimatePayload>;
+
+const projectBase = (workspaceSlug: string, projectId: string) =>
+  `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/estimates/`;
+
+export const estimateService = {
+  async list(workspaceSlug: string, projectId: string): Promise<EstimateApiResponse[]> {
+    const { data } = await apiClient.get<EstimateApiResponse[]>(
+      projectBase(workspaceSlug, projectId),
+    );
+    return Array.isArray(data) ? data : [];
+  },
+
+  async create(
+    workspaceSlug: string,
+    projectId: string,
+    payload: CreateEstimatePayload,
+  ): Promise<EstimateApiResponse> {
+    const { data } = await apiClient.post<EstimateApiResponse>(
+      projectBase(workspaceSlug, projectId),
+      payload,
+    );
+    return data;
+  },
+
+  async update(
+    workspaceSlug: string,
+    projectId: string,
+    estimateId: string,
+    payload: UpdateEstimatePayload,
+  ): Promise<EstimateApiResponse> {
+    const { data } = await apiClient.patch<EstimateApiResponse>(
+      `${projectBase(workspaceSlug, projectId)}${encodeURIComponent(estimateId)}/`,
+      payload,
+    );
+    return data;
+  },
+
+  async remove(workspaceSlug: string, projectId: string, estimateId: string): Promise<void> {
+    await apiClient.delete(
+      `${projectBase(workspaceSlug, projectId)}${encodeURIComponent(estimateId)}/`,
+    );
+  },
+};


### PR DESCRIPTION
## Summary

Part of #127 (estimates & issue types end to end). This change wires
**estimates** end to end on the configuration side; assigning estimate points
to work items and rendering them in views will follow in a separate PR.

### Backend
- Estimate + estimate-point CRUD: `store.EstimateStore` → `service.EstimateService`
  → `handler.EstimateHandler` at
  `/api/workspaces/:slug/projects/:projectId/estimates/` (list/create/get/update/delete).
- Estimates are returned with their ordered points. Create/update replace the
  points atomically; marking a system active clears `last_used` on the others
  (at most one active per project). Workspace-member scoped (mirrors labels).
- Filled in the `Estimate`/`EstimatePoint` models (`description`, `last_used`)
  to match the existing schema — no migration needed.

### Frontend
- `estimateService` + a new `ProjectEstimatesSettings` component that replaces
  the previously stubbed "Estimate systems will be available when the API is
  connected" section. Members can create, edit, and delete estimate systems
  with a dynamic point list, and choose the active system.

### Issue types
Left as the existing string-based `type` field (hidden cleanly per the issue's
acceptance criteria) — no dynamic issue-type management is introduced here.

## Testing

- `go test ./internal/handler -run TestEstimates` — pass (real Postgres via
  testcontainers): full CRUD incl. point replacement + active toggle, and
  non-member access returns 404.
- `go vet ./...`, UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright) against the running stack: created a
  "T-Shirt sizes" system with S/M/L points marked active (renders with the
  ACTIVE badge and point chips), then deleted it (back to the empty state).

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
the test suite and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project estimate management across the app: list, create, view, update, delete, and set an estimate set as active.
  * Estimates now include descriptions and ordered points, with API + UI support for an `last_used` active flag.
* **Bug Fixes**
  * Unauthorized/non-member users now receive a not-found response instead of leaking estimate details.
  * Improved CRUD handling with consistent status codes and safe defaults when lists are empty.
* **Tests**
  * Added integration tests covering the full estimates lifecycle and access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->