### PR TITLE
feat(estimates): assign estimate points to work items

### DIFF
--- a/apps/api/internal/handler/epic.go
+++ b/apps/api/internal/handler/epic.go
@@ -205,7 +205,7 @@ func (h *EpicHandler) UpdateEpic(c *gin.Context) {
 		tmp := body.LabelIDs
 		labelIDs = &tmp
 	}
-	epic, err := h.Issue.Update(c.Request.Context(), slug, projectID, eID, user.ID, name, priority, body.Description, body.StateID, assigneeIDs, labelIDs, nil, nil, nil, nil, nil)
+	epic, err := h.Issue.Update(c.Request.Context(), slug, projectID, eID, user.ID, name, priority, body.Description, body.StateID, assigneeIDs, labelIDs, nil, nil, nil, nil, nil, false, nil)
 	if err != nil {
 		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})

--- a/apps/api/internal/handler/estimate_test.go
+++ b/apps/api/internal/handler/estimate_test.go
@@ -63,6 +63,40 @@ func TestEstimates_CRUD(t *testing.T) {
 	require.NotContains(t, ts.GET(base, w.Session).Body.String(), "Sizes")
 }
 
+func TestEstimates_AssignToWorkItem(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	estBase := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/estimates/"
+
+	// An estimate with one point.
+	rc := ts.POST(estBase, map[string]any{
+		"name":   "Sizes",
+		"points": []map[string]any{{"key": 0, "value": "M"}},
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, rc.Code, "body=%s", rc.Body.String())
+	pts, _ := testutil.MustJSONMap(t, rc)["points"].([]any)
+	require.Len(t, pts, 1)
+	pointID, _ := pts[0].(map[string]any)["id"].(string)
+	require.NotEmpty(t, pointID)
+
+	// A work item, then assign the estimate point to it.
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	issueBase := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/" + issue.ID.String() + "/"
+
+	ru := ts.PATCH(issueBase, map[string]any{"estimate_point_id": pointID}, w.Session)
+	require.Equal(t, http.StatusOK, ru.Code, "body=%s", ru.Body.String())
+	require.Equal(t, pointID, testutil.MustJSONMap(t, ru)["estimate_point_id"])
+
+	// Persisted on GET.
+	require.Equal(t, pointID, testutil.MustJSONMap(t, ts.GET(issueBase, w.Session))["estimate_point_id"])
+
+	// Clearing it with "" removes the estimate.
+	rclear := ts.PATCH(issueBase, map[string]any{"estimate_point_id": ""}, w.Session)
+	require.Equal(t, http.StatusOK, rclear.Code, "body=%s", rclear.Body.String())
+	_, present := testutil.MustJSONMap(t, ts.GET(issueBase, w.Session))["estimate_point_id"]
+	require.False(t, present, "estimate_point_id should be omitted once cleared")
+}
+
 func TestEstimates_NonMemberForbidden(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/apps/api/internal/handler/issue.go
+++ b/apps/api/internal/handler/issue.go
@@ -209,6 +209,8 @@ func (h *IssueHandler) Update(c *gin.Context) {
 		LabelIDs        []uuid.UUID `json:"label_ids"`
 		IsDraft         *bool       `json:"is_draft"`
 		Type            string      `json:"type"`
+		// estimate_point_id: omitted = leave alone, "" = clear, uuid = set.
+		EstimatePointID *string `json:"estimate_point_id"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
@@ -262,7 +264,20 @@ func (h *IssueHandler) Update(c *gin.Context) {
 	if body.Type != "" {
 		issueType = &body.Type
 	}
-	issue, err := h.Issue.Update(c.Request.Context(), slug, projectID, issueID, user.ID, name, priority, description, body.StateID, assigneeIDs, labelIDs, startDate, targetDate, body.ParentID, body.IsDraft, issueType)
+	var estimatePointIDSet bool
+	var estimatePointID *uuid.UUID
+	if body.EstimatePointID != nil {
+		estimatePointIDSet = true
+		if *body.EstimatePointID != "" {
+			pid, err := uuid.Parse(*body.EstimatePointID)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid estimate_point_id"})
+				return
+			}
+			estimatePointID = &pid
+		}
+	}
+	issue, err := h.Issue.Update(c.Request.Context(), slug, projectID, issueID, user.ID, name, priority, description, body.StateID, assigneeIDs, labelIDs, startDate, targetDate, body.ParentID, body.IsDraft, issueType, estimatePointIDSet, estimatePointID)
 	if err != nil {
 		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Issue not found"})

--- a/apps/api/internal/model/issue.go
+++ b/apps/api/internal/model/issue.go
@@ -35,6 +35,7 @@ type Issue struct {
 	IsDraft         bool           `gorm:"column:is_draft;default:false" json:"is_draft"`
 	IsEpic          bool           `gorm:"column:is_epic;default:false" json:"is_epic"`
 	Type            string         `gorm:"type:varchar(50);default:task" json:"type,omitempty"`
+	EstimatePointID *uuid.UUID     `gorm:"column:estimate_point_id;type:uuid" json:"estimate_point_id,omitempty"`
 }
 
 func (Issue) TableName() string { return "issues" }

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -249,7 +249,7 @@ func (s *IssueService) BulkUpdate(ctx context.Context, workspaceSlug string, pro
 	n := 0
 	var firstErr error
 	for _, id := range issueIDs {
-		if _, err := s.Update(ctx, workspaceSlug, projectID, id, userID, nil, priority, nil, stateID, nil, nil, nil, nil, nil, nil, nil); err != nil {
+		if _, err := s.Update(ctx, workspaceSlug, projectID, id, userID, nil, priority, nil, stateID, nil, nil, nil, nil, nil, nil, nil, false, nil); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -456,7 +456,7 @@ func (s *IssueService) Create(ctx context.Context, workspaceSlug string, project
 	return issue, nil
 }
 
-func (s *IssueService) Update(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, name, priority, description *string, stateID *uuid.UUID, assigneeIDs, labelIDs *[]uuid.UUID, startDate, targetDate *time.Time, parentID *uuid.UUID, isDraft *bool, issueType *string) (*model.Issue, error) {
+func (s *IssueService) Update(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, name, priority, description *string, stateID *uuid.UUID, assigneeIDs, labelIDs *[]uuid.UUID, startDate, targetDate *time.Time, parentID *uuid.UUID, isDraft *bool, issueType *string, estimatePointIDSet bool, estimatePointID *uuid.UUID) (*model.Issue, error) {
 	issue, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID)
 	if err != nil {
 		return nil, err
@@ -498,6 +498,9 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 	}
 	if issueType != nil && *issueType != "" {
 		issue.Type = *issueType
+	}
+	if estimatePointIDSet {
+		issue.EstimatePointID = estimatePointID
 	}
 	issue.UpdatedByID = &userID
 	if err := s.is.Update(ctx, issue); err != nil {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -207,6 +207,7 @@ export interface IssueApiResponse {
   is_draft?: boolean;
   is_epic?: boolean;
   type?: string;
+  estimate_point_id?: string | null;
 }
 
 /** External URL linked to an issue */

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -16,6 +16,7 @@ import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
 import { cycleService } from '../services/cycleService';
 import { moduleService } from '../services/moduleService';
+import { estimateService } from '../services/estimateService';
 import { recentsService } from '../services/recentsService';
 import { commentService } from '../services/commentService';
 import { CreateWorkItemModal } from '../components/CreateWorkItemModal';
@@ -40,6 +41,7 @@ import type {
   IssueActivityApiResponse,
   CycleApiResponse,
   ModuleApiResponse,
+  EstimateApiResponse,
   IssueLinkApiResponse,
   IssueRelationApiResponse,
   IssueAttachmentApiResponse,
@@ -233,6 +235,23 @@ const IconType = () => (
   </svg>
 );
 
+const IconEstimate = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden
+  >
+    <path d="M12 14a6 6 0 1 0-6-6" />
+    <path d="M6 8H2" />
+    <path d="m12 14 3-3" />
+    <circle cx="12" cy="14" r="1.5" fill="currentColor" stroke="none" />
+  </svg>
+);
+
 const WORK_ITEM_TYPES = [
   { value: 'task', label: 'Task' },
   { value: 'bug', label: 'Bug' },
@@ -285,6 +304,7 @@ export function IssueDetailPage() {
   const [cycles, setCycles] = useState<CycleApiResponse[]>([]);
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
+  const [estimates, setEstimates] = useState<EstimateApiResponse[]>([]);
   const [allIssues, setAllIssues] = useState<IssueApiResponse[]>([]);
   const [comments, setComments] = useState<IssueCommentApiResponse[]>([]);
   const [activities, setActivities] = useState<IssueActivityApiResponse[]>([]);
@@ -321,6 +341,22 @@ export function IssueDetailPage() {
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
 
   useDocumentTitle(loading ? 'Work item' : (issue?.name ?? 'Work item'));
+
+  useEffect(() => {
+    if (!workspaceSlug || !projectId) return;
+    let cancelled = false;
+    estimateService
+      .list(workspaceSlug, projectId)
+      .then((list) => {
+        if (!cancelled) setEstimates(list);
+      })
+      .catch(() => {
+        if (!cancelled) setEstimates([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId]);
 
   useEffect(() => {
     if (!workspaceSlug || !projectId || !issueId) {
@@ -616,6 +652,14 @@ export function IssueDetailPage() {
       setDeletingCommentId(null);
     }
   };
+
+  // Estimate picker: offer the project's active estimate's points; resolve the
+  // currently-selected point across all estimates so it renders even if it
+  // belongs to a since-deactivated system.
+  const activeEstimate = estimates.find((e) => e.last_used) ?? estimates[0] ?? null;
+  const estimatePoints = activeEstimate?.points ?? [];
+  const currentEstimatePoint =
+    estimates.flatMap((e) => e.points).find((p) => p.id === issue.estimate_point_id) ?? null;
 
   return (
     <div className="space-y-6">
@@ -1734,6 +1778,57 @@ export function IssueDetailPage() {
                   ))}
                 </Dropdown>
               </PropertyRow>
+
+              {/* Estimate */}
+              {estimatePoints.length > 0 && (
+                <PropertyRow icon={<IconEstimate />} label="Estimate">
+                  <Dropdown
+                    id="estimate"
+                    openId={openDropdown}
+                    onOpen={setOpenDropdown}
+                    label="Estimate"
+                    icon={<IconEstimate />}
+                    displayValue=""
+                    align="right"
+                    triggerClassName={GHOST_TRIGGER}
+                    triggerContent={
+                      <span className="text-(--txt-secondary)">
+                        {currentEstimatePoint?.value ?? 'No estimate'}
+                      </span>
+                    }
+                  >
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
+                      onClick={() => {
+                        setOpenDropdown(null);
+                        updateIssue({ estimate_point_id: '' });
+                      }}
+                    >
+                      <span className="text-(--txt-primary)">No estimate</span>
+                      {!issue.estimate_point_id && (
+                        <span className="ml-auto text-xs text-(--txt-tertiary)">Selected</span>
+                      )}
+                    </button>
+                    {estimatePoints.map((p) => (
+                      <button
+                        key={p.id}
+                        type="button"
+                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
+                        onClick={() => {
+                          setOpenDropdown(null);
+                          updateIssue({ estimate_point_id: p.id });
+                        }}
+                      >
+                        <span className="text-(--txt-primary)">{p.value}</span>
+                        {issue.estimate_point_id === p.id && (
+                          <span className="ml-auto text-xs text-(--txt-tertiary)">Selected</span>
+                        )}
+                      </button>
+                    ))}
+                  </Dropdown>
+                </PropertyRow>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -78,6 +78,8 @@ export const issueService = {
         is_draft?: boolean;
         description_html?: string;
         type?: string;
+        /** uuid to set, "" to clear, omit to leave unchanged */
+        estimate_point_id?: string | null;
       }
     >,
   ): Promise<IssueApiResponse> {


### PR DESCRIPTION
## Summary

Completes #127 (estimates & issue types end to end), building on #222 which
added estimate-system management in project settings.

### Backend
- Added `estimate_point_id` to the `Issue` model and threaded it through the
  issue update path. Semantics on PATCH: field omitted = leave unchanged,
  `""` = clear, a uuid = set. (`IssueStore.Update` uses `Save`, so a nil FK
  clears the column.)

### Frontend
- Work-item detail page now has an **Estimate** property: a dropdown of the
  project's active estimate's points (plus "No estimate") that sets/clears the
  estimate; the selected point's value renders in the property row. The detail
  page loads the project's estimates to resolve the value.
- `estimate_point_id` added to `IssueApiResponse` and the issue update payload.

### Scope notes
- Surfacing the estimate as a **column** in the list/board/etc. layouts is part
  of #174 (applying group-by + display properties across all work-item
  layouts) — the layouts don't yet consume display properties at all.
- **Issue types** remain the existing string `type` field, hidden cleanly per
  the issue's acceptance criteria.

## Testing

- `go test ./internal/handler -run TestEstimates` — pass (real Postgres via
  testcontainers), including a new test that assigns an estimate point to a
  work item, reads it back, and clears it with `""`.
- `go vet ./...`, UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright) against the running stack: opened a work
  item, the Estimate row showed "No estimate", selecting "M" persisted
  `estimate_point_id` and rendered "M" (0 console errors).

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
the test suite and in-browser checks.