### PR TITLE
feat(cycles): render a real cycle burndown chart

### DIFF
--- a/apps/web/src/components/cycles/CycleBurndownChart.tsx
+++ b/apps/web/src/components/cycles/CycleBurndownChart.tsx
@@ -70,7 +70,13 @@ export function CycleBurndownChart({
         day,
         // Only plot the actual line up to (and including) today.
         pending: day <= today ? remaining : null,
-        ideal: ranged ? Math.round(((total * (lastIdx - i)) / lastIdx) * 10) / 10 : null,
+        // Ideal line from total -> 0; a single-day cycle (lastIdx === 0) has no
+        // slope, so anchor it at 0 to avoid dividing by zero.
+        ideal: ranged
+          ? lastIdx > 0
+            ? Math.round(((total * (lastIdx - i)) / lastIdx) * 10) / 10
+            : 0
+          : null,
       };
     });
   }, [completionChart, total, startDate, endDate]);

--- a/apps/web/src/components/cycles/CycleBurndownChart.tsx
+++ b/apps/web/src/components/cycles/CycleBurndownChart.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface CycleBurndownChartProps {
+  /** Map of YYYY-MM-DD -> number of work items completed that day. */
+  completionChart: Record<string, number | null>;
+  /** Total work items in the cycle (the burndown starts here). */
+  total: number;
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
+/** Inclusive list of YYYY-MM-DD strings between two dates (UTC), or [] if invalid. */
+function eachDay(start: string, end: string): string[] {
+  const out: string[] = [];
+  const s = new Date(`${start}T00:00:00Z`);
+  const e = new Date(`${end}T00:00:00Z`);
+  if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime()) || e < s) return out;
+  // Cap to a sane span so a misconfigured cycle can't produce a huge series.
+  for (let i = 0; i < 366 && s <= e; i++) {
+    out.push(s.toISOString().slice(0, 10));
+    s.setUTCDate(s.getUTCDate() + 1);
+  }
+  return out;
+}
+
+interface BurndownPoint {
+  day: string;
+  pending: number | null;
+  ideal: number | null;
+}
+
+/**
+ * A real burndown line chart for a cycle: the actual pending (remaining) work
+ * items per day, derived from the per-day completion counts and the cycle
+ * total, plotted against an ideal straight line. Handles cycles without dates
+ * and empty completion data cleanly.
+ */
+export function CycleBurndownChart({
+  completionChart,
+  total,
+  startDate,
+  endDate,
+}: CycleBurndownChartProps) {
+  const data = useMemo<BurndownPoint[]>(() => {
+    const start = startDate?.slice(0, 10);
+    const end = endDate?.slice(0, 10);
+    const ranged = Boolean(start && end);
+    const days = ranged
+      ? eachDay(start!, end!)
+      : Object.keys(completionChart)
+          .filter((k) => completionChart[k] != null)
+          .sort();
+    if (days.length === 0) return [];
+    const today = new Date().toISOString().slice(0, 10);
+    const lastIdx = days.length - 1;
+    let cumulative = 0;
+    return days.map((day, i) => {
+      cumulative += completionChart[day] ?? 0;
+      const remaining = Math.max(0, total - cumulative);
+      return {
+        day,
+        // Only plot the actual line up to (and including) today.
+        pending: day <= today ? remaining : null,
+        ideal: ranged ? Math.round(((total * (lastIdx - i)) / lastIdx) * 10) / 10 : null,
+      };
+    });
+  }, [completionChart, total, startDate, endDate]);
+
+  if (data.length === 0) {
+    return (
+      <p className="text-xs text-(--txt-tertiary)">
+        Add start and due dates to the cycle to see the burndown.
+      </p>
+    );
+  }
+
+  return (
+    <div className="h-48 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -18 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border-subtle)" vertical={false} />
+          <XAxis
+            dataKey="day"
+            tick={{ fontSize: 10, fill: 'var(--txt-tertiary)' }}
+            tickLine={{ stroke: 'var(--border-subtle)' }}
+            tickFormatter={(d: string) => d.slice(5)}
+            minTickGap={20}
+          />
+          <YAxis
+            allowDecimals={false}
+            width={28}
+            tick={{ fontSize: 10, fill: 'var(--txt-tertiary)' }}
+            tickLine={{ stroke: 'var(--border-subtle)' }}
+          />
+          <Tooltip
+            contentStyle={{
+              background: 'var(--bg-surface-1)',
+              border: '1px solid var(--border-subtle)',
+              borderRadius: 8,
+              fontSize: 12,
+            }}
+            labelStyle={{ color: 'var(--txt-secondary)' }}
+          />
+          <Line
+            type="linear"
+            dataKey="ideal"
+            name="Ideal"
+            stroke="var(--txt-tertiary)"
+            strokeDasharray="4 4"
+            dot={false}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="pending"
+            name="Pending"
+            stroke="var(--brand-default)"
+            strokeWidth={2}
+            dot={false}
+            connectNulls={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CycleDetailPage.tsx
+++ b/apps/web/src/pages/CycleDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { Badge } from '../components/ui';
+import { CycleBurndownChart } from '../components/cycles/CycleBurndownChart';
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
 import { cycleService, type CycleProgressResponse } from '../services/cycleService';
@@ -43,55 +44,6 @@ function ProgressBar({ value, max, color }: { value: number; max: number; color:
         />
       </div>
       <span className="w-8 text-right text-xs tabular-nums text-(--txt-tertiary)">{pct}%</span>
-    </div>
-  );
-}
-
-function BurndownChart({
-  chart,
-  startDate,
-  endDate,
-}: {
-  chart: Record<string, number | null>;
-  startDate?: string | null;
-  endDate?: string | null;
-}) {
-  const entries = Object.entries(chart)
-    .filter(([, v]) => v != null)
-    .sort(([a], [b]) => a.localeCompare(b));
-  if (entries.length === 0) {
-    return <p className="text-xs text-(--txt-tertiary)">No completion data yet.</p>;
-  }
-  const maxVal = Math.max(...entries.map(([, v]) => v as number), 1);
-  return (
-    <div>
-      <p className="mb-2 text-xs font-medium text-(--txt-secondary)">Completions per day</p>
-      <div className="flex h-24 items-end gap-0.5 overflow-x-auto">
-        {entries.map(([date, count]) => {
-          const h = Math.round(((count as number) / maxVal) * 100);
-          return (
-            <div
-              key={date}
-              className="group relative flex flex-col items-center"
-              style={{ minWidth: 12 }}
-            >
-              <div
-                className="w-2.5 rounded-t bg-(--bg-accent-primary) opacity-80 transition-all group-hover:opacity-100"
-                style={{ height: `${h}%` }}
-              />
-              <div className="absolute bottom-full mb-1 hidden whitespace-nowrap rounded bg-(--bg-surface-1) px-1.5 py-0.5 text-[10px] text-(--txt-secondary) shadow group-hover:block">
-                {date}: {count}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      {(startDate || endDate) && (
-        <div className="mt-1 flex justify-between text-[10px] text-(--txt-tertiary)">
-          <span>{startDate ? formatDate(startDate) : ''}</span>
-          <span>{endDate ? formatDate(endDate) : ''}</span>
-        </div>
-      )}
     </div>
   );
 }
@@ -217,15 +169,13 @@ export function CycleDetailPage() {
 
           {/* Burndown chart */}
           <div className="rounded-md border border-(--border-subtle) bg-(--bg-surface-1) p-4">
-            {progress.distribution?.completion_chart ? (
-              <BurndownChart
-                chart={progress.distribution.completion_chart as Record<string, number | null>}
-                startDate={cycle.start_date}
-                endDate={cycle.end_date}
-              />
-            ) : (
-              <p className="text-xs text-(--txt-tertiary)">No completion data yet.</p>
-            )}
+            <p className="mb-2 text-xs font-medium text-(--txt-secondary)">Burndown</p>
+            <CycleBurndownChart
+              completionChart={progress.distribution?.completion_chart ?? {}}
+              total={progress.total_issues}
+              startDate={cycle.start_date}
+              endDate={cycle.end_date}
+            />
           </div>
         </div>
       )}

--- a/apps/web/src/pages/CyclesPage.tsx
+++ b/apps/web/src/pages/CyclesPage.tsx
@@ -584,10 +584,13 @@ export function CyclesPage() {
       cancelled = true;
     };
   }, [workspaceSlug, projectId, activeCycleId]);
-  const activeBurndownChart =
+  // Both the burndown total and the per-day completions must come from the same
+  // (progress endpoint) source so the baseline matches the curve.
+  const activeProgress =
     activeCycleProgress && activeCycleId && activeCycleProgress.cycleId === activeCycleId
-      ? activeCycleProgress.progress.distribution?.completion_chart
-      : undefined;
+      ? activeCycleProgress.progress
+      : null;
+  const activeBurndownChart = activeProgress?.distribution?.completion_chart;
 
   const getIssueCount = (cycleId: string) => cycles.find((c) => c.id === cycleId)?.issue_count ?? 0;
   const getProgress = (c: CycleApiResponse) => {
@@ -637,6 +640,10 @@ export function CyclesPage() {
     const percentClosed = total > 0 ? Math.round((completed / total) * 100) : 0;
     return { started, backlog, completed, total, percentClosed };
   })();
+
+  // Burndown baseline: prefer the progress endpoint's total (same source as the
+  // completion chart), falling back to the client-side count before it loads.
+  const activeBurndownTotal = activeProgress?.total_issues ?? activeCycleProgressStats.total;
 
   const activeCycleAssigneeStats = (() => {
     if (!activeCycle) return [];
@@ -1122,7 +1129,7 @@ export function CyclesPage() {
                   <div className="mt-4">
                     <CycleBurndownChart
                       completionChart={activeBurndownChart ?? {}}
-                      total={activeCycleProgressStats.total}
+                      total={activeBurndownTotal}
                       startDate={activeCycle.start_date}
                       endDate={activeCycle.end_date}
                     />

--- a/apps/web/src/pages/CyclesPage.tsx
+++ b/apps/web/src/pages/CyclesPage.tsx
@@ -4,7 +4,8 @@ import { Avatar, Badge, Button, Modal } from '../components/ui';
 import { UpdateCycleModal } from '../components/UpdateCycleModal';
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
-import { cycleService } from '../services/cycleService';
+import { cycleService, type CycleProgressResponse } from '../services/cycleService';
+import { CycleBurndownChart } from '../components/cycles/CycleBurndownChart';
 import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
@@ -314,6 +315,10 @@ export function CyclesPage() {
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [labels, setLabels] = useState<LabelApiResponse[]>([]);
+  const [activeCycleProgress, setActiveCycleProgress] = useState<{
+    cycleId: string;
+    progress: CycleProgressResponse;
+  } | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeCycleExpanded, setActiveCycleExpanded] = useState(true);
   const [activeCycleTab, setActiveCycleTab] = useState<'priority' | 'assignees' | 'labels'>(
@@ -559,6 +564,30 @@ export function CyclesPage() {
     if (!activeCycle) return [];
     return issues.filter((i) => i.cycle_ids?.includes(activeCycle.id));
   }, [issues, activeCycle]);
+
+  // Fetch the active cycle's progress snapshot (for the burndown chart). The
+  // result is keyed by cycle id so a stale snapshot from a previously active
+  // cycle is ignored during render (see progressForActive).
+  const activeCycleId = activeCycle?.id;
+  useEffect(() => {
+    if (!workspaceSlug || !projectId || !activeCycleId) return;
+    let cancelled = false;
+    cycleService
+      .getProgress(workspaceSlug, projectId, activeCycleId)
+      .then((snap) => {
+        if (!cancelled) setActiveCycleProgress({ cycleId: activeCycleId, progress: snap });
+      })
+      .catch(() => {
+        if (!cancelled) setActiveCycleProgress(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug, projectId, activeCycleId]);
+  const activeBurndownChart =
+    activeCycleProgress && activeCycleId && activeCycleProgress.cycleId === activeCycleId
+      ? activeCycleProgress.progress.distribution?.completion_chart
+      : undefined;
 
   const getIssueCount = (cycleId: string) => cycles.find((c) => c.id === cycleId)?.issue_count ?? 0;
   const getProgress = (c: CycleApiResponse) => {
@@ -1090,11 +1119,13 @@ export function CyclesPage() {
                   </span>
                 </div>
                 {activeCycleProgressStats.total > 0 ? (
-                  <div className="mt-4 flex flex-col items-center justify-center py-6">
-                    <IconActivity />
-                    <p className="mt-2 text-center text-sm text-(--txt-tertiary)">
-                      Burndown chart coming soon.
-                    </p>
+                  <div className="mt-4">
+                    <CycleBurndownChart
+                      completionChart={activeBurndownChart ?? {}}
+                      total={activeCycleProgressStats.total}
+                      startDate={activeCycle.start_date}
+                      endDate={activeCycle.end_date}
+                    />
                   </div>
                 ) : (
                   <div className="mt-4 flex flex-col items-center justify-center py-6">


### PR DESCRIPTION
## Summary

Closes #130.

Replaces the "Burndown chart coming soon." placeholder on the cycles page with
a real burndown line chart, using the cycle progress data the API already
returns.

- **New `CycleBurndownChart`** (Recharts `LineChart`): plots the actual
  *pending* work items per day — derived from the cycle total and the per-day
  completion counts in the progress response (`distribution.completion_chart`)
  — against an ideal straight line from total → 0. The actual line stops at
  today; the ideal spans the cycle.
- **CyclesPage**: fetches the active cycle's progress (kept keyed by cycle id so
  a stale snapshot from a previously active cycle is ignored) and renders the
  chart in the burndown card. The "add work items" empty state is preserved.
- **CycleDetailPage**: now reuses the same component, replacing the old per-day
  bar chart so the overview and detail views match.
- Handles cycles **without dates** and with **no completion data** cleanly
  (renders the flat/ideal lines or a short hint instead of crashing).

## Testing

- UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright) against the running stack: created an active
  cycle with work items and dates → the burndown card renders the line chart
  (pending + ideal) on both the cycles overview and the cycle detail page, with
  0 console errors; the no-active-cycle and no-cycles states render without
  errors (caught and fixed a null-deref in the no-active-cycle path during
  verification).

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
typecheck/lint and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared cycle burndown chart that visualizes remaining work over time, with an ideal straight-line trend when the date range is available.
  * The burndown chart is now shown on both cycle detail and cycles list for the active cycle, using live progress data.

* **Bug Fixes**
  * Improved handling for missing/empty completion data with a clear instructional fallback.
  * Limits burndown history to a reasonable range and prevents future values from showing beyond today for cleaner reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->