### PR TITLE
feat(views): render kanban/calendar/gantt for saved workspace views

### DIFF
--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -8,6 +8,7 @@ import { useWorkspaceViewsState } from '../../contexts/WorkspaceViewsStateContex
 import {
   WorkspaceViewsFiltersDropdown,
   WorkspaceViewsDisplayDropdown,
+  WorkspaceViewsLayoutSelector,
   WorkspaceViewsEllipsisMenu,
   CreateViewModal,
   ModuleFiltersPanel,
@@ -3031,6 +3032,7 @@ function WorkspaceViewsHeader() {
         </Dropdown>
       </div>
       <div className="flex items-center gap-1">
+        <WorkspaceViewsLayoutSelector />
         <WorkspaceViewsFiltersDropdown
           openId={toolbarDropdownOpen}
           onOpen={setToolbarDropdownOpen}

--- a/apps/web/src/components/work-item/layouts/IssueLayoutBoard.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutBoard.tsx
@@ -11,7 +11,7 @@ import {
 import { membersFromAssigneeIds } from '../../../lib/issueRowHelpers';
 import type { IssueApiResponse, LabelApiResponse } from '../../../api/types';
 import type { Priority } from '../../../types';
-import type { IssueLayoutProps } from './IssueLayoutTypes';
+import { issueDisplayId, type IssueLayoutProps } from './IssueLayoutTypes';
 
 /**
  * Kanban board grouped by state. One column per state, ordered by `sequence`,
@@ -29,6 +29,7 @@ export function IssueLayoutBoard({
   prSummary,
   issueHref,
   now,
+  projectsById,
 }: IssueLayoutProps) {
   const labelById = useMemo(() => new Map(labels.map((l) => [l.id, l])), [labels]);
   const orderedStates = useMemo(
@@ -69,6 +70,7 @@ export function IssueLayoutBoard({
                 key={issue.id}
                 issue={issue}
                 project={project}
+                projectsById={projectsById}
                 state={state}
                 labels={(issue.label_ids ?? [])
                   .map((id) => labelById.get(id))
@@ -93,6 +95,7 @@ export function IssueLayoutBoard({
               key={issue.id}
               issue={issue}
               project={project}
+              projectsById={projectsById}
               state={null}
               labels={(issue.label_ids ?? [])
                 .map((id) => labelById.get(id))
@@ -142,6 +145,7 @@ function BoardColumn({
 interface BoardCardProps {
   issue: IssueApiResponse;
   project: IssueLayoutProps['project'];
+  projectsById?: IssueLayoutProps['projectsById'];
   state: IssueLayoutProps['states'][number] | null;
   labels: LabelApiResponse[];
   assignees: ReturnType<typeof membersFromAssigneeIds>;
@@ -153,6 +157,7 @@ interface BoardCardProps {
 function BoardCard({
   issue,
   project,
+  projectsById,
   state,
   labels,
   assignees,
@@ -160,7 +165,7 @@ function BoardCard({
   href,
   now,
 }: BoardCardProps) {
-  const displayId = `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`;
+  const displayId = issueDisplayId(issue, project, projectsById);
   return (
     <Link
       to={href}

--- a/apps/web/src/components/work-item/layouts/IssueLayoutBoard.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutBoard.tsx
@@ -11,7 +11,12 @@ import {
 import { membersFromAssigneeIds } from '../../../lib/issueRowHelpers';
 import type { IssueApiResponse, LabelApiResponse } from '../../../api/types';
 import type { Priority } from '../../../types';
-import { issueDisplayId, type IssueLayoutProps } from './IssueLayoutTypes';
+import {
+  issueDisplayId,
+  STATE_GROUP_LABELS,
+  STATE_GROUP_ORDER,
+  type IssueLayoutProps,
+} from './IssueLayoutTypes';
 
 /**
  * Kanban board grouped by state. One column per state, ordered by `sequence`,
@@ -30,20 +35,47 @@ export function IssueLayoutBoard({
   issueHref,
   now,
   projectsById,
+  groupByStateGroup,
 }: IssueLayoutProps) {
   const labelById = useMemo(() => new Map(labels.map((l) => [l.id, l])), [labels]);
-  const orderedStates = useMemo(
-    () =>
-      [...states].sort(
-        (a, b) => (a.sequence ?? 0) - (b.sequence ?? 0) || a.name.localeCompare(b.name),
-      ),
-    [states],
-  );
+  const stateById = useMemo(() => new Map(states.map((s) => [s.id, s])), [states]);
 
-  const groups = useMemo(() => {
+  // Build the columns + the leftover "No state" bucket. In group mode columns
+  // are the canonical state groups present in the workspace (so a multi-project
+  // board doesn't repeat "Todo/In Progress/Done" once per project); otherwise
+  // one column per individual state.
+  const { columns, orphans } = useMemo(() => {
+    const orphans: IssueApiResponse[] = [];
+
+    if (groupByStateGroup) {
+      const buckets = new Map<string, IssueApiResponse[]>();
+      for (const issue of issues) {
+        const group = issue.state_id ? stateById.get(issue.state_id)?.group : undefined;
+        if (group && STATE_GROUP_ORDER.includes(group as (typeof STATE_GROUP_ORDER)[number])) {
+          const arr = buckets.get(group) ?? [];
+          arr.push(issue);
+          buckets.set(group, arr);
+        } else {
+          orphans.push(issue);
+        }
+      }
+      const presentGroups = new Set(states.map((s) => s.group).filter(Boolean) as string[]);
+      const columns = STATE_GROUP_ORDER.filter(
+        (g) => presentGroups.has(g) || (buckets.get(g)?.length ?? 0) > 0,
+      ).map((g) => ({
+        key: g,
+        title: STATE_GROUP_LABELS[g] ?? g,
+        color: undefined as string | undefined,
+        items: buckets.get(g) ?? [],
+      }));
+      return { columns, orphans };
+    }
+
+    const orderedStates = [...states].sort(
+      (a, b) => (a.sequence ?? 0) - (b.sequence ?? 0) || a.name.localeCompare(b.name),
+    );
     const buckets = new Map<string, IssueApiResponse[]>();
     for (const s of orderedStates) buckets.set(s.id, []);
-    const orphans: IssueApiResponse[] = [];
     for (const issue of issues) {
       if (issue.state_id && buckets.has(issue.state_id)) {
         buckets.get(issue.state_id)!.push(issue);
@@ -51,61 +83,46 @@ export function IssueLayoutBoard({
         orphans.push(issue);
       }
     }
-    return { buckets, orphans };
-  }, [orderedStates, issues]);
+    const columns = orderedStates.map((s) => ({
+      key: s.id,
+      title: s.name,
+      color: s.color ?? undefined,
+      items: buckets.get(s.id) ?? [],
+    }));
+    return { columns, orphans };
+  }, [groupByStateGroup, states, issues, stateById]);
+
+  const renderCard = (issue: IssueApiResponse) => (
+    <BoardCard
+      key={issue.id}
+      issue={issue}
+      project={project}
+      projectsById={projectsById}
+      state={issue.state_id ? (stateById.get(issue.state_id) ?? null) : null}
+      labels={(issue.label_ids ?? [])
+        .map((id) => labelById.get(id))
+        .filter((l): l is LabelApiResponse => Boolean(l))}
+      assignees={membersFromAssigneeIds(members, issue.assignee_ids ?? [])}
+      prSummary={prSummary[issue.id]}
+      href={issueHref(issue.id)}
+      now={now}
+    />
+  );
 
   return (
     <div className="flex gap-3 overflow-x-auto px-4 py-4">
-      {orderedStates.map((state) => {
-        const colIssues = groups.buckets.get(state.id) ?? [];
-        return (
-          <BoardColumn
-            key={state.id}
-            title={state.name}
-            color={state.color}
-            count={colIssues.length}
-          >
-            {colIssues.map((issue) => (
-              <BoardCard
-                key={issue.id}
-                issue={issue}
-                project={project}
-                projectsById={projectsById}
-                state={state}
-                labels={(issue.label_ids ?? [])
-                  .map((id) => labelById.get(id))
-                  .filter((l): l is LabelApiResponse => Boolean(l))}
-                assignees={membersFromAssigneeIds(members, issue.assignee_ids ?? [])}
-                prSummary={prSummary[issue.id]}
-                href={issueHref(issue.id)}
-                now={now}
-              />
-            ))}
-            {colIssues.length === 0 && (
-              <p className="px-2 py-6 text-center text-xs text-(--txt-tertiary)">No work items</p>
-            )}
-          </BoardColumn>
-        );
-      })}
+      {columns.map((col) => (
+        <BoardColumn key={col.key} title={col.title} color={col.color} count={col.items.length}>
+          {col.items.map(renderCard)}
+          {col.items.length === 0 && (
+            <p className="px-2 py-6 text-center text-xs text-(--txt-tertiary)">No work items</p>
+          )}
+        </BoardColumn>
+      ))}
 
-      {groups.orphans.length > 0 && (
-        <BoardColumn title="No state" color={undefined} count={groups.orphans.length}>
-          {groups.orphans.map((issue) => (
-            <BoardCard
-              key={issue.id}
-              issue={issue}
-              project={project}
-              projectsById={projectsById}
-              state={null}
-              labels={(issue.label_ids ?? [])
-                .map((id) => labelById.get(id))
-                .filter((l): l is LabelApiResponse => Boolean(l))}
-              assignees={membersFromAssigneeIds(members, issue.assignee_ids ?? [])}
-              prSummary={prSummary[issue.id]}
-              href={issueHref(issue.id)}
-              now={now}
-            />
-          ))}
+      {orphans.length > 0 && (
+        <BoardColumn title="No state" color={undefined} count={orphans.length}>
+          {orphans.map(renderCard)}
         </BoardColumn>
       )}
     </div>

--- a/apps/web/src/components/work-item/layouts/IssueLayoutCalendar.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutCalendar.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { PriorityIcon } from '../IssueRowCells';
 import type { IssueApiResponse } from '../../../api/types';
 import type { Priority } from '../../../types';
-import type { IssueLayoutProps } from './IssueLayoutTypes';
+import { issueDisplayId, type IssueLayoutProps } from './IssueLayoutTypes';
 
 const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
 const MAX_PER_CELL = 3;
@@ -18,7 +18,14 @@ const MAX_PER_CELL = 3;
  * Navigation: prev/next month. "Today" jumps to current month. The "viewMonth"
  * is local UI state so switching layout doesn't lose the user's place.
  */
-export function IssueLayoutCalendar({ project, states, issues, issueHref, now }: IssueLayoutProps) {
+export function IssueLayoutCalendar({
+  project,
+  states,
+  issues,
+  issueHref,
+  now,
+  projectsById,
+}: IssueLayoutProps) {
   const [viewMonth, setViewMonth] = useState(() => startOfMonth(new Date(now)));
 
   const stateById = useMemo(() => new Map(states.map((s) => [s.id, s])), [states]);
@@ -148,8 +155,7 @@ export function IssueLayoutCalendar({ project, states, issues, issueHref, now }:
                   <PriorityIcon priority={issue.priority as Priority | null | undefined} />
                   <span className="truncate">{issue.name}</span>
                   <span className="ml-auto text-[11px] text-(--txt-tertiary)">
-                    {project.identifier ?? project.id.slice(0, 8)}-
-                    {issue.sequence_id ?? issue.id.slice(-4)}
+                    {issueDisplayId(issue, project, projectsById)}
                   </span>
                 </Link>
               </li>

--- a/apps/web/src/components/work-item/layouts/IssueLayoutGantt.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutGantt.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { PriorityIcon } from '../IssueRowCells';
 import type { Priority } from '../../../types';
-import type { IssueLayoutProps } from './IssueLayoutTypes';
+import { issueDisplayId, type IssueLayoutProps } from './IssueLayoutTypes';
 
 const DAY_MS = 24 * 3600 * 1000;
 const DAY_PX = 28; // width per day on the timeline; pannable, not zoomable yet
@@ -22,7 +22,14 @@ const DAY_PX = 28; // width per day on the timeline; pannable, not zoomable yet
  *   - Sidebar (left) shows id + name; the chart (right) is horizontally
  *     scrollable for projects whose range exceeds the viewport.
  */
-export function IssueLayoutGantt({ project, states, issues, issueHref, now }: IssueLayoutProps) {
+export function IssueLayoutGantt({
+  project,
+  states,
+  issues,
+  issueHref,
+  now,
+  projectsById,
+}: IssueLayoutProps) {
   const stateById = useMemo(() => new Map(states.map((s) => [s.id, s])), [states]);
 
   const dated = useMemo(
@@ -125,8 +132,7 @@ export function IssueLayoutGantt({ project, states, issues, issueHref, now }: Is
                       className="flex min-w-0 items-center gap-1.5 text-xs text-(--txt-primary) no-underline hover:text-(--txt-accent-primary)"
                     >
                       <span className="font-medium text-(--txt-accent-primary)">
-                        {project.identifier ?? project.id.slice(0, 8)}-
-                        {issue.sequence_id ?? issue.id.slice(-4)}
+                        {issueDisplayId(issue, project, projectsById)}
                       </span>
                       <span className="truncate">{issue.name}</span>
                     </Link>

--- a/apps/web/src/components/work-item/layouts/IssueLayoutTypes.ts
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutTypes.ts
@@ -42,4 +42,25 @@ export interface IssueLayoutProps {
   issueHref: (id: string) => string;
   /** Stable per-render "now" timestamp (ms) used by date cells. */
   now: number;
+  /**
+   * Optional map of project id -> project, used by workspace-wide views where
+   * issues span multiple projects so each card can show its own project's
+   * identifier. When omitted, the single `project` prop is used.
+   */
+  projectsById?: Record<string, ProjectApiResponse>;
+}
+
+/**
+ * The human "DEV-42" identifier for an issue. In multi-project (workspace)
+ * views the issue's own project is resolved from `projectsById`; otherwise the
+ * single `project` is used.
+ */
+export function issueDisplayId(
+  issue: Pick<IssueApiResponse, 'id' | 'project_id' | 'sequence_id'>,
+  project: ProjectApiResponse,
+  projectsById?: Record<string, ProjectApiResponse>,
+): string {
+  const p = projectsById?.[issue.project_id] ?? project;
+  const prefix = p.identifier ?? p.id.slice(0, 8);
+  return `${prefix}-${issue.sequence_id ?? issue.id.slice(-4)}`;
 }

--- a/apps/web/src/components/work-item/layouts/IssueLayoutTypes.ts
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutTypes.ts
@@ -48,7 +48,31 @@ export interface IssueLayoutProps {
    * identifier. When omitted, the single `project` prop is used.
    */
   projectsById?: Record<string, ProjectApiResponse>;
+  /**
+   * Board layout only: group columns by canonical state group (Backlog / Todo /
+   * In Progress / Done / Cancelled) instead of by individual state. Used by
+   * workspace-wide views where states differ per project but share groups.
+   */
+  groupByStateGroup?: boolean;
 }
+
+/** Canonical state groups, in board column order. */
+export const STATE_GROUP_ORDER = [
+  'backlog',
+  'unstarted',
+  'started',
+  'completed',
+  'cancelled',
+] as const;
+
+/** Display labels for the canonical state groups. */
+export const STATE_GROUP_LABELS: Record<string, string> = {
+  backlog: 'Backlog',
+  unstarted: 'Todo',
+  started: 'In Progress',
+  completed: 'Done',
+  cancelled: 'Cancelled',
+};
 
 /**
  * The human "DEV-42" identifier for an issue. In multi-project (workspace)

--- a/apps/web/src/pages/WorkspaceViewsPage.tsx
+++ b/apps/web/src/pages/WorkspaceViewsPage.tsx
@@ -11,6 +11,9 @@ import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
 import { viewService } from '../services/viewService';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { IssueLayoutBoard } from '../components/work-item/layouts/IssueLayoutBoard';
+import { IssueLayoutCalendar } from '../components/work-item/layouts/IssueLayoutCalendar';
+import { IssueLayoutGantt } from '../components/work-item/layouts/IssueLayoutGantt';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -162,6 +165,8 @@ export function WorkspaceViewsPage() {
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [labels, setLabels] = useState<LabelApiResponse[]>([]);
+  // Stable per-mount timestamp passed to the work-item layouts for date cells.
+  const [now] = useState(() => Date.now());
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const { user: currentUser } = useAuth();
@@ -699,14 +704,46 @@ export function WorkspaceViewsPage() {
     display.layout === 'calendar' ||
     display.layout === 'gantt_chart'
   ) {
+    // Workspace views span multiple projects, so reuse the project work-item
+    // layout components with a projectsById map (for per-issue identifiers) and
+    // a project-aware issue href. A representative project satisfies the
+    // single-project prop; the map drives the actual per-card display.
+    const layoutProject = projects[0];
+    if (!layoutProject) {
+      return (
+        <div className="-mt-(--padding-page) -mr-(--padding-page) -mb-(--padding-page) flex min-h-0 flex-1 flex-col">
+          <div className="px-4 py-16 text-center text-sm text-(--txt-tertiary)">
+            No work items yet. Create one from a project&apos;s Work items section or add a view to
+            get started.
+          </div>
+        </div>
+      );
+    }
+    const projectsById = Object.fromEntries(projects.map((p) => [p.id, p]));
+    const issueProjectById = new Map(sortedIssues.map((i) => [i.id, i.project_id]));
+    const layoutProps = {
+      workspaceSlug: workspace.slug,
+      project: layoutProject,
+      projectsById,
+      issues: sortedIssues,
+      states,
+      labels,
+      members,
+      prSummary: {},
+      baseUrl,
+      issueHref: (id: string) => {
+        const pid = issueProjectById.get(id);
+        const proj = pid ? getProject(pid) : undefined;
+        return proj ? `${baseUrl}/projects/${proj.id}/issues/${id}` : baseUrl;
+      },
+      now,
+    };
     return (
       <div className="-mt-(--padding-page) -mr-(--padding-page) -mb-(--padding-page) flex min-h-0 flex-1 flex-col">
-        <div className="flex flex-1 items-center justify-center p-8">
-          <p className="text-sm text-(--txt-tertiary)">
-            {display.layout === 'kanban' && 'Kanban view is coming soon.'}
-            {display.layout === 'calendar' && 'Calendar view is coming soon.'}
-            {display.layout === 'gantt_chart' && 'Gantt chart view is coming soon.'}
-          </p>
+        <div className="min-h-0 flex-1 overflow-auto">
+          {display.layout === 'kanban' && <IssueLayoutBoard {...layoutProps} />}
+          {display.layout === 'calendar' && <IssueLayoutCalendar {...layoutProps} />}
+          {display.layout === 'gantt_chart' && <IssueLayoutGantt {...layoutProps} />}
         </div>
       </div>
     );

--- a/apps/web/src/pages/WorkspaceViewsPage.tsx
+++ b/apps/web/src/pages/WorkspaceViewsPage.tsx
@@ -741,7 +741,7 @@ export function WorkspaceViewsPage() {
     return (
       <div className="-mt-(--padding-page) -mr-(--padding-page) -mb-(--padding-page) flex min-h-0 flex-1 flex-col">
         <div className="min-h-0 flex-1 overflow-auto">
-          {display.layout === 'kanban' && <IssueLayoutBoard {...layoutProps} />}
+          {display.layout === 'kanban' && <IssueLayoutBoard {...layoutProps} groupByStateGroup />}
           {display.layout === 'calendar' && <IssueLayoutCalendar {...layoutProps} />}
           {display.layout === 'gantt_chart' && <IssueLayoutGantt {...layoutProps} />}
         </div>


### PR DESCRIPTION
## Summary

Closes #129.

Saved workspace views showed "coming soon" for the kanban, calendar, and gantt
layouts even though the project work-item pages already have working layout
components. This reuses those components for workspace views.

- `IssueLayoutProps` gains an optional `projectsById` map plus a shared
  `issueDisplayId()` helper, so Board/Calendar/Gantt can render each card's own
  project identifier when issues span multiple projects. Project pages omit the
  map and keep their exact previous single-project behaviour.
- `WorkspaceViewsPage` renders `IssueLayoutBoard` / `IssueLayoutCalendar` /
  `IssueLayoutGantt` for the kanban/calendar/gantt_chart layouts (workspace-wide
  issues, project-aware `issueHref`) instead of the placeholder.
- Mounts the previously-unused `WorkspaceViewsLayoutSelector` in the views
  toolbar so every layout is actually selectable (it existed but was never
  rendered).

## Testing

- UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright): on a workspace view, switching to Kanban,
  Calendar, and Gantt renders the real layouts (no "coming soon", no crashes)
  with project-aware issue links (`/{ws}/projects/{projectId}/issues/{id}`).
  Regression-checked the project board/calendar/gantt — still render correct
  `APO-N` identifiers (the `issueDisplayId` fallback is byte-identical to the
  previous inline code).

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
typecheck/lint and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Kanban, Calendar, and Gantt layouts in Workspace Views.
  * Added a layout-selection control to the Workspace Views header.
  * Improved how issue display identifiers are generated for consistent presentation across multi-project views.

* **Bug Fixes**
  * Updated issue linking and identifier rendering in board, calendar, and Gantt views to resolve correctly when multiple projects are present.
  * Show an empty state in Workspace Views when no projects are available, instead of placeholder content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->