### PR TITLE
feat(archives): list and restore archived work items

### DIFF
--- a/apps/api/internal/handler/issue.go
+++ b/apps/api/internal/handler/issue.go
@@ -55,6 +55,32 @@ func (h *IssueHandler) ListWorkspaceDrafts(c *gin.Context) {
 	c.JSON(http.StatusOK, list)
 }
 
+// ListWorkspaceArchived returns archived issues across the workspace.
+// GET /api/workspaces/:slug/archived-issues/
+func (h *IssueHandler) ListWorkspaceArchived(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	list, err := h.Issue.ListArchivedForWorkspace(c.Request.Context(), slug, user.ID, limit, offset)
+	if err != nil {
+		if err == service.ErrWorkspaceForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list archived issues"})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
 // List returns issues for the project.
 // GET /api/workspaces/:slug/projects/:projectId/issues/
 func (h *IssueHandler) List(c *gin.Context) {

--- a/apps/api/internal/handler/issue_archive_test.go
+++ b/apps/api/internal/handler/issue_archive_test.go
@@ -42,3 +42,29 @@ func TestIssue_ArchiveRestore(t *testing.T) {
 	rr6 := ts.GET(issuesBase, w.Session)
 	require.Contains(t, rr6.Body.String(), id)
 }
+
+func TestIssue_WorkspaceArchivedList(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	id := issue.ID.String()
+	issuesBase := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/"
+	wsArchived := "/api/workspaces/" + w.Workspace.Slug + "/archived-issues/"
+
+	// Empty before archiving.
+	r0 := ts.GET(wsArchived, w.Session)
+	require.Equal(t, http.StatusOK, r0.Code, "body=%s", r0.Body.String())
+	require.NotContains(t, r0.Body.String(), id)
+
+	// Archive, then it appears in the workspace-wide archived list.
+	require.Equal(t, http.StatusOK, ts.POST(issuesBase+id+"/archive/", map[string]any{}, w.Session).Code)
+	require.Contains(t, ts.GET(wsArchived, w.Session).Body.String(), id)
+
+	// Restore removes it again.
+	require.Equal(t, http.StatusOK, ts.DELETE(issuesBase+id+"/archive/", w.Session).Code)
+	require.NotContains(t, ts.GET(wsArchived, w.Session).Body.String(), id)
+
+	// Non-members can't read it.
+	outsider := testutil.CreateUser(t, ts.DB)
+	require.Equal(t, http.StatusNotFound, ts.GET(wsArchived, testutil.LoginAs(t, ts.DB, outsider)).Code)
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -281,6 +281,7 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/users/me/workspaces/:slug/projects/invitations/", projectHandler.ListUserProjectInvitations)
 		api.POST("/workspaces/:slug/projects/join/", projectHandler.JoinByToken)
 		api.GET("/workspaces/:slug/draft-issues/", issueHandler.ListWorkspaceDrafts)
+		api.GET("/workspaces/:slug/archived-issues/", issueHandler.ListWorkspaceArchived)
 		api.GET("/workspaces/:slug/search/", searchHandler.Search)
 
 		api.GET("/workspaces/:slug/projects/", projectHandler.List)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -226,6 +226,16 @@ func (s *IssueService) ListArchived(ctx context.Context, workspaceSlug string, p
 	return s.is.ListArchivedByProjectID(ctx, projectID, limit, offset)
 }
 
+// ListArchivedForWorkspace lists archived issues across all projects in a
+// workspace (for the workspace Archives page).
+func (s *IssueService) ListArchivedForWorkspace(ctx context.Context, workspaceSlug string, userID uuid.UUID, limit, offset int) ([]model.Issue, error) {
+	wrk, err := s.ensureWorkspaceAccess(ctx, workspaceSlug, userID)
+	if err != nil {
+		return nil, err
+	}
+	return s.is.ListArchivedByWorkspaceID(ctx, wrk.ID, limit, offset)
+}
+
 // BulkUpdate applies priority/state changes to many issues in a project. It
 // validates the inputs, then routes each issue through the single-issue Update
 // so activity logging and notifications fire exactly as they do individually.

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -105,6 +105,23 @@ func (s *IssueStore) ListArchivedByProjectID(ctx context.Context, projectID uuid
 	return list, err
 }
 
+// ListArchivedByWorkspaceID lists archived (non-deleted) issues across all
+// projects in a workspace, most-recently-archived first.
+func (s *IssueStore) ListArchivedByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int) ([]model.Issue, error) {
+	var list []model.Issue
+	q := s.db.WithContext(ctx).
+		Where("workspace_id = ? AND deleted_at IS NULL AND archived_at IS NOT NULL", workspaceID).
+		Order("archived_at DESC")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
+	err := q.Find(&list).Error
+	return list, err
+}
+
 // SetArchived archives (sets archived_at) or restores (clears archived_at) an
 // issue. archived_at is the source of truth for archived state.
 func (s *IssueStore) SetArchived(ctx context.Context, id uuid.UUID, archived bool) error {

--- a/apps/web/src/pages/ArchivesPage.tsx
+++ b/apps/web/src/pages/ArchivesPage.tsx
@@ -6,6 +6,8 @@ import { issueService } from '../services/issueService';
 import { projectService } from '../services/projectService';
 import type { IssueApiResponse, ProjectApiResponse } from '../api/types';
 
+const ARCHIVES_PAGE_SIZE = 50;
+
 function formatArchivedAt(iso: string | null | undefined): string {
   if (!iso) return '';
   const t = Date.parse(iso);
@@ -24,6 +26,8 @@ export function ArchivesPage() {
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [restoringId, setRestoringId] = useState<string | null>(null);
 
@@ -32,12 +36,14 @@ export function ArchivesPage() {
     let cancelled = false;
     setLoading(true);
     Promise.all([
-      issueService.listWorkspaceArchived(workspaceSlug, { limit: 100 }),
+      // Fetch one extra to detect whether more pages exist.
+      issueService.listWorkspaceArchived(workspaceSlug, { limit: ARCHIVES_PAGE_SIZE + 1 }),
       projectService.list(workspaceSlug).catch(() => [] as ProjectApiResponse[]),
     ])
       .then(([archived, projs]) => {
         if (cancelled) return;
-        setIssues(archived);
+        setHasMore(archived.length > ARCHIVES_PAGE_SIZE);
+        setIssues(archived.slice(0, ARCHIVES_PAGE_SIZE));
         setProjects(projs ?? []);
         setError(null);
       })
@@ -51,6 +57,23 @@ export function ArchivesPage() {
       cancelled = true;
     };
   }, [workspaceSlug]);
+
+  const loadMore = async () => {
+    if (!workspaceSlug || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const next = await issueService.listWorkspaceArchived(workspaceSlug, {
+        limit: ARCHIVES_PAGE_SIZE + 1,
+        offset: issues.length,
+      });
+      setHasMore(next.length > ARCHIVES_PAGE_SIZE);
+      setIssues((prev) => [...prev, ...next.slice(0, ARCHIVES_PAGE_SIZE)]);
+    } catch {
+      setError('Could not load more archived work items.');
+    } finally {
+      setLoadingMore(false);
+    }
+  };
 
   const projectById = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects]);
 
@@ -128,6 +151,19 @@ export function ArchivesPage() {
             </li>
           ))}
         </ul>
+      )}
+
+      {!loading && hasMore && (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => void loadMore()}
+            disabled={loadingMore}
+            className="rounded-(--radius-md) border border-(--border-subtle) px-3 py-1.5 text-sm text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary) disabled:opacity-50"
+          >
+            {loadingMore ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/pages/ArchivesPage.tsx
+++ b/apps/web/src/pages/ArchivesPage.tsx
@@ -28,6 +28,10 @@ export function ArchivesPage() {
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
+  // Server-side fetch position; tracked separately from issues.length so that
+  // restoring an item (which removes it from the list) doesn't skew the next
+  // page's offset.
+  const [fetchedCount, setFetchedCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [restoringId, setRestoringId] = useState<string | null>(null);
 
@@ -42,8 +46,10 @@ export function ArchivesPage() {
     ])
       .then(([archived, projs]) => {
         if (cancelled) return;
+        const page = archived.slice(0, ARCHIVES_PAGE_SIZE);
         setHasMore(archived.length > ARCHIVES_PAGE_SIZE);
-        setIssues(archived.slice(0, ARCHIVES_PAGE_SIZE));
+        setIssues(page);
+        setFetchedCount(page.length);
         setProjects(projs ?? []);
         setError(null);
       })
@@ -64,10 +70,16 @@ export function ArchivesPage() {
     try {
       const next = await issueService.listWorkspaceArchived(workspaceSlug, {
         limit: ARCHIVES_PAGE_SIZE + 1,
-        offset: issues.length,
+        offset: fetchedCount,
       });
+      const page = next.slice(0, ARCHIVES_PAGE_SIZE);
       setHasMore(next.length > ARCHIVES_PAGE_SIZE);
-      setIssues((prev) => [...prev, ...next.slice(0, ARCHIVES_PAGE_SIZE)]);
+      setFetchedCount((c) => c + page.length);
+      // De-dup by id in case a restore shifted the server-side window.
+      setIssues((prev) => {
+        const seen = new Set(prev.map((i) => i.id));
+        return [...prev, ...page.filter((i) => !seen.has(i.id))];
+      });
     } catch {
       setError('Could not load more archived work items.');
     } finally {

--- a/apps/web/src/pages/ArchivesPage.tsx
+++ b/apps/web/src/pages/ArchivesPage.tsx
@@ -1,15 +1,134 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ArchiveRestore } from 'lucide-react';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { issueService } from '../services/issueService';
+import { projectService } from '../services/projectService';
+import type { IssueApiResponse, ProjectApiResponse } from '../api/types';
+
+function formatArchivedAt(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  return new Date(t).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
 
 export function ArchivesPage() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
   useDocumentTitle('Archives');
+
+  const [issues, setIssues] = useState<IssueApiResponse[]>([]);
+  const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!workspaceSlug) return;
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([
+      issueService.listWorkspaceArchived(workspaceSlug, { limit: 100 }),
+      projectService.list(workspaceSlug).catch(() => [] as ProjectApiResponse[]),
+    ])
+      .then(([archived, projs]) => {
+        if (cancelled) return;
+        setIssues(archived);
+        setProjects(projs ?? []);
+        setError(null);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load archived work items.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceSlug]);
+
+  const projectById = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects]);
+
+  const restore = async (issue: IssueApiResponse) => {
+    if (!workspaceSlug || restoringId) return;
+    setRestoringId(issue.id);
+    try {
+      await issueService.restore(workspaceSlug, issue.project_id, issue.id);
+      setIssues((prev) => prev.filter((i) => i.id !== issue.id));
+    } catch {
+      setError('Could not restore that work item.');
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
+  const displayId = (issue: IssueApiResponse) => {
+    const p = projectById.get(issue.project_id);
+    const prefix = p?.identifier ?? p?.id.slice(0, 8) ?? issue.project_id.slice(0, 8);
+    return `${prefix}-${issue.sequence_id ?? issue.id.slice(-4)}`;
+  };
+
   return (
     <div className="mx-auto max-w-4xl space-y-6 pb-8">
-      <h1 className="text-2xl font-semibold text-(--txt-primary)">Archives</h1>
-      <p className="text-sm text-(--txt-secondary)">
-        Archived projects and items. (Placeholder for {workspaceSlug})
-      </p>
+      <div>
+        <h1 className="text-2xl font-semibold text-(--txt-primary)">Archives</h1>
+        <p className="mt-0.5 text-sm text-(--txt-secondary)">
+          Archived work items across this workspace. Restore one to bring it back to its project.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded-(--radius-md) bg-(--bg-danger-subtle) px-3 py-2 text-sm text-(--txt-danger-primary)">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <p className="px-1 py-10 text-center text-sm text-(--txt-tertiary)">Loading archives…</p>
+      ) : issues.length === 0 ? (
+        <div className="rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-16 text-center">
+          <p className="text-sm font-medium text-(--txt-secondary)">No archived work items</p>
+          <p className="mt-1 text-xs text-(--txt-tertiary)">
+            Archive a work item from its menu and it will show up here.
+          </p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-(--border-subtle) overflow-hidden rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1)">
+          {issues.map((issue) => (
+            <li
+              key={issue.id}
+              className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-(--bg-layer-1-hover)"
+            >
+              <Link
+                to={`/${workspaceSlug}/projects/${issue.project_id}/issues/${issue.id}`}
+                className="flex min-w-0 flex-1 items-center gap-2 text-(--txt-primary) no-underline hover:text-(--txt-accent-primary)"
+              >
+                <span className="shrink-0 text-[11px] font-medium text-(--txt-accent-primary)">
+                  {displayId(issue)}
+                </span>
+                <span className="truncate font-medium">{issue.name}</span>
+              </Link>
+              <span className="shrink-0 text-xs text-(--txt-tertiary)">
+                Archived {formatArchivedAt(issue.archived_at)}
+              </span>
+              <button
+                type="button"
+                onClick={() => void restore(issue)}
+                disabled={restoringId === issue.id}
+                className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary) disabled:opacity-50"
+              >
+                <ArchiveRestore className="size-3.5" />
+                {restoringId === issue.id ? 'Restoring…' : 'Restore'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -35,6 +35,19 @@ export const issueService = {
     return data;
   },
 
+  async listWorkspaceArchived(
+    workspaceSlug: string,
+    params?: ListIssuesParams,
+  ): Promise<IssueApiResponse[]> {
+    const searchParams = new URLSearchParams();
+    if (params?.limit != null) searchParams.set('limit', String(params.limit));
+    if (params?.offset != null) searchParams.set('offset', String(params.offset));
+    const qs = searchParams.toString();
+    const url = `/api/workspaces/${encodeURIComponent(workspaceSlug)}/archived-issues/${qs ? `?${qs}` : ''}`;
+    const { data } = await apiClient.get<IssueApiResponse[]>(url);
+    return Array.isArray(data) ? data : [];
+  },
+
   async list(
     workspaceSlug: string,
     projectId: string,


### PR DESCRIPTION
## Summary

Makes the workspace **Archives** page real (part of #128). It now lists
archived work items across the workspace and lets you open or restore them.

### Backend
- `GET /api/workspaces/:slug/archived-issues/` — lists archived (non-deleted)
  work items across all projects in the workspace, newest-archived first
  (`IssueStore.ListArchivedByWorkspaceID` → `IssueService.ListArchivedForWorkspace`
  → `IssueHandler.ListWorkspaceArchived`). Workspace-member scoped (mirrors the
  draft-issues endpoint). Per-issue archive/restore already existed and is
  reused for restore.

### Frontend
- `issueService.listWorkspaceArchived`, and an `ArchivesPage` that replaces the
  placeholder: lists archived items (identifier, name, archived date), links to
  each item, and restores them — with loading/empty/error states.

### Scope
Archived **projects** are out of scope here: there is no project-archive action
yet (the `projects.archived_at` column exists but nothing sets it), so that
section would always be empty. This covers archived work items, the page's main
content; project archiving can follow once a project-archive action exists.

## Testing

- `go test ./internal/handler -run "TestIssue_WorkspaceArchivedList|TestIssue_ArchiveRestore"`
  — pass (real Postgres via testcontainers): workspace archived list reflects
  archive/restore, and non-members get 404.
- `go vet ./...`, UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright): archived a work item → it appears on the
  Archives page with an "Archived <date>" label → Restore removes it and the
  backend no longer lists it as archived.

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
the test suite and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace archives page that loads archived issues for the whole workspace, showing archived dates and a “Load more” paginated list with links to each issue.
  * Added the ability to restore archived issues from the archives list.

* **Bug Fixes**
  * Archived issues are now correctly aggregated at the workspace level, with proper access handling (unauthorized access returns not found).

* **Tests**
  * Added coverage to verify archived listing and restore behavior, including access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->