### PR TITLE
feat(issues): drag-to-reorder work items in the List layout

### DIFF
--- a/apps/api/internal/handler/epic.go
+++ b/apps/api/internal/handler/epic.go
@@ -205,7 +205,7 @@ func (h *EpicHandler) UpdateEpic(c *gin.Context) {
 		tmp := body.LabelIDs
 		labelIDs = &tmp
 	}
-	epic, err := h.Issue.Update(c.Request.Context(), slug, projectID, eID, user.ID, name, priority, body.Description, body.StateID, assigneeIDs, labelIDs, nil, nil, nil, nil, nil, false, nil)
+	epic, err := h.Issue.Update(c.Request.Context(), slug, projectID, eID, user.ID, name, priority, body.Description, body.StateID, assigneeIDs, labelIDs, nil, nil, nil, nil, nil, false, nil, nil)
 	if err != nil {
 		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})

--- a/apps/api/internal/handler/issue.go
+++ b/apps/api/internal/handler/issue.go
@@ -237,6 +237,8 @@ func (h *IssueHandler) Update(c *gin.Context) {
 		Type            string      `json:"type"`
 		// estimate_point_id: omitted = leave alone, "" = clear, uuid = set.
 		EstimatePointID *string `json:"estimate_point_id"`
+		// sort_order: manual ordering position (drag-to-reorder).
+		SortOrder *float64 `json:"sort_order"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
@@ -303,7 +305,7 @@ func (h *IssueHandler) Update(c *gin.Context) {
 			estimatePointID = &pid
 		}
 	}
-	issue, err := h.Issue.Update(c.Request.Context(), slug, projectID, issueID, user.ID, name, priority, description, body.StateID, assigneeIDs, labelIDs, startDate, targetDate, body.ParentID, body.IsDraft, issueType, estimatePointIDSet, estimatePointID)
+	issue, err := h.Issue.Update(c.Request.Context(), slug, projectID, issueID, user.ID, name, priority, description, body.StateID, assigneeIDs, labelIDs, startDate, targetDate, body.ParentID, body.IsDraft, issueType, estimatePointIDSet, estimatePointID, body.SortOrder)
 	if err != nil {
 		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Issue not found"})

--- a/apps/api/internal/handler/issue_bulk.go
+++ b/apps/api/internal/handler/issue_bulk.go
@@ -103,3 +103,28 @@ func (h *IssueHandler) BulkDelete(c *gin.Context) {
 	n, err := h.Issue.BulkDelete(c.Request.Context(), slug, projectID, userID, body.IssueIDs)
 	bulkRespond(c, n, err, "Failed to delete work items")
 }
+
+// BulkReorder renumbers work items to match the given id order (drag-to-reorder).
+// POST /api/workspaces/:slug/projects/:projectId/issues-bulk/reorder/
+func (h *IssueHandler) BulkReorder(c *gin.Context) {
+	slug, projectID, userID, ok := bulkContext(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		IssueIDs []uuid.UUID `json:"issue_ids"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || len(body.IssueIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "issue_ids is required"})
+		return
+	}
+	if err := h.Issue.Reorder(c.Request.Context(), slug, projectID, userID, body.IssueIDs); err != nil {
+		if issueAccessNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reorder work items"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/apps/api/internal/handler/issue_bulk_test.go
+++ b/apps/api/internal/handler/issue_bulk_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Devlaner/devlane/api/internal/testutil"
@@ -56,4 +57,29 @@ func TestIssue_BulkUpdate_RejectsInvalidPriority(t *testing.T) {
 		"priority":  "bogus",
 	}, w.Session)
 	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
+}
+
+func TestIssue_BulkReorder(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	i1 := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	i2 := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	i3 := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/"
+	bulk := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues-bulk/"
+
+	// New issues all share the default sort_order; reorder to i3, i1, i2.
+	rr := ts.POST(bulk+"reorder/", map[string]any{
+		"issue_ids": []string{i3.ID.String(), i1.ID.String(), i2.ID.String()},
+	}, w.Session)
+	require.Equal(t, http.StatusNoContent, rr.Code, "body=%s", rr.Body.String())
+
+	// The list (ordered by sort_order ASC) now reflects the requested order.
+	body := ts.GET(base+"?limit=100", w.Session).Body.String()
+	p3, p1, p2 := strings.Index(body, i3.ID.String()), strings.Index(body, i1.ID.String()), strings.Index(body, i2.ID.String())
+	require.Less(t, p3, p1, "i3 should precede i1")
+	require.Less(t, p1, p2, "i1 should precede i2")
+
+	// Empty payload is rejected.
+	require.Equal(t, http.StatusBadRequest, ts.POST(bulk+"reorder/", map[string]any{"issue_ids": []string{}}, w.Session).Code)
 }

--- a/apps/api/internal/handler/issue_test.go
+++ b/apps/api/internal/handler/issue_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Devlaner/devlane/api/internal/testutil"
@@ -127,4 +128,27 @@ func TestIssue_DraftCreation(t *testing.T) {
 	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
 	body := testutil.MustJSONMap(t, rr)
 	assert.Equal(t, true, body["is_draft"])
+}
+
+func TestIssue_SortOrderReorder(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := issueBase(w.Workspace.Slug, w.Project.ID.String())
+
+	a := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	b := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	idA, idB := a.ID.String(), b.ID.String()
+
+	// Order A before B.
+	require.Equal(t, http.StatusOK, ts.PATCH(base+idA+"/", map[string]any{"sort_order": 100}, w.Session).Code)
+	require.Equal(t, http.StatusOK, ts.PATCH(base+idB+"/", map[string]any{"sort_order": 200}, w.Session).Code)
+	body1 := ts.GET(base, w.Session).Body.String()
+	require.Less(t, strings.Index(body1, idA), strings.Index(body1, idB), "A should sort before B")
+
+	// Move A to the bottom — B should now come first.
+	rr := ts.PATCH(base+idA+"/", map[string]any{"sort_order": 300}, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.InDelta(t, 300.0, testutil.MustJSONMap(t, rr)["sort_order"], 0.001)
+	body2 := ts.GET(base, w.Session).Body.String()
+	require.Less(t, strings.Index(body2, idB), strings.Index(body2, idA), "B should sort before A after reorder")
 }

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -347,6 +347,7 @@ func New(cfg Config) *gin.Engine {
 		api.POST("/workspaces/:slug/projects/:projectId/issues-bulk/update/", issueHandler.BulkUpdate)
 		api.POST("/workspaces/:slug/projects/:projectId/issues-bulk/archive/", issueHandler.BulkArchive)
 		api.POST("/workspaces/:slug/projects/:projectId/issues-bulk/delete/", issueHandler.BulkDelete)
+		api.POST("/workspaces/:slug/projects/:projectId/issues-bulk/reorder/", issueHandler.BulkReorder)
 
 		api.GET("/workspaces/:slug/projects/:projectId/cycles/", cycleHandler.List)
 		api.POST("/workspaces/:slug/projects/:projectId/cycles/", cycleHandler.Create)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -236,6 +236,15 @@ func (s *IssueService) ListArchivedForWorkspace(ctx context.Context, workspaceSl
 	return s.is.ListArchivedByWorkspaceID(ctx, wrk.ID, limit, offset)
 }
 
+// Reorder renumbers the given issues' sort_order to match the order of ids
+// (manual drag-to-reorder).
+func (s *IssueService) Reorder(ctx context.Context, workspaceSlug string, projectID, userID uuid.UUID, ids []uuid.UUID) error {
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return err
+	}
+	return s.is.ReorderIssues(ctx, projectID, ids)
+}
+
 // BulkUpdate applies priority/state changes to many issues in a project. It
 // validates the inputs, then routes each issue through the single-issue Update
 // so activity logging and notifications fire exactly as they do individually.
@@ -259,7 +268,7 @@ func (s *IssueService) BulkUpdate(ctx context.Context, workspaceSlug string, pro
 	n := 0
 	var firstErr error
 	for _, id := range issueIDs {
-		if _, err := s.Update(ctx, workspaceSlug, projectID, id, userID, nil, priority, nil, stateID, nil, nil, nil, nil, nil, nil, nil, false, nil); err != nil {
+		if _, err := s.Update(ctx, workspaceSlug, projectID, id, userID, nil, priority, nil, stateID, nil, nil, nil, nil, nil, nil, nil, false, nil, nil); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -466,7 +475,7 @@ func (s *IssueService) Create(ctx context.Context, workspaceSlug string, project
 	return issue, nil
 }
 
-func (s *IssueService) Update(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, name, priority, description *string, stateID *uuid.UUID, assigneeIDs, labelIDs *[]uuid.UUID, startDate, targetDate *time.Time, parentID *uuid.UUID, isDraft *bool, issueType *string, estimatePointIDSet bool, estimatePointID *uuid.UUID) (*model.Issue, error) {
+func (s *IssueService) Update(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, name, priority, description *string, stateID *uuid.UUID, assigneeIDs, labelIDs *[]uuid.UUID, startDate, targetDate *time.Time, parentID *uuid.UUID, isDraft *bool, issueType *string, estimatePointIDSet bool, estimatePointID *uuid.UUID, sortOrder *float64) (*model.Issue, error) {
 	issue, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID)
 	if err != nil {
 		return nil, err
@@ -511,6 +520,9 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 	}
 	if estimatePointIDSet {
 		issue.EstimatePointID = estimatePointID
+	}
+	if sortOrder != nil {
+		issue.SortOrder = *sortOrder
 	}
 	issue.UpdatedByID = &userID
 	if err := s.is.Update(ctx, issue); err != nil {

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -172,6 +172,25 @@ func (s *IssueStore) BulkUpdateFields(ctx context.Context, projectID uuid.UUID, 
 	return res.RowsAffected, res.Error
 }
 
+// ReorderIssues renumbers sort_order for the given issues to match the order of
+// `ids` (evenly spaced), in a single transaction. This makes manual drag-order
+// deterministic even when issues currently share the default sort_order.
+func (s *IssueStore) ReorderIssues(ctx context.Context, projectID uuid.UUID, ids []uuid.UUID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for i, id := range ids {
+			if err := tx.Model(&model.Issue{}).
+				Where("id = ? AND project_id = ? AND deleted_at IS NULL", id, projectID).
+				Update("sort_order", float64((i+1)*1024)).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // BulkSetArchived archives or restores many issues scoped to a project.
 func (s *IssueStore) BulkSetArchived(ctx context.Context, projectID uuid.UUID, ids []uuid.UUID, archived bool) (int64, error) {
 	updates := map[string]any{"archived_at": nil}

--- a/apps/web/src/components/work-item/layouts/IssueLayoutList.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { GripVertical } from 'lucide-react';
 import { IssuePRBadge } from '../IssuePRBadge';
@@ -77,7 +77,31 @@ export function IssueLayoutList({
     setDropTarget(null);
   };
 
-  const renderRow = (issue: IssueApiResponse) => {
+  // Keyboard reorder: keep focus on the moved row's handle across the re-render
+  // so repeated Arrow presses keep working.
+  const handleRefs = useRef(new Map<string, HTMLButtonElement>());
+  const pendingFocusId = useRef<string | null>(null);
+  useEffect(() => {
+    const id = pendingFocusId.current;
+    if (!id) return;
+    pendingFocusId.current = null;
+    handleRefs.current.get(id)?.focus();
+  });
+  const keyboardMove =
+    (issue: IssueApiResponse, idx: number, list: IssueApiResponse[]) =>
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowUp' && idx > 0) {
+        e.preventDefault();
+        pendingFocusId.current = issue.id;
+        onReorder!(issue.id, list[idx - 1]!.id, false);
+      } else if (e.key === 'ArrowDown' && idx < list.length - 1) {
+        e.preventDefault();
+        pendingFocusId.current = issue.id;
+        onReorder!(issue.id, list[idx + 1]!.id, true);
+      }
+    };
+
+  const renderRow = (issue: IssueApiResponse, idx?: number, list?: IssueApiResponse[]) => {
     const displayId = `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`;
     const subN = subWorkCountByParentId.get(issue.id) ?? 0;
     const issueState = issue.state_id ? (stateById.get(issue.state_id) ?? null) : null;
@@ -123,19 +147,27 @@ export function IssueLayoutList({
         }
       >
         {reorderable ? (
-          <span
+          <button
+            type="button"
             draggable
+            ref={(el) => {
+              if (el) handleRefs.current.set(issue.id, el);
+              else handleRefs.current.delete(issue.id);
+            }}
             onDragStart={(e) => {
               setDraggingId(issue.id);
               e.dataTransfer.effectAllowed = 'move';
             }}
             onDragEnd={clearDrag}
-            className="flex shrink-0 cursor-grab items-center pl-2 text-(--txt-icon-tertiary) opacity-0 transition-opacity hover:text-(--txt-icon-secondary) active:cursor-grabbing group-hover/row:opacity-100"
-            aria-label={`Reorder ${displayId}`}
-            title="Drag to reorder"
+            onKeyDown={
+              list !== undefined && idx !== undefined ? keyboardMove(issue, idx, list) : undefined
+            }
+            className="flex shrink-0 cursor-grab items-center rounded-sm pl-2 text-(--txt-icon-tertiary) opacity-0 transition-opacity hover:text-(--txt-icon-secondary) focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--border-focus) active:cursor-grabbing group-hover/row:opacity-100"
+            aria-label={`Reorder ${displayId}. Use Arrow Up or Arrow Down to move.`}
+            title="Drag, or focus and use arrow keys, to reorder"
           >
             <GripVertical className="size-4" />
-          </span>
+          </button>
         ) : null}
         {selection ? (
           <span className="shrink-0 pl-4">
@@ -209,9 +241,10 @@ export function IssueLayoutList({
   };
 
   if (groupedIssues.isFlat) {
+    const flatList = groupedIssues.groups.get(groupedIssues.order[0]) ?? [];
     return (
       <ul className="w-full divide-y divide-(--border-subtle)">
-        {(groupedIssues.groups.get(groupedIssues.order[0]) ?? []).map((issue) => renderRow(issue))}
+        {flatList.map((issue, idx) => renderRow(issue, idx, flatList))}
       </ul>
     );
   }

--- a/apps/web/src/components/work-item/layouts/IssueLayoutList.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutList.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { GripVertical } from 'lucide-react';
 import { IssuePRBadge } from '../IssuePRBadge';
 import {
   DueDateCell,
@@ -9,6 +10,7 @@ import {
   WorkItemAvatarGroup,
 } from '../IssueRowCells';
 import { membersFromAssigneeIds } from '../../../lib/issueRowHelpers';
+import { cn } from '../../../lib/utils';
 import type { IssueApiResponse, LabelApiResponse } from '../../../api/types';
 import type { Priority } from '../../../types';
 import type { GroupedIssuesResult } from '../../../lib/issueListGroupAndSort';
@@ -37,6 +39,12 @@ interface IssueLayoutListProps extends IssueLayoutProps {
     selectedIds: Set<string>;
     onToggle: (id: string) => void;
   };
+  /**
+   * Optional manual reorder (drag-and-drop). Only active for the flat
+   * (ungrouped) list; the parent persists the new order. `after` indicates the
+   * dragged item should land below the drop target rather than above.
+   */
+  onReorder?: (activeId: string, overId: string, after: boolean) => void;
 }
 
 export function IssueLayoutList({
@@ -54,9 +62,20 @@ export function IssueLayoutList({
   cycleName,
   moduleName,
   selection,
+  onReorder,
 }: IssueLayoutListProps) {
   const stateById = useMemo(() => new Map(states.map((s) => [s.id, s])), [states]);
   const labelById = useMemo(() => new Map(labels.map((l) => [l.id, l])), [labels]);
+
+  // Drag-to-reorder is only offered on the flat list (the parent decides whether
+  // manual ordering is active by passing onReorder).
+  const reorderable = Boolean(onReorder && groupedIssues.isFlat);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ id: string; after: boolean } | null>(null);
+  const clearDrag = () => {
+    setDraggingId(null);
+    setDropTarget(null);
+  };
 
   const renderRow = (issue: IssueApiResponse) => {
     const displayId = `${project.identifier ?? project.id.slice(0, 8)}-${issue.sequence_id ?? issue.id.slice(-4)}`;
@@ -69,8 +88,55 @@ export function IssueLayoutList({
     const prInfo = prSummary[issue.id];
     const startStr = formatShort(issue.start_date);
 
+    const isDropTarget = reorderable && dropTarget?.id === issue.id && draggingId !== issue.id;
+
     return (
-      <li key={issue.id} className="flex items-center">
+      <li
+        key={issue.id}
+        className={cn(
+          'group/row flex items-center',
+          draggingId === issue.id && 'opacity-50',
+          isDropTarget &&
+            (dropTarget!.after
+              ? 'shadow-[inset_0_-2px_0_0_var(--border-focus)]'
+              : 'shadow-[inset_0_2px_0_0_var(--border-focus)]'),
+        )}
+        onDragOver={
+          reorderable
+            ? (e) => {
+                if (!draggingId) return;
+                e.preventDefault();
+                const r = e.currentTarget.getBoundingClientRect();
+                setDropTarget({ id: issue.id, after: e.clientY > r.top + r.height / 2 });
+              }
+            : undefined
+        }
+        onDrop={
+          reorderable
+            ? (e) => {
+                e.preventDefault();
+                const after = dropTarget?.after ?? false;
+                if (draggingId && draggingId !== issue.id) onReorder!(draggingId, issue.id, after);
+                clearDrag();
+              }
+            : undefined
+        }
+      >
+        {reorderable ? (
+          <span
+            draggable
+            onDragStart={(e) => {
+              setDraggingId(issue.id);
+              e.dataTransfer.effectAllowed = 'move';
+            }}
+            onDragEnd={clearDrag}
+            className="flex shrink-0 cursor-grab items-center pl-2 text-(--txt-icon-tertiary) opacity-0 transition-opacity hover:text-(--txt-icon-secondary) active:cursor-grabbing group-hover/row:opacity-100"
+            aria-label={`Reorder ${displayId}`}
+            title="Drag to reorder"
+          >
+            <GripVertical className="size-4" />
+          </span>
+        ) : null}
         {selection ? (
           <span className="shrink-0 pl-4">
             <input
@@ -83,6 +149,7 @@ export function IssueLayoutList({
           </span>
         ) : null}
         <Link
+          draggable={false}
           to={issueHref(issue.id)}
           className="flex min-h-12 flex-1 items-center gap-3 px-4 py-2.5 no-underline transition-colors hover:bg-(--bg-layer-1-hover)"
         >

--- a/apps/web/src/pages/IssueListPage.tsx
+++ b/apps/web/src/pages/IssueListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { Button } from '../components/ui';
 import { CreateWorkItemModal } from '../components/CreateWorkItemModal';
@@ -110,6 +110,8 @@ export function IssueListPage() {
   const [listDisplay, setListDisplay] = useState<ProjectIssuesDisplayState>(() =>
     cloneDefaultProjectIssuesDisplay(),
   );
+  // Chains reorder saves so rapid drags commit in order (see handleReorder).
+  const reorderChain = useRef<Promise<unknown>>(Promise.resolve());
   useDocumentTitle('Work items');
 
   const refetchIssues = () => {
@@ -554,31 +556,32 @@ export function IssueListPage() {
     now,
   };
 
-  // Manual drag-to-reorder (flat list + manual order): build the new flat order,
-  // assign evenly-spaced sort_order optimistically, then persist the id order so
-  // it works even when items currently share the default sort_order.
+  // Manual drag-to-reorder. We splice the move into the FULL loaded issue set
+  // (in manual order) — not just the visible/filtered rows — so hidden items
+  // keep consistent positions, then persist the whole canonical order. Saves are
+  // chained so rapid drags commit in order (no stale overwrite).
   const handleReorder = (activeId: string, overId: string, after: boolean) => {
     if (!workspaceSlug || !projectId || activeId === overId) return;
-    const flat = groupedIssues.isFlat
-      ? (groupedIssues.groups.get(groupedIssues.order[0]) ?? [])
-      : [];
-    const without = flat.filter((i) => i.id !== activeId);
+    const fullOrdered = [...issues].sort(
+      (a, b) =>
+        (a.sort_order ?? 0) - (b.sort_order ?? 0) ||
+        (a.sequence_id ?? 0) - (b.sequence_id ?? 0) ||
+        a.name.localeCompare(b.name),
+    );
+    const active = fullOrdered.find((i) => i.id === activeId);
+    const without = fullOrdered.filter((i) => i.id !== activeId);
     const overIdx = without.findIndex((i) => i.id === overId);
-    if (overIdx === -1) return;
-    const active = flat.find((i) => i.id === activeId);
-    if (!active) return;
+    if (!active || overIdx === -1) return;
     const insertIdx = after ? overIdx + 1 : overIdx;
     const newOrder = [...without.slice(0, insertIdx), active, ...without.slice(insertIdx)];
     const orderById = new Map(newOrder.map((iss, idx) => [iss.id, (idx + 1) * 1024]));
     setIssues((prev) =>
       prev.map((i) => (orderById.has(i.id) ? { ...i, sort_order: orderById.get(i.id)! } : i)),
     );
-    issueService
-      .reorder(
-        workspaceSlug,
-        projectId,
-        newOrder.map((i) => i.id),
-      )
+    const ids = newOrder.map((i) => i.id);
+    reorderChain.current = reorderChain.current
+      .catch(() => {})
+      .then(() => issueService.reorder(workspaceSlug, projectId, ids))
       .catch(() => refetchIssues());
   };
 

--- a/apps/web/src/pages/IssueListPage.tsx
+++ b/apps/web/src/pages/IssueListPage.tsx
@@ -554,6 +554,36 @@ export function IssueListPage() {
     now,
   };
 
+  // Manual drag-to-reorder (flat list + manual order): build the new flat order,
+  // assign evenly-spaced sort_order optimistically, then persist the id order so
+  // it works even when items currently share the default sort_order.
+  const handleReorder = (activeId: string, overId: string, after: boolean) => {
+    if (!workspaceSlug || !projectId || activeId === overId) return;
+    const flat = groupedIssues.isFlat
+      ? (groupedIssues.groups.get(groupedIssues.order[0]) ?? [])
+      : [];
+    const without = flat.filter((i) => i.id !== activeId);
+    const overIdx = without.findIndex((i) => i.id === overId);
+    if (overIdx === -1) return;
+    const active = flat.find((i) => i.id === activeId);
+    if (!active) return;
+    const insertIdx = after ? overIdx + 1 : overIdx;
+    const newOrder = [...without.slice(0, insertIdx), active, ...without.slice(insertIdx)];
+    const orderById = new Map(newOrder.map((iss, idx) => [iss.id, (idx + 1) * 1024]));
+    setIssues((prev) =>
+      prev.map((i) => (orderById.has(i.id) ? { ...i, sort_order: orderById.get(i.id)! } : i)),
+    );
+    issueService
+      .reorder(
+        workspaceSlug,
+        projectId,
+        newOrder.map((i) => i.id),
+      )
+      .catch(() => refetchIssues());
+  };
+
+  const reorderEnabled = listDisplay.orderBy === 'manual';
+
   return (
     <div className="w-full">
       <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
@@ -674,6 +704,7 @@ export function IssueListPage() {
               cycleName={cycleName}
               moduleName={moduleName}
               selection={{ selectedIds, onToggle: toggleSelect }}
+              onReorder={reorderEnabled ? handleReorder : undefined}
             />
           )}
           {layout === 'board' && <IssueLayoutBoard {...layoutProps} />}

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -93,6 +93,8 @@ export const issueService = {
         type?: string;
         /** uuid to set, "" to clear, omit to leave unchanged */
         estimate_point_id?: string | null;
+        /** manual ordering position (drag-to-reorder) */
+        sort_order?: number;
       }
     >,
   ): Promise<IssueApiResponse> {
@@ -361,5 +363,10 @@ export const issueService = {
 
   async bulkDelete(workspaceSlug: string, projectId: string, issueIds: string[]): Promise<void> {
     await apiClient.post(`${bulkBase(workspaceSlug, projectId)}/delete/`, { issue_ids: issueIds });
+  },
+
+  /** Renumber work items to match the given id order (manual drag-to-reorder). */
+  async reorder(workspaceSlug: string, projectId: string, issueIds: string[]): Promise<void> {
+    await apiClient.post(`${bulkBase(workspaceSlug, projectId)}/reorder/`, { issue_ids: issueIds });
   },
 };


### PR DESCRIPTION
## Summary

Closes #168. Adds manual drag-to-reorder of work items in the project List
layout (when ordering is set to **Manual**).

### Backend
- `POST /api/workspaces/:slug/projects/:projectId/issues-bulk/reorder/` accepts
  `{ issue_ids: [...] }` and renumbers them to evenly-spaced `sort_order`
  (1024-step) in a single transaction — `IssueStore.ReorderIssues` →
  `IssueService.Reorder` → `IssueHandler.BulkReorder`. Renumbering (rather than
  midpoint math) makes reordering deterministic even when work items currently
  share the default `sort_order`.
- The issue `PATCH` also accepts `sort_order` for single granular updates.

### Frontend
- `IssueLayoutList` rows show a drag handle (on hover) and are reorderable via
  native HTML5 drag-and-drop, with a drop indicator. Only active for the flat
  (ungrouped) list passed an `onReorder` callback.
- `IssueListPage` enables it in Manual order: computes the new flat order,
  optimistically applies spaced `sort_order`s, and persists via
  `issueService.reorder` (resyncing on failure).

## Testing

- `go test ./internal/handler -run "TestIssue_BulkReorder|TestIssue_SortOrderReorder"`
  — pass (real Postgres via testcontainers): the reorder endpoint reorders
  even default-valued items; the `sort_order` PATCH persists; empty payload
  rejected. Full `go test ./...` green via the pre-commit hook.
- `go vet ./...`, UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright): in Manual order, dragging a row below
  another reorders the list and persists the new `sort_order` (e.g. 3072), with
  no console errors.

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
the test suite and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now manually reorder issues in flat lists using drag-and-drop and keyboard controls.
  * Added a bulk reorder action for issues so list order can be saved in one step.
  * Issue updates can now adjust list position directly via an optional sort order.

* **Bug Fixes**
  * Reordering now updates issue order consistently across the list.
  * If saving a reordered list fails, the issue list refreshes to restore the correct order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->