### PR TITLE
feat(issues): convert a work item to/from an epic in place

### DIFF
--- a/apps/api/internal/handler/issue_archive.go
+++ b/apps/api/internal/handler/issue_archive.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -67,6 +68,48 @@ func (h *IssueHandler) Restore(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "restored"})
+}
+
+// Convert promotes a work item to an epic or demotes an epic to a work item.
+// POST /api/workspaces/:slug/projects/:projectId/issues/:pk/convert/
+func (h *IssueHandler) Convert(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	iid, ok := issueID(c)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	var body struct {
+		IsEpic *bool `json:"is_epic"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.IsEpic == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "is_epic is required"})
+		return
+	}
+	issue, err := h.Issue.Convert(c.Request.Context(), slug, projectID, iid, user.ID, *body.IsEpic)
+	if err != nil {
+		if err == service.ErrEpicHasChildren {
+			c.JSON(http.StatusConflict, gin.H{"error": "Move or remove the epic's work items before converting it back."})
+			return
+		}
+		if issueAccessNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to convert work item"})
+		return
+	}
+	c.JSON(http.StatusOK, issue)
 }
 
 // ListArchived returns archived work items for a project.

--- a/apps/api/internal/handler/issue_convert_test.go
+++ b/apps/api/internal/handler/issue_convert_test.go
@@ -1,0 +1,44 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue_ConvertToEpicAndBack(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/"
+
+	a := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	id := a.ID.String()
+
+	// Promote to epic.
+	rr := ts.POST(base+id+"/convert/", map[string]any{"is_epic": true}, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Equal(t, true, testutil.MustJSONMap(t, rr)["is_epic"])
+
+	// Give the epic a child work item; demoting should be rejected (409).
+	child := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(child).Update("parent_id", a.ID).Error)
+	rr2 := ts.POST(base+id+"/convert/", map[string]any{"is_epic": false}, w.Session)
+	require.Equal(t, http.StatusConflict, rr2.Code, "body=%s", rr2.Body.String())
+
+	// Detach the child, then the epic can be demoted back to a work item.
+	require.NoError(t, ts.DB.Model(child).Update("parent_id", nil).Error)
+	rr3 := ts.POST(base+id+"/convert/", map[string]any{"is_epic": false}, w.Session)
+	require.Equal(t, http.StatusOK, rr3.Code, "body=%s", rr3.Body.String())
+	require.Equal(t, false, testutil.MustJSONMap(t, rr3)["is_epic"])
+}
+
+func TestIssue_ConvertRequiresIsEpic(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	a := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/"
+	rr := ts.POST(base+a.ID.String()+"/convert/", map[string]any{}, w.Session)
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -343,6 +343,7 @@ func New(cfg Config) *gin.Engine {
 		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/reactions/:reaction/", issueHandler.RemoveReaction)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/archive/", issueHandler.Archive)
 		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/archive/", issueHandler.Restore)
+		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/convert/", issueHandler.Convert)
 		api.GET("/workspaces/:slug/projects/:projectId/archived-issues/", issueHandler.ListArchived)
 		api.POST("/workspaces/:slug/projects/:projectId/issues-bulk/update/", issueHandler.BulkUpdate)
 		api.POST("/workspaces/:slug/projects/:projectId/issues-bulk/archive/", issueHandler.BulkArchive)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -230,25 +230,22 @@ func (s *IssueService) Convert(ctx context.Context, workspaceSlug string, projec
 	if issue.IsEpic == toEpic {
 		return issue, nil
 	}
-	if toEpic {
-		issue.ParentID = nil // an epic cannot itself be a child
-	} else {
-		children, err := s.is.ListIssuesByEpicID(ctx, issue.ID)
-		if err != nil {
-			return nil, err
-		}
-		if len(children) > 0 {
-			return nil, ErrEpicHasChildren
-		}
-	}
-	prev := boolStr(issue.IsEpic)
-	issue.IsEpic = toEpic
-	issue.UpdatedByID = &userID
-	if err := s.is.Update(ctx, issue); err != nil {
+	// The demotion guard (no child work items) and the flip happen in one atomic
+	// UPDATE so a concurrent "add child" can't orphan children under a demoted
+	// epic; 0 rows affected on a demote means children still exist.
+	affected, err := s.is.SetIsEpic(ctx, issue.ID, userID, toEpic)
+	if err != nil {
 		return nil, err
 	}
-	s.recordActivity(ctx, issue, userID, "is_epic", prev, boolStr(toEpic))
-	return issue, nil
+	if affected == 0 {
+		return nil, ErrEpicHasChildren
+	}
+	updated, err := s.is.GetByID(ctx, issue.ID)
+	if err != nil {
+		return nil, err
+	}
+	s.recordActivity(ctx, updated, userID, "is_epic", boolStr(!toEpic), boolStr(toEpic))
+	return updated, nil
 }
 
 func boolStr(b bool) string {

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -21,6 +21,8 @@ var (
 	// requested value is not an accepted priority or a state of the project.
 	ErrInvalidPriority = errors.New("invalid priority")
 	ErrInvalidState    = errors.New("invalid state for project")
+	// ErrEpicHasChildren blocks demoting an epic that still has child work items.
+	ErrEpicHasChildren = errors.New("epic has child work items")
 )
 
 // validPriorities is the accepted set of work-item priority values.
@@ -216,6 +218,44 @@ func (s *IssueService) Restore(ctx context.Context, workspaceSlug string, projec
 		return err
 	}
 	return s.is.SetArchived(ctx, issueID, false)
+}
+
+// Convert promotes a work item to an epic (clearing its parent) or demotes an
+// epic back to a work item (rejected while it still has child work items).
+func (s *IssueService) Convert(ctx context.Context, workspaceSlug string, projectID, issueID, userID uuid.UUID, toEpic bool) (*model.Issue, error) {
+	issue, err := s.issueForAccess(ctx, workspaceSlug, projectID, issueID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if issue.IsEpic == toEpic {
+		return issue, nil
+	}
+	if toEpic {
+		issue.ParentID = nil // an epic cannot itself be a child
+	} else {
+		children, err := s.is.ListIssuesByEpicID(ctx, issue.ID)
+		if err != nil {
+			return nil, err
+		}
+		if len(children) > 0 {
+			return nil, ErrEpicHasChildren
+		}
+	}
+	prev := boolStr(issue.IsEpic)
+	issue.IsEpic = toEpic
+	issue.UpdatedByID = &userID
+	if err := s.is.Update(ctx, issue); err != nil {
+		return nil, err
+	}
+	s.recordActivity(ctx, issue, userID, "is_epic", prev, boolStr(toEpic))
+	return issue, nil
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // ListArchived returns archived issues for a project.

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -172,6 +172,28 @@ func (s *IssueStore) BulkUpdateFields(ctx context.Context, projectID uuid.UUID, 
 	return res.RowsAffected, res.Error
 }
 
+// SetIsEpic flips an issue's is_epic flag. Promotion also clears parent_id.
+// Demotion is guarded atomically: the UPDATE only matches when the issue has no
+// child work items, so a concurrent "add child" can't leave orphaned children
+// under a demoted epic. Returns rows affected (0 on a blocked demotion).
+func (s *IssueStore) SetIsEpic(ctx context.Context, id, userID uuid.UUID, toEpic bool) (int64, error) {
+	updates := map[string]any{"is_epic": toEpic, "updated_by_id": userID}
+	if toEpic {
+		updates["parent_id"] = nil
+		res := s.db.WithContext(ctx).Model(&model.Issue{}).
+			Where("id = ? AND deleted_at IS NULL", id).
+			Updates(updates)
+		return res.RowsAffected, res.Error
+	}
+	res := s.db.WithContext(ctx).Model(&model.Issue{}).
+		Where(
+			"id = ? AND deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM issues c WHERE c.parent_id = issues.id AND c.is_epic = false AND c.deleted_at IS NULL)",
+			id,
+		).
+		Updates(updates)
+	return res.RowsAffected, res.Error
+}
+
 // ReorderIssues renumbers sort_order for the given issues to match the order of
 // `ids` (evenly spaced), in a single transaction. This makes manual drag-order
 // deterministic even when issues currently share the default sort_order.

--- a/apps/web/src/pages/EpicDetailPage.tsx
+++ b/apps/web/src/pages/EpicDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Badge, Card, CardContent, CardHeader } from '../components/ui';
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
@@ -32,6 +32,7 @@ export function EpicDetailPage() {
     projectId: string;
     epicId: string;
   }>();
+  const navigate = useNavigate();
 
   const [loading, setLoading] = useState(true);
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
@@ -109,6 +110,18 @@ export function EpicDetailPage() {
       (addIssueSearch === '' || i.name.toLowerCase().includes(addIssueSearch.toLowerCase())),
   );
 
+  const handleConvertToWorkItem = async () => {
+    if (!workspaceSlug || !epicId) return;
+    if (!window.confirm('Convert this epic back to a work item?')) return;
+    try {
+      await issueService.convert(workspaceSlug, project.id, epicId, false);
+      navigate(`${projectBase}/issues/${epicId}`);
+    } catch (err) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setError(msg || 'Failed to convert to work item.');
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div className="space-y-1">
@@ -118,11 +131,22 @@ export function EpicDetailPage() {
         >
           ← Back to epics
         </Link>
-        <h1 className="text-xl font-semibold text-(--txt-primary)">{epic.name}</h1>
-        <p className="text-sm text-(--txt-secondary)">
-          {project.identifier ?? project.id.slice(0, 6)}-{epic.sequence_id} ·{' '}
-          {stateName(epic.state_id)} · {epic.priority ?? 'no priority'}
-        </p>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-xl font-semibold text-(--txt-primary)">{epic.name}</h1>
+            <p className="text-sm text-(--txt-secondary)">
+              {project.identifier ?? project.id.slice(0, 6)}-{epic.sequence_id} ·{' '}
+              {stateName(epic.state_id)} · {epic.priority ?? 'no priority'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleConvertToWorkItem()}
+            className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+          >
+            Convert to work item
+          </button>
+        </div>
         <div className="mt-2">
           <EpicProgressBar progress={epicId ? progress[epicId] : undefined} />
         </div>

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -1804,6 +1804,20 @@ export function IssueDetailPage() {
                       )}
                     </button>
                   ))}
+                  {!issue.is_epic && (
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 border-t border-(--border-subtle) px-3 py-2 text-left text-sm hover:bg-(--bg-layer-1-hover)"
+                      onClick={() => {
+                        setOpenDropdown(null);
+                        void handleConvertToEpic();
+                      }}
+                    >
+                      <Layers className="size-3.5 text-(--txt-icon-tertiary)" />
+                      <span className="text-(--txt-primary)">Epic</span>
+                      <span className="ml-auto text-xs text-(--txt-tertiary)">Convert</span>
+                    </button>
+                  )}
                 </Dropdown>
               </PropertyRow>
 

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { Archive, ArchiveRestore } from 'lucide-react';
+import { Archive, ArchiveRestore, Layers } from 'lucide-react';
 import { Button, Card, CardContent, CardHeader, Avatar } from '../components/ui';
 import { useAuth } from '../contexts/AuthContext';
 import { Dropdown, DatePickerTrigger, CommentEditor } from '../components/work-item';
@@ -501,6 +501,22 @@ export function IssueDetailPage() {
       setErrorMessage('Failed to restore work item.');
     }
   };
+
+  const handleConvertToEpic = async () => {
+    if (!workspaceSlug || !projectId || !issueId) return;
+    if (
+      !window.confirm(
+        'Convert this work item to an epic? It will be detached from its parent, if any.',
+      )
+    )
+      return;
+    try {
+      await issueService.convert(workspaceSlug, projectId, issueId, true);
+      navigate(`${baseUrl}/epics/${issueId}`);
+    } catch {
+      setErrorMessage('Failed to convert to epic.');
+    }
+  };
   const descriptionHtml =
     issue.description_html && typeof issue.description_html === 'string'
       ? issue.description_html
@@ -680,25 +696,37 @@ export function IssueDetailPage() {
           <span>/</span>
           <span className="text-(--txt-secondary)">{displayId}</span>
         </div>
-        {issue.archived_at ? (
-          <button
-            type="button"
-            onClick={() => void handleRestore()}
-            className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
-          >
-            <ArchiveRestore className="h-3.5 w-3.5" />
-            Restore
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={() => void handleArchive()}
-            className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
-          >
-            <Archive className="h-3.5 w-3.5" />
-            Archive
-          </button>
-        )}
+        <div className="flex shrink-0 items-center gap-2">
+          {!issue.is_epic && !issue.archived_at ? (
+            <button
+              type="button"
+              onClick={() => void handleConvertToEpic()}
+              className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+            >
+              <Layers className="h-3.5 w-3.5" />
+              Convert to epic
+            </button>
+          ) : null}
+          {issue.archived_at ? (
+            <button
+              type="button"
+              onClick={() => void handleRestore()}
+              className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+            >
+              <ArchiveRestore className="h-3.5 w-3.5" />
+              Restore
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void handleArchive()}
+              className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover)"
+            >
+              <Archive className="h-3.5 w-3.5" />
+              Archive
+            </button>
+          )}
+        </div>
       </div>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -323,6 +323,20 @@ export const issueService = {
     await apiClient.delete(`${base(workspaceSlug, projectId, issueId)}/archive/`);
   },
 
+  /** Promote a work item to an epic (isEpic=true) or demote it back. */
+  async convert(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    isEpic: boolean,
+  ): Promise<IssueApiResponse> {
+    const { data } = await apiClient.post<IssueApiResponse>(
+      `${base(workspaceSlug, projectId, issueId)}/convert/`,
+      { is_epic: isEpic },
+    );
+    return data;
+  },
+
   async listArchived(
     workspaceSlug: string,
     projectId: string,


### PR DESCRIPTION
## Summary

Closes #170. Epics are work items with `is_epic = true`; this adds in-place
conversion in both directions.

### Backend
- `POST /api/workspaces/:slug/projects/:projectId/issues/:pk/convert/` with
  `{ "is_epic": bool }` — `IssueService.Convert`:
  - **Promote** (work item → epic): clears `parent_id` (an epic can't be a child).
  - **Demote** (epic → work item): rejected with **409** while the epic still has
    child work items (move/remove them first); otherwise flips the flag.
  - Records an `is_epic` activity entry.

### Frontend
- "Convert to epic" action on the work-item detail header → navigates to the
  epic view. "Convert to work item" on the epic detail header → navigates back,
  surfacing the 409 message when children block it. `issueService.convert`
  wraps the endpoint.

## Testing

- `go test ./internal/handler -run TestIssue_Convert` — pass (real Postgres via
  testcontainers): promote, demote, demote-with-children → 409, and missing
  `is_epic` → 400. Full `go test ./...` green via the pre-commit hook.
- `go vet ./...`, UI `typecheck` / `lint` — pass.
- Verified in-browser (Playwright): work item → "Convert to epic" navigates to
  the epic page (`is_epic` persisted true); childless epic → "Convert to work
  item" navigates back (`is_epic` false); 0 console errors.

## AI assistance

Implemented with the assistance of Claude Code (Claude Opus 4.8); verified via
the test suite and in-browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added issue↔epic conversion via a new convert action, including “Convert to epic” and “Convert to work item” flows on detail pages with confirmation prompts and navigation after success.
  * Added the “Convert” option to the Issue Detail page type selector when applicable.
* **Bug Fixes**
  * Prevented demoting an epic back to a work item when it still has child items, returning a clear conflict response.
  * Added validation to require the `is_epic` flag for conversion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->