### PR TITLE
fix(auth): reject unconfirmed GitLab OAuth emails to prevent account takeover

### DIFF
--- a/apps/api/internal/oauth/gitlab.go
+++ b/apps/api/internal/oauth/gitlab.go
@@ -62,6 +62,12 @@ func (g *GitLabProvider) GetUserInfo(ctx context.Context, token *TokenData) (*Us
 	if err != nil {
 		return nil, err
 	}
+	// Refuse an unconfirmed email: GitLab lets a user set an arbitrary address
+	// before confirming it, so an unconfirmed email must not be linked to an
+	// existing account (mirrors the Google/GitHub verified-email checks).
+	if strVal(resp, "confirmed_at") == "" {
+		return nil, ErrEmailNotVerified
+	}
 	return &UserInfo{
 		Email:      strVal(resp, "email"),
 		FirstName:  strVal(resp, "name"),

--- a/apps/api/internal/oauth/gitlab_test.go
+++ b/apps/api/internal/oauth/gitlab_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,12 @@ func newGitLabTestServer(t *testing.T, body map[string]interface{}) *httptest.Se
 		if r.URL.Path != "/api/v4/user" {
 			http.NotFound(w, r)
 			return
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("expected bearer token auth header, got %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(body)
@@ -33,7 +40,7 @@ func TestGitLabGetUserInfo_RejectsUnconfirmedEmail(t *testing.T) {
 
 	provider := NewGitLabProvider(ProviderConfig{}, srv.URL)
 	_, err := provider.GetUserInfo(context.Background(), &TokenData{AccessToken: "tok"})
-	if err != ErrEmailNotVerified {
+	if !errors.Is(err, ErrEmailNotVerified) {
 		t.Fatalf("expected ErrEmailNotVerified, got %v", err)
 	}
 }

--- a/apps/api/internal/oauth/gitlab_test.go
+++ b/apps/api/internal/oauth/gitlab_test.go
@@ -1,0 +1,61 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newGitLabTestServer(t *testing.T, body map[string]interface{}) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v4/user" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGitLabGetUserInfo_RejectsUnconfirmedEmail(t *testing.T) {
+	srv := newGitLabTestServer(t, map[string]interface{}{
+		"id":           42,
+		"email":        "victim@example.com",
+		"name":         "Attacker",
+		"avatar_url":   "https://example.com/a.png",
+		"confirmed_at": nil,
+	})
+
+	provider := NewGitLabProvider(ProviderConfig{}, srv.URL)
+	_, err := provider.GetUserInfo(context.Background(), &TokenData{AccessToken: "tok"})
+	if err != ErrEmailNotVerified {
+		t.Fatalf("expected ErrEmailNotVerified, got %v", err)
+	}
+}
+
+func TestGitLabGetUserInfo_AcceptsConfirmedEmail(t *testing.T) {
+	srv := newGitLabTestServer(t, map[string]interface{}{
+		"id":           42,
+		"email":        "user@example.com",
+		"name":         "Real User",
+		"avatar_url":   "https://example.com/a.png",
+		"confirmed_at": "2024-01-01T00:00:00.000Z",
+	})
+
+	provider := NewGitLabProvider(ProviderConfig{}, srv.URL)
+	info, err := provider.GetUserInfo(context.Background(), &TokenData{AccessToken: "tok"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Email != "user@example.com" {
+		t.Fatalf("expected email to be returned, got %q", info.Email)
+	}
+	if info.ProviderID != "42" {
+		t.Fatalf("expected provider id 42, got %q", info.ProviderID)
+	}
+}


### PR DESCRIPTION
## Summary
GitLab OAuth linked accounts by the email GitLab returned, without checking whether that email was confirmed. Because GitLab lets a user set an arbitrary (unconfirmed) email on their profile, an attacker could set a victim's Devlane email on their own GitLab account, complete GitLab OAuth, and get logged into the victim's existing Devlane account. Google and GitHub OAuth were already hardened against this (`verified_email` / verified-emails endpoint checks); GitLab was missed.

Fixes #153

## Changes
- `apps/api/internal/oauth/gitlab.go`: `GetUserInfo` now checks GitLab's `confirmed_at` field and returns `ErrEmailNotVerified` (the same sentinel error already used by the Google/GitHub providers) when the email is unconfirmed. The existing generic error handling in `handler/oauth.go` already surfaces this as a login failure — no handler changes needed.
- `apps/api/internal/oauth/gitlab_test.go` (new): covers both the rejection of an unconfirmed email and the happy path with a confirmed email, using an `httptest.Server` to stand in for the GitLab API (mirroring how `host` is already injectable via `NewGitLabProvider`).

## Test plan
- [x] `go test ./internal/oauth/...` — new tests pass
- [x] `go vet ./...` and `go test ./...` — full suite passes
- [x] `npm run typecheck` — passes (no UI changes)
- [x] Reviewed with `/code-review` (high effort) — no findings

## AI assistance
This change was implemented with Claude Code (Sonnet 5), which read the issue, located the root cause, wrote the fix mirroring the existing Google/GitHub verified-email pattern, and added tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GitLab sign-in to reject users whose email is not verified, instead of allowing access.
  * Verified GitLab users continue to receive their account details as before.

* **Tests**
  * Added unit tests for GitLab user-info handling for both unverified and verified email cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->