### PR TITLE
fix(api): cap project role updates and protect workspace owner's project membership

### DIFF
--- a/apps/api/internal/handler/project_test.go
+++ b/apps/api/internal/handler/project_test.go
@@ -159,6 +159,91 @@ func TestProject_DraftIssues(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
 }
 
+func TestProject_UpdateMember_CannotEscalateAboveOwnRole(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	owner := testutil.CreateUser(t, ts.DB)
+	w := testutil.CreateWorkspace(t, ts.DB, owner.ID)
+	p := testutil.CreateProject(t, ts.DB, w.ID, owner.ID)
+
+	// A project Admin (not a workspace admin/owner) tries to promote another
+	// project member to Owner — must be capped at the Admin's own role.
+	projectAdmin := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, projectAdmin.ID, testutil.RoleMember)
+	testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, projectAdmin.ID, testutil.RoleAdmin)
+
+	target := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, target.ID, testutil.RoleMember)
+	m := testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, target.ID, testutil.RoleMember)
+
+	session := testutil.LoginAs(t, ts.DB, projectAdmin)
+	rr := ts.PATCH("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/members/"+m.ID.String()+"/", map[string]any{
+		"role": testutil.RoleOwner,
+	}, session)
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+}
+
+func TestProject_UpdateMember_CannotChangeWorkspaceOwnersMembership(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	owner := testutil.CreateUser(t, ts.DB)
+	w := testutil.CreateWorkspace(t, ts.DB, owner.ID)
+	lead := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, lead.ID, testutil.RoleMember)
+	p := testutil.CreateProject(t, ts.DB, w.ID, lead.ID)
+	// The workspace owner also happens to have a project membership (e.g.
+	// they joined the project directly); it must still be untouchable by a
+	// project Admin who isn't the workspace owner.
+	ownerMembership := testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, owner.ID, testutil.RoleOwner)
+
+	projectAdmin := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, projectAdmin.ID, testutil.RoleMember)
+	testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, projectAdmin.ID, testutil.RoleAdmin)
+
+	session := testutil.LoginAs(t, ts.DB, projectAdmin)
+	rr := ts.PATCH("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/members/"+ownerMembership.ID.String()+"/", map[string]any{
+		"role": testutil.RoleMember,
+	}, session)
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+
+	delRR := ts.DELETE("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/members/"+ownerMembership.ID.String()+"/", session)
+	require.Equal(t, http.StatusNotFound, delRR.Code, "body=%s", delRR.Body.String())
+}
+
+func TestProject_UpdateMember_WorkspaceOwnerCanGrantOwner(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	owner := testutil.CreateUser(t, ts.DB)
+	w := testutil.CreateWorkspace(t, ts.DB, owner.ID)
+	p := testutil.CreateProject(t, ts.DB, w.ID, owner.ID)
+
+	target := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, target.ID, testutil.RoleMember)
+	m := testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, target.ID, testutil.RoleMember)
+
+	session := testutil.LoginAs(t, ts.DB, owner)
+	rr := ts.PATCH("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/members/"+m.ID.String()+"/", map[string]any{
+		"role": testutil.RoleOwner,
+	}, session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	assert.EqualValues(t, testutil.RoleOwner, testutil.MustJSONMap(t, rr)["role"])
+}
+
+func TestProject_CreateInvite_CannotInviteAboveOwnRole(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	owner := testutil.CreateUser(t, ts.DB)
+	w := testutil.CreateWorkspace(t, ts.DB, owner.ID)
+	p := testutil.CreateProject(t, ts.DB, w.ID, owner.ID)
+
+	projectAdmin := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, projectAdmin.ID, testutil.RoleMember)
+	testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, projectAdmin.ID, testutil.RoleAdmin)
+
+	session := testutil.LoginAs(t, ts.DB, projectAdmin)
+	rr := ts.POST("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/invitations/", map[string]any{
+		"email": "escalate@test.local",
+		"role":  testutil.RoleOwner,
+	}, session)
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+}
+
 func TestProject_UserInvitations(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/apps/api/internal/handler/project_test.go
+++ b/apps/api/internal/handler/project_test.go
@@ -208,6 +208,34 @@ func TestProject_UpdateMember_CannotChangeWorkspaceOwnersMembership(t *testing.T
 	require.Equal(t, http.StatusNotFound, delRR.Code, "body=%s", delRR.Body.String())
 }
 
+func TestProject_UpdateMember_CannotActOnDelegatedOwner(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	owner := testutil.CreateUser(t, ts.DB)
+	w := testutil.CreateWorkspace(t, ts.DB, owner.ID)
+	lead := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, lead.ID, testutil.RoleMember)
+	p := testutil.CreateProject(t, ts.DB, w.ID, lead.ID)
+	// A non-workspace-owner member was previously delegated project Owner by
+	// the actual workspace owner. A project Admin (lower role) must not be
+	// able to demote or remove them.
+	delegatedOwner := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, delegatedOwner.ID, testutil.RoleMember)
+	delegatedOwnerMembership := testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, delegatedOwner.ID, testutil.RoleOwner)
+
+	projectAdmin := testutil.CreateUser(t, ts.DB)
+	testutil.AddWorkspaceMember(t, ts.DB, w.ID, projectAdmin.ID, testutil.RoleMember)
+	testutil.AddProjectMember(t, ts.DB, p.ID, w.ID, projectAdmin.ID, testutil.RoleAdmin)
+
+	session := testutil.LoginAs(t, ts.DB, projectAdmin)
+	rr := ts.PATCH("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/members/"+delegatedOwnerMembership.ID.String()+"/", map[string]any{
+		"role": testutil.RoleMember,
+	}, session)
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+
+	delRR := ts.DELETE("/api/workspaces/"+w.Slug+"/projects/"+p.ID.String()+"/members/"+delegatedOwnerMembership.ID.String()+"/", session)
+	require.Equal(t, http.StatusNotFound, delRR.Code, "body=%s", delRR.Body.String())
+}
+
 func TestProject_UpdateMember_WorkspaceOwnerCanGrantOwner(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	owner := testutil.CreateUser(t, ts.DB)

--- a/apps/api/internal/service/project.go
+++ b/apps/api/internal/service/project.go
@@ -59,18 +59,27 @@ func (s *ProjectService) GetByID(ctx context.Context, workspaceSlug string, proj
 	return s.ps.GetByID(ctx, projectID)
 }
 
-// requireProjectAdmin allows the action when the caller is a workspace
-// admin/owner, or a project member with at least the Admin role. Read access
-// (workspace membership) is validated separately by GetByID.
-func (s *ProjectService) requireProjectAdmin(ctx context.Context, workspaceID, projectID, userID uuid.UUID) error {
+// projectCallerRole returns the caller's effective role for admin actions on
+// a project: their workspace role if they are a workspace admin/owner,
+// otherwise their project-member role. Returns ErrProjectForbidden if
+// neither grants at least the Admin role. Read access (workspace membership)
+// is validated separately by GetByID.
+func (s *ProjectService) projectCallerRole(ctx context.Context, workspaceID, projectID, userID uuid.UUID) (int16, error) {
 	if wm, err := s.ws.GetMember(ctx, workspaceID, userID); err == nil && wm != nil && wm.Role >= model.RoleAdmin {
-		return nil
+		return wm.Role, nil
 	}
 	pm, err := s.ps.GetProjectMember(ctx, projectID, userID)
 	if err != nil || pm == nil || pm.Role < model.RoleAdmin {
-		return ErrProjectForbidden
+		return 0, ErrProjectForbidden
 	}
-	return nil
+	return pm.Role, nil
+}
+
+// requireProjectAdmin allows the action when the caller is a workspace
+// admin/owner, or a project member with at least the Admin role.
+func (s *ProjectService) requireProjectAdmin(ctx context.Context, workspaceID, projectID, userID uuid.UUID) error {
+	_, err := s.projectCallerRole(ctx, workspaceID, projectID, userID)
+	return err
 }
 
 func (s *ProjectService) Create(ctx context.Context, workspaceSlug, name, identifier string, userID uuid.UUID) (*model.Project, error) {
@@ -201,12 +210,27 @@ func (s *ProjectService) UpdateMemberRole(ctx context.Context, workspaceSlug str
 	if err != nil {
 		return nil, err
 	}
-	if err := s.requireProjectAdmin(ctx, p.WorkspaceID, p.ID, userID); err != nil {
+	callerRole, err := s.projectCallerRole(ctx, p.WorkspaceID, p.ID, userID)
+	if err != nil {
 		return nil, err
+	}
+	wrk, err := s.ws.GetByID(ctx, p.WorkspaceID)
+	if err != nil {
+		return nil, ErrProjectNotFound
 	}
 	m, err := s.ps.GetProjectMemberByPK(ctx, memberPK)
 	if err != nil || m.ProjectID != projectID {
 		return nil, ErrMemberNotFound
+	}
+	// Only the workspace owner may change the role of their own project
+	// membership; nobody else may touch it.
+	if m.MemberID != nil && *m.MemberID == wrk.OwnerID && userID != wrk.OwnerID {
+		return nil, ErrProjectForbidden
+	}
+	// Cannot grant a role above your own, and only the workspace owner may
+	// grant project Owner.
+	if role > callerRole || (role >= model.RoleOwner && userID != wrk.OwnerID) {
+		return nil, ErrProjectForbidden
 	}
 	m.Role = role
 	if err := s.ps.UpdateProjectMember(ctx, m); err != nil {
@@ -223,9 +247,17 @@ func (s *ProjectService) DeleteMember(ctx context.Context, workspaceSlug string,
 	if err := s.requireProjectAdmin(ctx, p.WorkspaceID, p.ID, userID); err != nil {
 		return err
 	}
+	wrk, err := s.ws.GetByID(ctx, p.WorkspaceID)
+	if err != nil {
+		return ErrProjectNotFound
+	}
 	m, err := s.ps.GetProjectMemberByPK(ctx, memberPK)
 	if err != nil || m.ProjectID != projectID {
 		return ErrMemberNotFound
+	}
+	// The workspace owner's project membership cannot be removed by anyone.
+	if m.MemberID != nil && *m.MemberID == wrk.OwnerID {
+		return ErrProjectForbidden
 	}
 	if m.MemberID != nil {
 		return s.ps.DeleteProjectMember(ctx, projectID, *m.MemberID)
@@ -252,8 +284,18 @@ func (s *ProjectService) CreateInvite(ctx context.Context, workspaceSlug string,
 	if err != nil {
 		return nil, err
 	}
-	if err := s.requireProjectAdmin(ctx, p.WorkspaceID, p.ID, userID); err != nil {
+	callerRole, err := s.projectCallerRole(ctx, p.WorkspaceID, p.ID, userID)
+	if err != nil {
 		return nil, err
+	}
+	wrk, err := s.ws.GetByID(ctx, p.WorkspaceID)
+	if err != nil {
+		return nil, ErrProjectNotFound
+	}
+	// Cannot invite at a role above your own, and only the workspace owner
+	// may invite at project Owner.
+	if role > callerRole || (role >= model.RoleOwner && userID != wrk.OwnerID) {
+		return nil, ErrProjectForbidden
 	}
 	inv := &model.ProjectMemberInvite{
 		ProjectID:   p.ID,

--- a/apps/api/internal/service/project.go
+++ b/apps/api/internal/service/project.go
@@ -227,6 +227,11 @@ func (s *ProjectService) UpdateMemberRole(ctx context.Context, workspaceSlug str
 	if m.MemberID != nil && *m.MemberID == wrk.OwnerID && userID != wrk.OwnerID {
 		return nil, ErrProjectForbidden
 	}
+	// Only the workspace owner may act on a member who already holds a
+	// higher role than the caller (e.g. a delegated project Owner).
+	if userID != wrk.OwnerID && m.Role > callerRole {
+		return nil, ErrProjectForbidden
+	}
 	// Cannot grant a role above your own, and only the workspace owner may
 	// grant project Owner.
 	if role > callerRole || (role >= model.RoleOwner && userID != wrk.OwnerID) {
@@ -244,7 +249,8 @@ func (s *ProjectService) DeleteMember(ctx context.Context, workspaceSlug string,
 	if err != nil {
 		return err
 	}
-	if err := s.requireProjectAdmin(ctx, p.WorkspaceID, p.ID, userID); err != nil {
+	callerRole, err := s.projectCallerRole(ctx, p.WorkspaceID, p.ID, userID)
+	if err != nil {
 		return err
 	}
 	wrk, err := s.ws.GetByID(ctx, p.WorkspaceID)
@@ -257,6 +263,11 @@ func (s *ProjectService) DeleteMember(ctx context.Context, workspaceSlug string,
 	}
 	// The workspace owner's project membership cannot be removed by anyone.
 	if m.MemberID != nil && *m.MemberID == wrk.OwnerID {
+		return ErrProjectForbidden
+	}
+	// Only the workspace owner may remove a member who already holds a
+	// higher role than the caller (e.g. a delegated project Owner).
+	if userID != wrk.OwnerID && m.Role > callerRole {
 		return ErrProjectForbidden
 	}
 	if m.MemberID != nil {


### PR DESCRIPTION
## Summary
Project member-role updates and invite creation had no role cap and no owner protection. Any project Admin could promote themselves or anyone to project Owner, or demote/strip another member's project membership — including the workspace owner's own project membership. The workspace-level equivalents (`apps/api/internal/service/workspace.go`) were already correctly guarded; the project paths were not.

Fixes #154

## Changes
- `apps/api/internal/service/project.go`:
  - Added `projectCallerRole` (replacing the boolean-only `requireProjectAdmin` internals) which returns the caller's effective numeric role — their workspace role if they're a workspace admin/owner, otherwise their project-member role.
  - `UpdateMemberRole`: caps the granted role at the caller's own role, restricts granting project Owner to the workspace owner, and blocks anyone but the workspace owner from changing the workspace owner's own project membership.
  - `DeleteMember`: blocks removing the workspace owner's project membership, by anyone.
  - `CreateInvite`: caps the invited role at the caller's own role, restricts inviting at project Owner to the workspace owner.
  - This mirrors the existing, already-shipped workspace-level logic in `WorkspaceService.UpdateMemberRole`/`CreateInvite`/`DeleteMember` exactly, per the issue's suggested fix.
- `apps/api/internal/handler/project_test.go`: 4 new integration tests — role-escalation is capped, workspace owner's project membership can't be changed/removed by a non-owner Admin, the workspace owner *can* grant project Owner, and invite creation is capped the same way.

## Behavior-change note
The web Settings UI's project-member "Admin" role control actually sends role value `20`, which is `RoleOwner` in the backend (the UI only has a two-tier member/admin model and never sends `15`/`RoleAdmin` — this is a pre-existing frontend/backend mismatch, unrelated to this PR, and the same mismatch already exists for workspace-member updates today). Before this fix, that meant any project Admin using the UI's "promote to Admin" control was unknowingly granting full project **Owner** with no restriction — i.e. the exact vulnerability this issue describes. After this fix, that promotion action will correctly be blocked for any project Admin who isn't the workspace owner (silently, matching the existing UX for the equivalent workspace-member control). This is the intended security tightening, not a regression, but flagging it since it does change what currently "works" in the UI for non-owner Admins.

## Test plan
- [x] New handler tests (`go test ./internal/handler/... -run TestProject_`) pass
- [x] `go vet ./...` and `go test ./...` — full suite passes
- [x] `npm run typecheck` — passes (no UI changes)
- [x] Reviewed with `/code-review` (high effort) — no code defects found; traced all Go call sites and the web UI's role-value usage to confirm no legitimate flow (other than the unintended Owner-grant above) breaks

## AI assistance
This change was implemented with Claude Code (Sonnet 5), which read the issue, located the vulnerable code, mirrored the existing workspace-level protection pattern, added regression tests, and traced call sites/UI usage to assess behavior-change risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened project admin permissions for role changes, member removal, and invitations.
  * Enforced consistent authorization using an effective “caller role” based on workspace/project membership.
  * Prevented assigning project roles above the caller’s allowed level.
  * Blocked updates/deletes affecting workspace owners and delegated project owners, except where permitted.
  * Allowed workspace owners to grant owner-level access within a project.
  * Added API handler tests covering role escalation limits and forbidden membership changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->