### PR TITLE
fix(auth): reject and evict sessions for deactivated users on every request

### DIFF
--- a/apps/api/internal/auth/service.go
+++ b/apps/api/internal/auth/service.go
@@ -240,7 +240,17 @@ func (s *Service) UserFromSession(ctx context.Context, sessionKey string) (*mode
 	if err != nil || data == nil {
 		return nil, nil
 	}
-	return s.userStore.GetByID(ctx, data.UserID)
+	user, err := s.userStore.GetByID(ctx, data.UserID)
+	if err != nil || user == nil {
+		return nil, nil
+	}
+	if !user.IsActive {
+		// Deactivation doesn't purge sessions, so re-check on every request
+		// rather than only at sign-in; evict this session while we're here.
+		_ = s.sessionStore.Delete(ctx, sessionKey)
+		return nil, nil
+	}
+	return user, nil
 }
 
 func (s *Service) UpdateProfile(ctx context.Context, u *model.User) error {

--- a/apps/api/internal/auth/service_test.go
+++ b/apps/api/internal/auth/service_test.go
@@ -210,6 +210,44 @@ func TestForgotResetPassword(t *testing.T) {
 	}
 }
 
+func TestUserFromSession_RejectsDeactivatedUser(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	svc, db := newTestService(t)
+
+	sessionKey, user, err := svc.SignUp(ctx, SignUpRequest{
+		Email:    "deactivated@example.com",
+		Password: "S3cur3!Pass",
+	})
+	if err != nil {
+		t.Fatalf("SignUp: %v", err)
+	}
+
+	// Sanity check: the session is valid while the user is active.
+	got, err := svc.UserFromSession(ctx, sessionKey)
+	if err != nil || got == nil {
+		t.Fatalf("UserFromSession before deactivation: got=%#v err=%v", got, err)
+	}
+
+	if err := db.Exec("UPDATE users SET is_active = 0 WHERE id = ?", user.ID.String()).Error; err != nil {
+		t.Fatalf("deactivate user: %v", err)
+	}
+
+	got2, err := svc.UserFromSession(ctx, sessionKey)
+	if err != nil || got2 != nil {
+		t.Fatalf("expected no user for a deactivated user's session, got=%#v err=%v", got2, err)
+	}
+
+	var sessionCount int64
+	if err := db.Table("sessions").Where("session_key = ?", sessionKey).Count(&sessionCount).Error; err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if sessionCount != 0 {
+		t.Fatalf("expected the deactivated user's session to be evicted, found %d rows", sessionCount)
+	}
+}
+
 func TestResetPasswordInactiveUser(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
`IsActive` was only checked at sign-in-adjacent entry points (sign-in, OAuth login, forgot/reset password). The per-request auth path (`RequireAuth` middleware -> `UserFromSession`) never rechecked it, and deactivation didn't purge sessions — so a deactivated user kept full API access for up to the 14-day session lifetime.

Fixes #155

## Changes
- `apps/api/internal/auth/service.go`: `UserFromSession` now fetches the user, checks `IsActive`, and if the user is deactivated, evicts that session (`sessionStore.Delete`) and returns no user — which `RequireAuth` (unchanged) already treats as a 401, same as any other unauthenticated request.
- `apps/api/internal/auth/service_test.go`: new `TestUserFromSession_RejectsDeactivatedUser` — signs up, confirms the session works while active, flips the user inactive (same raw-SQL pattern as the existing `TestResetPasswordInactiveUser`), then asserts `UserFromSession` returns no user *and* the session row is gone.

## Scope note
The issue's suggested fix also mentions calling `sessionStore.DeleteByUserID` whenever a user is deactivated. I checked and **there is currently no production code path anywhere that sets `IsActive = false`** — no admin-deactivate handler/service exists yet (that looks like it's future issue #209's job, which is out of scope for this security-fix loop). So that half of the suggested fix has no real call site to hook into today. I implemented the per-request recheck only, which is strictly stronger anyway: it closes the vulnerability regardless of whether a future deactivation feature remembers to purge sessions, since every request independently re-validates `IsActive`.

## Test plan
- [x] New test (`go test ./internal/auth/... -run TestUserFromSession_RejectsDeactivatedUser`) passes
- [x] `go vet ./...` and `go test ./...` — full suite passes
- [x] `npm run typecheck` — passes (no UI changes)
- [x] Reviewed with `/code-review` (high effort) — no findings; confirmed `UserFromSession` has exactly one production caller (`RequireAuth`), so no other call site is affected

## AI assistance
This change was implemented with Claude Code (Sonnet 5), which read the issue, traced the auth code path, confirmed there's no current deactivation trigger to wire session-purging into, implemented the per-request recheck, and added a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User sessions now stop working immediately after the associated account is deactivated.
  * If a session can’t be matched to an active user, no user is returned and the session is cleared.

* **Tests**
  * Added coverage to verify deactivated users can no longer authenticate and their sessions are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->