### PR TITLE
docs: clean up public docs and repo metadata

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,18 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+Devlane is under active development on a single `main` branch. Only the latest
+commit on `main` is supported with security fixes — there are no parallel
+maintained release lines.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please **do not** open a public GitHub issue for security vulnerabilities.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Instead, use GitHub's private vulnerability reporting for this repository:
+open the **Security** tab → **Report a vulnerability**. This creates a private
+advisory visible only to maintainers until a fix is ready.
+
+We'll acknowledge new reports as soon as possible and keep you updated as we
+investigate and prepare a fix. Once a fix is released, we'll credit you in the
+advisory (unless you'd prefer to stay anonymous).

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,1 +1,62 @@
 # Devlane API
+
+Go backend for Devlane (Gin + GORM + PostgreSQL). Module path
+`github.com/Devlaner/devlane/api`.
+
+## Prerequisites
+
+- Go 1.26+ (see `go.mod` for the exact version)
+- Local infra from the repo root: `docker compose up -d` (Postgres, Redis,
+  RabbitMQ, MinIO)
+
+## Local setup
+
+1. From the repo root, start infra: `docker compose up -d`. Postgres is
+   published on host port **15432**, not the default 5432.
+2. Copy `.env.example` to `.env` in this directory and set at least
+   `DB_PORT=15432`, plus your Postgres/Redis credentials if you changed the
+   defaults in `docker-compose.yml`.
+3. Run the API: `go run ./cmd/api`. Migrations under `migrations/` are applied
+   automatically on startup — no separate migration command needed.
+4. The API listens on `:8080` by default.
+
+Redis, RabbitMQ, and MinIO are optional: if any of them fail to connect at
+startup, the API logs a warning and continues — features that depend on them
+(caching, magic-link login, background email/webhook delivery, file uploads)
+degrade gracefully rather than crashing the process.
+
+## Environment variables
+
+See `internal/config/config.go` for the full list and defaults. The most
+commonly changed ones for local dev:
+
+| Variable         | Purpose                                   | Local default        |
+| ---------------- | ------------------------------------------ | --------------------- |
+| `DB_PORT`        | Postgres port                              | `15432` (via `.env`)  |
+| `DB_HOST`        | Postgres host                              | `localhost`           |
+| `REDIS_ADDR`     | Redis address                              | `localhost:6379`      |
+| `RABBITMQ_URL`   | RabbitMQ connection string                 | `amqp://guest:guest@localhost:5672/` |
+| `MINIO_ENDPOINT` | MinIO endpoint                             | `localhost:9000`      |
+| `CORS_ORIGIN`    | Allowed origin for the web app in dev      | `http://localhost:5173` |
+
+## Commands
+
+```sh
+go run ./cmd/api                              # start the API server (auto-runs migrations)
+go vet ./...                                   # static analysis
+go test ./...                                  # run all tests
+go test ./internal/auth -run TestMagicCode     # run a single package/test
+```
+
+## Migrations
+
+Add paired files under `migrations/`: `NNNNNN_<name>.up.sql` and
+`NNNNNN_<name>.down.sql`. They're applied automatically at startup via
+`internal/database`. Never edit a migration after it has been merged — add a
+new one instead.
+
+## Conventions
+
+Layering is `handler → service → store` (handlers never touch GORM directly;
+stores never call services). See the repo-root `CLAUDE.md` for the full
+architecture overview and `CONTRIBUTING.md` for commit/PR conventions.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -13,8 +13,9 @@ Router 7).
 
 1. `npm install`
 2. `npm run dev` — starts the Vite dev server on `http://localhost:5173` by
-   default, proxying API calls to `http://localhost:8080` (see
-   `src/api/client.ts`).
+   default. API calls go directly (no dev-server proxy) to
+   `http://localhost:8080` unless `VITE_API_BASE_URL` is set (see
+   `src/api/client.ts`); the API must allow that origin via `CORS_ORIGIN`.
 3. On first run, complete instance setup in the browser (create the admin
    account, then a workspace and project).
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,99 +1,46 @@
-# React + TypeScript + Vite
+# Devlane Web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React 19 + TypeScript + Vite single-page app for Devlane (Tailwind 4, React
+Router 7).
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Node.js (see the root `package.json`/CI config for the version used)
+- The Devlane API running locally (see `apps/api/README.md`) — or set
+  `VITE_API_BASE_URL` to point at a different instance.
 
-## React Compiler
+## Local setup
 
-The React Compiler is currently not compatible with SWC. See [this issue](https://github.com/vitejs/vite-plugin-react/issues/428) for tracking the progress.
+1. `npm install`
+2. `npm run dev` — starts the Vite dev server on `http://localhost:5173` by
+   default, proxying API calls to `http://localhost:8080` (see
+   `src/api/client.ts`).
+3. On first run, complete instance setup in the browser (create the admin
+   account, then a workspace and project).
 
-## Expanding the ESLint configuration
+## Environment variables
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+| Variable            | Purpose                     | Default (dev)           |
+| ------------------- | --------------------------- | ----------------------- |
+| `VITE_API_BASE_URL` | Base URL of the Devlane API | `http://localhost:8080` |
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+## Commands
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```sh
+npm run dev            # start the Vite dev server (HMR)
+npm run build           # tsc -b && vite build
+npm run typecheck       # tsc -b --noEmit
+npm run lint            # eslint .
+npm run lint:fix        # eslint --fix .
+npm run format          # prettier --write .
+npm run format:check    # prettier --check .
+npm run preview         # serve the production build locally
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Conventions
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x';
-import reactDom from 'eslint-plugin-react-dom';
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
-```
-
----
-
-## Ufazien Deployment
-
-This project is configured for deployment to Ufazien Hosting.
-
-### Build and Deploy
-
-1. Build your project (this will create a `dist` or `build` folder):
-
-```bash
-npm run build
-# or
-yarn build
-# or
-pnpm build
-```
-
-2. Deploy to Ufazien:
-
-```bash
-ufazien deploy
-```
-
-The deployment will automatically upload the contents of your build folder.
+API calls always go through a service in `src/services/`, which uses the
+shared `apiClient` in `src/api/client.ts` (`withCredentials: true` for cookie
+sessions — don't create new axios instances). Routing is workspace-scoped
+(`/:workspaceSlug/...`). See the repo-root `CLAUDE.md` for the full frontend
+architecture overview and `CONTRIBUTING.md` for commit/PR conventions.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",


### PR DESCRIPTION
## Summary
Cleans up the repo's public-facing docs and metadata, which had leftover template/placeholder content that makes the project look unfinished to new contributors and self-hosters.

Fixes #131

## What changed
- **`SECURITY.md`**: replaced the raw GitHub template (fake `5.1.x`/`4.0.x` version table, placeholder instructions) with real content — only the latest commit on `main` is supported, and vulnerabilities should be reported via GitHub's private vulnerability reporting (Security tab → "Report a vulnerability") rather than a fabricated email address (there wasn't one anywhere in the repo, so I didn't invent one).
- **`apps/api/README.md`**: was a single line (`# Devlane API`). Now documents what it is, prerequisites, local setup (env vars, `docker compose up -d`, `go run ./cmd/api`, auto-run migrations), the env vars that actually exist in `internal/config/config.go`, key commands, migration conventions, and links to the root `CLAUDE.md`/`CONTRIBUTING.md` instead of duplicating them.
- **`apps/web/README.md`**: was still the default `create-vite` template (plus a stray, irrelevant "Ufazien Deployment" section from some project generator). Replaced with real content: what it is, prerequisites, local setup, the actual env var (`VITE_API_BASE_URL`), the real `npm run` commands from `package.json`, and frontend conventions.
- **`package.json`**: `"license": "ISC"` → `"license": "SEE LICENSE IN LICENSE"` — the repo's actual `LICENSE` is a custom MIT-plus-non-commercial-hosting-restriction license that explicitly isn't OSI-approved open source, so `"ISC"` was factually wrong. `"SEE LICENSE IN LICENSE"` is the correct, recognized value for a non-standard license pointing at the `LICENSE` file.
- **`CONTRIBUTING.md`**: left untouched — I checked it against the issue's claim ("only contains a heading") and it's already fully written (repo layout, local dev, branching, commit conventions, AI-disclosure policy, migrations, bug reporting). The issue was filed before/without noticing this was already fixed.

No code or behavior changes — pure documentation per the issue's "Refactor (no behavior change)" classification.

## Test plan
- [x] `npm run validate` (web typecheck + lint + prettier check, `go vet` + `go test`) passes
- [x] Every command/env-var/file-path mentioned in the new docs was cross-checked against the actual code (`internal/config/config.go`, `package.json` scripts, `docker-compose.yml`) rather than guessed
- [x] Reviewed with `/code-review` (high effort) — found and fixed one real inaccuracy (an early draft claimed the Vite dev server "proxies" API calls; there's no such proxy configured — corrected to describe the actual direct cross-origin request + CORS behavior)

## AI assistance
This change was implemented with Claude Code (Sonnet 5), which audited the actual current state of each file the issue named, wrote the replacement docs, verified every factual claim against the real code/config, and caught one inaccuracy via code review before this PR was opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the API and web app README files with clearer setup, environment, command, and project workflow guidance.
  * Added more detailed local development notes, including startup steps and common troubleshooting behavior.

* **Security**
  * Updated security guidance to direct vulnerability reports through private reporting and outline the review process.

* **Chores**
  * Updated the project license reference in package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->