### PR TITLE
fix(api): make readiness probe check database health

### DIFF
--- a/apps/api/internal/handler/health.go
+++ b/apps/api/internal/handler/health.go
@@ -1,10 +1,17 @@
 package handler
 
 import (
+	"context"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
+
+// readinessPingTimeout bounds the DB ping so a hung connection can't block
+// the probe indefinitely regardless of the caller's own context deadline.
+const readinessPingTimeout = 3 * time.Second
 
 // Health is the liveness probe.
 // GET /health
@@ -12,8 +19,22 @@ func Health(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
-// Readiness is the readiness probe.
+// NewReadinessHandler returns the readiness probe. It pings the database (the
+// one hard dependency) and returns 503 if it's unreachable, so an
+// orchestrator holds the instance out of rotation instead of routing traffic
+// to it. Optional infra (Redis/RabbitMQ/MinIO) is intentionally excluded per
+// the graceful-degradation convention.
 // GET /ready
-func Readiness(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"status": "ready"})
+func NewReadinessHandler(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), readinessPingTimeout)
+		defer cancel()
+
+		sqlDB, err := db.DB()
+		if err != nil || sqlDB.PingContext(ctx) != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "ready"})
+	}
 }

--- a/apps/api/internal/handler/health_test.go
+++ b/apps/api/internal/handler/health_test.go
@@ -2,11 +2,15 @@ package handler_test
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/Devlaner/devlane/api/internal/handler"
 	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestHealth(t *testing.T) {
@@ -25,6 +29,33 @@ func TestReadiness(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
 	body := testutil.MustJSONMap(t, rr)
 	assert.Equal(t, "ready", body["status"])
+}
+
+// unusableConnPool implements gorm.ConnPool but is not a *sql.DB, *sql.Tx, or
+// gorm.GetDBConnector, so gorm.DB.DB() cannot extract a usable connection
+// from it — exactly what happens when the underlying database connection is
+// unusable. See gorm.io/gorm@.../gorm.go's DB() method.
+type unusableConnPool struct{ gorm.ConnPool }
+
+// TestReadiness_DBUnreachable exercises the readiness handler directly
+// against a *gorm.DB whose connection cannot be resolved to a real *sql.DB
+// (rather than against the shared test container, which other tests in this
+// package depend on staying up), proving the handler's db.DB() error branch
+// returns 503 instead of the previous unconditional 200.
+func TestReadiness_DBUnreachable(t *testing.T) {
+	gdb := &gorm.DB{Config: &gorm.Config{ConnPool: unusableConnPool{}}}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/ready", handler.NewReadinessHandler(gdb))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code, "body=%s", rr.Body.String())
+	body := testutil.MustJSONMap(t, rr)
+	assert.Equal(t, "not_ready", body["status"])
 }
 
 func TestUnknownRouteReturns404(t *testing.T) {

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -56,7 +56,7 @@ func New(cfg Config) *gin.Engine {
 
 	// Health (no auth)
 	r.GET("/health", handler.Health)
-	r.GET("/ready", handler.Readiness)
+	r.GET("/ready", handler.NewReadinessHandler(cfg.DB))
 
 	// Stores
 	userStore := store.NewUserStore(cfg.DB)


### PR DESCRIPTION
## Summary
`/ready` returned an unconditional `200 {"status":"ready"}` regardless of database health, making it indistinguishable from `/health` (the liveness probe). An orchestrator relying on `/ready` would keep routing traffic to an instance whose Postgres connection is down, producing user-facing 500s instead of holding the instance out of rotation.

Fixes #145

## What changed
- `apps/api/internal/handler/health.go`: `Readiness` (plain function, always 200) replaced with `NewReadinessHandler(db *gorm.DB) gin.HandlerFunc`, which pings the database via `db.DB()` + `PingContext` (bounded by a 3s server-side timeout so a hung connection can't block the probe indefinitely regardless of the caller's own context) and returns `503 {"status":"not_ready"}` on failure.
- `apps/api/internal/router/router.go`: wires the DB-backed handler in place of the old stateless one.
- Optional infra (Redis/RabbitMQ/MinIO) is intentionally **not** checked, per this repo's graceful-degradation convention — only the one hard dependency.

## Test plan
- [x] `go vet ./... && go test ./...` — full suite passes
- [x] New `TestReadiness_DBUnreachable`: exercises the handler directly against a `*gorm.DB` whose `ConnPool` can't be resolved to a real `*sql.DB` (a `db.DB()` failure), asserting 503 — deliberately avoids touching the shared test-container DB that other tests in the package depend on staying up
- [x] Existing `TestReadiness` (real Postgres testcontainer) still asserts 200 on the happy path
- [x] **Live end-to-end**: ran `docker compose up -d` + `go run ./cmd/api`, confirmed `/ready` returns 200 while Postgres is up, then `docker compose stop postgres` → `/ready` returned `503 {"status":"not_ready"}` immediately, then `docker compose start postgres` → `/ready` recovered to 200 within seconds. Reproduced the actual bug and confirmed the fix closes it, not just at the test level.
- [x] Reviewed with `/code-review` (high effort): 2 findings surfaced — (1) missing server-side timeout on the ping, which I fixed (3s bound, independent of the caller's own context); (2) the handler calls GORM directly rather than going through a service/store layer, which I judged a reasonable, narrow exception given there's no business logic to layer for a pure connectivity check and no existing precedent for infra-health helpers elsewhere in the repo — noting it here for visibility rather than adding a layer with nothing to do.

## AI assistance
Implemented with Claude Code (Sonnet 5), which reproduced the actual bug against a live local instance (stopped/started Postgres and observed the probe's response) before and after the fix, not just relying on unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The readiness endpoint now checks database connectivity before reporting the service as ready.
  * If the database cannot be reached, `/ready` returns `503` with `not_ready` instead of a success response.
  * Added test coverage for the database-unavailable readiness case.

* **Refactor**
  * Updated the readiness check wiring to use the application’s configured database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->