### PR TITLE
ci: add root-ci workflow to close root-only-PR blind spot

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -12,12 +12,17 @@ on:
       - '.husky/**'
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: node --check commitlint.config.cjs
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -1,0 +1,39 @@
+name: Root CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker-compose.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'commitlint.config.cjs'
+      - 'lint-staged.config.mjs'
+      - '.husky/**'
+      - '.github/workflows/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Validate docker-compose.yml
+        run: docker compose config --quiet
+
+      - name: Check lint-staged.config.mjs syntax
+        run: node --check lint-staged.config.mjs
+
+      - name: Check commitlint.config.cjs syntax
+        run: node --check commitlint.config.cjs
+
+      - name: Install root dependencies
+        run: npm ci


### PR DESCRIPTION
## Summary
`api-ci.yml` and `ui-ci.yml` are path-filtered to `apps/api/**` and `apps/web/**` respectively. A PR that only touches root-level files — `docker-compose.yml`, root `package.json`/`package-lock.json`, `commitlint.config.cjs`, `lint-staged.config.mjs`, `.husky/**`, or any other `.github/workflows/*.yml` — triggers **zero** checks and merges with an empty/green status. GitHub's default CodeQL scanning (the `Analyze (*)` checks visible on every PR) doesn't cover this either — that's security pattern scanning, not functional/syntax validation.

Fixes #148

## What changed
Added `.github/workflows/root-ci.yml`, triggered on `pull_request` with paths covering exactly the root files not already covered by the other two workflows (plus `.github/workflows/**` broadly, so any workflow-file edit gets validated by something). Steps, kept intentionally minimal per the issue's "at minimum validates the compose/config files":
- `docker compose config --quiet` — validates `docker-compose.yml` parses/resolves
- `node --check lint-staged.config.mjs` / `node --check commitlint.config.cjs` — syntax-only checks (no execution/side effects)
- `npm ci` — validates root `package.json`/`package-lock.json` are consistent and installable

Deliberately not duplicating `api-ci`/`ui-ci`'s full `npm run validate` here — this workflow's job is only to close the root-file blind spot, not re-run existing coverage.

## Test plan
- [x] Ran all four checks locally before pushing: `docker compose config --quiet`, both `node --check` calls, and `npm ci --dry-run` — all pass
- [x] Will confirm on this PR itself that `root-ci` actually triggers (it touches `.github/workflows/root-ci.yml`, matching its own path filter) and passes for real

## AI assistance
Implemented with Claude Code (Sonnet 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI check for pull requests that validates key root-level project configuration and dependency setup.
  * The workflow runs Node.js 22, confirms Docker Compose config is valid, syntax-checks lint/commit message scripts, and installs dependencies using cached npm for faster runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->