### PR TITLE
fix(pages): render bullet and number markers in the page editor

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -159,6 +159,19 @@
   padding-left: 1.5rem;
   margin: 0.5rem 0;
 }
+.page-editor-prose ul {
+  list-style: disc outside;
+}
+.page-editor-prose ol {
+  list-style: decimal outside;
+}
+.page-editor-prose ul ul {
+  list-style-type: circle;
+}
+.page-editor-prose ul ul ul {
+  list-style-type: square;
+}
+/* Task lists render their own checkboxes, so they must not show a marker. */
 .page-editor-prose ul[data-type='taskList'] {
   list-style: none;
   padding-left: 0.25rem;


### PR DESCRIPTION
## What

Fixes #247. Ordered and unordered lists in Pages rendered without their bullets or numbers.

## Why

Tailwind's preflight resets `ul`/`ol` to `list-style: none`. The page editor's list rule only restored padding and margin, so nothing ever brought the markers back. The `prose` classes on the editor container are no-ops here because `@tailwindcss/typography` is not installed in this app, so they were not filling the gap either.

## How

Restore `list-style` on `.page-editor-prose ul` (disc) and `ol` (decimal), and vary the marker for nested bullet levels (circle, then square). Task lists keep their existing `list-style: none` since they render their own checkboxes, and that rule has higher specificity so it still wins.

CSS-only change, scoped to the page editor.

## Testing

Created a page and added a bullet list and an ordered list in the editor. Before the change the computed `list-style-type` was `none` on both; after, it is `disc` on the `ul` and `decimal` on the `ol`, and the markers render:

- Apples / Oranges show bullets
- First step / Second step show 1. and 2.

Verified in the browser with Playwright.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). AI-assisted commits carry a `Co-Authored-By` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance of nested lists in the editor so bullets and numbers display consistently at deeper levels.
  * Task lists now render without default list markers, keeping checkboxes visually clean and easier to read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->