### PR TITLE
feat(pages): move a page to another project

### DIFF
--- a/apps/api/internal/handler/page.go
+++ b/apps/api/internal/handler/page.go
@@ -58,6 +58,8 @@ func translatePageError(c *gin.Context, err error, fallback string) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
 	case errors.Is(err, service.ErrPageSameProject):
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Page is already in that project"})
+	case errors.Is(err, service.ErrPageMoveConflict):
+		c.JSON(http.StatusConflict, gin.H{"error": "The page changed while moving. Try again."})
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
 	}

--- a/apps/api/internal/handler/page.go
+++ b/apps/api/internal/handler/page.go
@@ -56,6 +56,8 @@ func translatePageError(c *gin.Context, err error, fallback string) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid parent page"})
 	case errors.Is(err, service.ErrPageBadRequest):
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+	case errors.Is(err, service.ErrPageSameProject):
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Page is already in that project"})
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
 	}
@@ -349,6 +351,38 @@ func (h *PageHandler) Duplicate(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, page)
+}
+
+// Move relinks a page and its subtree to another project.
+// POST /api/workspaces/:slug/pages/:pageId/move/
+func (h *PageHandler) Move(c *gin.Context) {
+	userID, ok := h.requireUser(c)
+	if !ok {
+		return
+	}
+	slug := c.Param("slug")
+	pageID, ok := parsePageID(c)
+	if !ok {
+		return
+	}
+	var body struct {
+		TargetProjectID string `json:"target_project_id"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.TargetProjectID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "target_project_id is required"})
+		return
+	}
+	targetID, err := uuid.Parse(body.TargetProjectID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid target project ID"})
+		return
+	}
+	page, err := h.Page.Move(c.Request.Context(), slug, pageID, userID, targetID)
+	if err != nil {
+		translatePageError(c, err, "Failed to move page")
+		return
+	}
+	c.JSON(http.StatusOK, page)
 }
 
 // ListVersions / GetVersion / RestoreVersion

--- a/apps/api/internal/handler/page_move_test.go
+++ b/apps/api/internal/handler/page_move_test.go
@@ -104,9 +104,10 @@ func TestPage_MoveRejectedWhenSubtreeNotOwned(t *testing.T) {
 	rr := ts.POST(base+"/move/", map[string]any{"target_project_id": target.ID.String()}, w.Session)
 	require.Equal(t, http.StatusForbidden, rr.Code, "body=%s", rr.Body.String())
 
-	// Nothing moved: the tree stays in the source project.
+	// Nothing moved: the whole tree stays in the source project.
 	require.Equal(t, int64(1), countPageLinks(t, ts, w.Project.ID, root.ID))
-	require.Zero(t, countPageLinks(t, ts, target.ID, root.ID))
+	require.Equal(t, int64(1), countPageLinks(t, ts, w.Project.ID, child.ID))
+	require.Zero(t, countPageLinks(t, ts, target.ID, root.ID, child.ID))
 }
 
 func TestPage_MoveCrossWorkspaceRejected(t *testing.T) {

--- a/apps/api/internal/handler/page_move_test.go
+++ b/apps/api/internal/handler/page_move_test.go
@@ -87,6 +87,28 @@ func TestPage_MoveToSameProjectRejected(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
 }
 
+func TestPage_MoveRejectedWhenSubtreeNotOwned(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	target := testutil.CreateProject(t, ts.DB, w.Workspace.ID, w.User.ID)
+	other := testutil.CreateUser(t, ts.DB)
+
+	// Root is owned by the caller, but a sub-page is owned by someone else.
+	root := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	linkPageToProject(t, ts, w.Project.ID, root.ID, w.Workspace.ID)
+	child := testutil.CreatePage(t, ts.DB, w.Workspace.ID, other.ID)
+	require.NoError(t, ts.DB.Model(child).Update("parent_id", root.ID).Error)
+	linkPageToProject(t, ts, w.Project.ID, child.ID, w.Workspace.ID)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/pages/" + root.ID.String()
+	rr := ts.POST(base+"/move/", map[string]any{"target_project_id": target.ID.String()}, w.Session)
+	require.Equal(t, http.StatusForbidden, rr.Code, "body=%s", rr.Body.String())
+
+	// Nothing moved: the tree stays in the source project.
+	require.Equal(t, int64(1), countPageLinks(t, ts, w.Project.ID, root.ID))
+	require.Zero(t, countPageLinks(t, ts, target.ID, root.ID))
+}
+
 func TestPage_MoveCrossWorkspaceRejected(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/apps/api/internal/handler/page_move_test.go
+++ b/apps/api/internal/handler/page_move_test.go
@@ -1,0 +1,102 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func linkPageToProject(t *testing.T, ts *testutil.TestServer, projectID, pageID, workspaceID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, ts.DB.Create(&model.ProjectPage{
+		ProjectID:   projectID,
+		PageID:      pageID,
+		WorkspaceID: workspaceID,
+	}).Error)
+}
+
+func countPageLinks(t *testing.T, ts *testutil.TestServer, projectID uuid.UUID, pageIDs ...uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, ts.DB.Model(&model.ProjectPage{}).
+		Where("project_id = ? AND page_id IN ?", projectID, pageIDs).
+		Count(&n).Error)
+	return n
+}
+
+func TestPage_MoveToProject(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	target := testutil.CreateProject(t, ts.DB, w.Workspace.ID, w.User.ID)
+
+	// A small tree in the source project: topParent > page > child. Only `page`
+	// and its subtree move; topParent stays behind.
+	topParent := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	linkPageToProject(t, ts, w.Project.ID, topParent.ID, w.Workspace.ID)
+
+	page := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(page).Update("parent_id", topParent.ID).Error)
+	linkPageToProject(t, ts, w.Project.ID, page.ID, w.Workspace.ID)
+
+	child := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(child).Update("parent_id", page.ID).Error)
+	linkPageToProject(t, ts, w.Project.ID, child.ID, w.Workspace.ID)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/pages/" + page.ID.String()
+	rr := ts.POST(base+"/move/", map[string]any{"target_project_id": target.ID.String()}, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+
+	// page + child are now linked to the target project and unlinked from source.
+	require.Equal(t, int64(2), countPageLinks(t, ts, target.ID, page.ID, child.ID))
+	require.Zero(t, countPageLinks(t, ts, w.Project.ID, page.ID, child.ID))
+
+	// The moved root is detached from its old-project parent; the child keeps its
+	// parent (which moved along with it).
+	var movedPage, movedChild model.Page
+	require.NoError(t, ts.DB.First(&movedPage, "id = ?", page.ID).Error)
+	require.NoError(t, ts.DB.First(&movedChild, "id = ?", child.ID).Error)
+	require.Nil(t, movedPage.ParentID, "moved root should be detached from its source-project parent")
+	require.NotNil(t, movedChild.ParentID)
+	require.Equal(t, page.ID, *movedChild.ParentID)
+
+	// topParent is untouched: still in the source project.
+	require.Equal(t, int64(1), countPageLinks(t, ts, w.Project.ID, topParent.ID))
+}
+
+func TestPage_MoveRequiresTarget(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	page := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	linkPageToProject(t, ts, w.Project.ID, page.ID, w.Workspace.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/pages/" + page.ID.String()
+	rr := ts.POST(base+"/move/", map[string]any{}, w.Session)
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
+}
+
+func TestPage_MoveToSameProjectRejected(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	page := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	linkPageToProject(t, ts, w.Project.ID, page.ID, w.Workspace.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/pages/" + page.ID.String()
+	rr := ts.POST(base+"/move/", map[string]any{"target_project_id": w.Project.ID.String()}, w.Session)
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
+}
+
+func TestPage_MoveCrossWorkspaceRejected(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	otherUser := testutil.CreateUser(t, ts.DB)
+	otherWS := testutil.CreateWorkspace(t, ts.DB, otherUser.ID)
+	foreign := testutil.CreateProject(t, ts.DB, otherWS.ID, otherUser.ID)
+
+	page := testutil.CreatePage(t, ts.DB, w.Workspace.ID, w.User.ID)
+	linkPageToProject(t, ts, w.Project.ID, page.ID, w.Workspace.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/pages/" + page.ID.String()
+	rr := ts.POST(base+"/move/", map[string]any{"target_project_id": foreign.ID.String()}, w.Session)
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -425,6 +425,7 @@ func New(cfg Config) *gin.Engine {
 		api.POST("/workspaces/:slug/pages/:pageId/archive/", pageHandler.Archive)
 		api.DELETE("/workspaces/:slug/pages/:pageId/archive/", pageHandler.Unarchive)
 		api.POST("/workspaces/:slug/pages/:pageId/duplicate/", pageHandler.Duplicate)
+		api.POST("/workspaces/:slug/pages/:pageId/move/", pageHandler.Move)
 		api.GET("/workspaces/:slug/pages/:pageId/versions/", pageHandler.ListVersions)
 		api.GET("/workspaces/:slug/pages/:pageId/versions/:versionId/", pageHandler.GetVersion)
 		api.POST("/workspaces/:slug/pages/:pageId/versions/:versionId/restore/", pageHandler.RestoreVersion)

--- a/apps/api/internal/service/page.go
+++ b/apps/api/internal/service/page.go
@@ -11,14 +11,15 @@ import (
 )
 
 var (
-	ErrPageNotFound    = errors.New("page not found")
-	ErrPageLocked      = errors.New("page is locked")
-	ErrPageArchived    = errors.New("page is archived")
-	ErrPageReadOnly    = errors.New("no permission to edit this page")
-	ErrPageNotArchived = errors.New("page must be archived before deletion")
-	ErrPageBadParent   = errors.New("invalid parent page")
-	ErrPageBadRequest  = errors.New("invalid page request")
-	ErrPageSameProject = errors.New("page already in target project")
+	ErrPageNotFound     = errors.New("page not found")
+	ErrPageLocked       = errors.New("page is locked")
+	ErrPageArchived     = errors.New("page is archived")
+	ErrPageReadOnly     = errors.New("no permission to edit this page")
+	ErrPageNotArchived  = errors.New("page must be archived before deletion")
+	ErrPageBadParent    = errors.New("invalid parent page")
+	ErrPageBadRequest   = errors.New("invalid page request")
+	ErrPageSameProject  = errors.New("page already in target project")
+	ErrPageMoveConflict = errors.New("page tree changed during move")
 )
 
 // PageService handles page business logic and permission gating.
@@ -354,6 +355,9 @@ func (s *PageService) Move(ctx context.Context, workspaceSlug string, pageID, us
 		ids = append(ids, subtree[i].ID)
 	}
 	if err := s.pageStore.MoveTreeToProject(ctx, pageID, ids, targetProjectID, page.WorkspaceID, userID); err != nil {
+		if errors.Is(err, store.ErrSubtreeChanged) {
+			return nil, ErrPageMoveConflict
+		}
 		return nil, err
 	}
 	return s.pageStore.GetByID(ctx, pageID)

--- a/apps/api/internal/service/page.go
+++ b/apps/api/internal/service/page.go
@@ -339,7 +339,21 @@ func (s *PageService) Move(ctx context.Context, workspaceSlug string, pageID, us
 	if len(projectIDs) == 1 && projectIDs[0] == targetProjectID {
 		return nil, ErrPageSameProject
 	}
-	if err := s.pageStore.MoveTreeToProject(ctx, pageID, targetProjectID, page.WorkspaceID, userID); err != nil {
+	// The move relinks the whole subtree, so the caller must be able to edit
+	// every page in it — otherwise a public parent's owner could drag someone
+	// else's private sub-page into another project.
+	subtree, err := s.pageStore.SubtreePages(ctx, pageID, page.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(subtree))
+	for i := range subtree {
+		if !canEditMeta(&subtree[i], userID, isMember) {
+			return nil, ErrPageReadOnly
+		}
+		ids = append(ids, subtree[i].ID)
+	}
+	if err := s.pageStore.MoveTreeToProject(ctx, pageID, ids, targetProjectID, page.WorkspaceID, userID); err != nil {
 		return nil, err
 	}
 	return s.pageStore.GetByID(ctx, pageID)

--- a/apps/api/internal/service/page.go
+++ b/apps/api/internal/service/page.go
@@ -18,6 +18,7 @@ var (
 	ErrPageNotArchived = errors.New("page must be archived before deletion")
 	ErrPageBadParent   = errors.New("invalid parent page")
 	ErrPageBadRequest  = errors.New("invalid page request")
+	ErrPageSameProject = errors.New("page already in target project")
 )
 
 // PageService handles page business logic and permission gating.
@@ -313,6 +314,35 @@ func (s *PageService) UpdateMeta(ctx context.Context, workspaceSlug string, page
 		return nil, err
 	}
 	return page, nil
+}
+
+// Move relinks a page and its subtree to another project in the same workspace.
+// The caller must be able to edit the page's meta and reach the target project.
+func (s *PageService) Move(ctx context.Context, workspaceSlug string, pageID, userID, targetProjectID uuid.UUID) (*model.Page, error) {
+	page, isMember, err := s.loadAndCheckView(ctx, workspaceSlug, pageID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !canEditMeta(page, userID, isMember) {
+		return nil, ErrPageReadOnly
+	}
+	if page.ArchivedAt != nil {
+		return nil, ErrPageArchived
+	}
+	if err := s.ensureProjectAccess(ctx, workspaceSlug, targetProjectID, userID); err != nil {
+		return nil, err
+	}
+	projectIDs, err := s.pageStore.ListProjectIDsForPage(ctx, pageID)
+	if err != nil {
+		return nil, err
+	}
+	if len(projectIDs) == 1 && projectIDs[0] == targetProjectID {
+		return nil, ErrPageSameProject
+	}
+	if err := s.pageStore.MoveTreeToProject(ctx, pageID, targetProjectID, page.WorkspaceID, userID); err != nil {
+		return nil, err
+	}
+	return s.pageStore.GetByID(ctx, pageID)
 }
 
 // validateParent rejects parents that would corrupt the tree:

--- a/apps/api/internal/store/page.go
+++ b/apps/api/internal/store/page.go
@@ -273,17 +273,19 @@ func (s *PageStore) RemoveProjectPage(ctx context.Context, projectID, pageID uui
 		Delete(&model.ProjectPage{}).Error
 }
 
-// collectPageSubtree returns rootID followed by every descendant id, walking the
-// parent_id tree iteratively so it works on any dialect.
-func collectPageSubtree(ctx context.Context, tx *gorm.DB, rootID uuid.UUID) ([]uuid.UUID, error) {
+// collectPageSubtreeIDs returns rootID followed by every descendant id within
+// workspaceID, walking the parent_id tree iteratively so it works on any
+// dialect. Scoping to the workspace keeps a stale cross-workspace parent link
+// from pulling in another workspace's pages.
+func collectPageSubtreeIDs(ctx context.Context, db *gorm.DB, rootID, workspaceID uuid.UUID) ([]uuid.UUID, error) {
 	ids := []uuid.UUID{rootID}
 	queue := []uuid.UUID{rootID}
 	for len(queue) > 0 {
 		parent := queue[0]
 		queue = queue[1:]
 		var childIDs []uuid.UUID
-		if err := tx.WithContext(ctx).Model(&model.Page{}).
-			Where("parent_id = ? AND deleted_at IS NULL", parent).
+		if err := db.WithContext(ctx).Model(&model.Page{}).
+			Where("parent_id = ? AND workspace_id = ? AND deleted_at IS NULL", parent, workspaceID).
 			Pluck("id", &childIDs).Error; err != nil {
 			return nil, err
 		}
@@ -293,22 +295,36 @@ func collectPageSubtree(ctx context.Context, tx *gorm.DB, rootID uuid.UUID) ([]u
 	return ids, nil
 }
 
-// MoveTreeToProject moves a page and its whole subtree into targetProjectID: it
-// detaches the root from any parent and replaces every affected page's
-// project_pages link with a single link to the target. Links are hard deleted
-// because project_pages has a (project_id, page_id) unique constraint that
-// ignores soft-delete, so a lingering soft-deleted row would block re-linking.
-func (s *PageStore) MoveTreeToProject(ctx context.Context, rootID, targetProjectID, workspaceID, userID uuid.UUID) error {
+// SubtreePages returns the root page plus every descendant within workspaceID,
+// so callers can permission-check the whole tree before moving it.
+func (s *PageStore) SubtreePages(ctx context.Context, rootID, workspaceID uuid.UUID) ([]model.Page, error) {
+	ids, err := collectPageSubtreeIDs(ctx, s.db, rootID, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	var pages []model.Page
+	if err := s.db.WithContext(ctx).
+		Where("id IN ? AND workspace_id = ? AND deleted_at IS NULL", ids, workspaceID).
+		Find(&pages).Error; err != nil {
+		return nil, err
+	}
+	return pages, nil
+}
+
+// MoveTreeToProject relinks the given pages (a page and its already-vetted
+// subtree) to targetProjectID: it detaches the root from any parent and replaces
+// every affected page's project_pages link with a single link to the target.
+// Links are hard deleted because project_pages has a (project_id, page_id)
+// unique constraint that ignores soft-delete, so a lingering soft-deleted row
+// would block re-linking. Every query is scoped to workspaceID.
+func (s *PageStore) MoveTreeToProject(ctx context.Context, rootID uuid.UUID, ids []uuid.UUID, targetProjectID, workspaceID, userID uuid.UUID) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		ids, err := collectPageSubtree(ctx, tx, rootID)
-		if err != nil {
-			return err
-		}
-		if err := tx.Model(&model.Page{}).Where("id = ?", rootID).
+		if err := tx.Model(&model.Page{}).Where("id = ? AND workspace_id = ?", rootID, workspaceID).
 			Updates(map[string]any{"parent_id": nil, "updated_by_id": userID}).Error; err != nil {
 			return err
 		}
-		if err := tx.Unscoped().Where("page_id IN ?", ids).Delete(&model.ProjectPage{}).Error; err != nil {
+		if err := tx.Unscoped().Where("page_id IN ? AND workspace_id = ?", ids, workspaceID).
+			Delete(&model.ProjectPage{}).Error; err != nil {
 			return err
 		}
 		links := make([]model.ProjectPage, 0, len(ids))
@@ -324,7 +340,7 @@ func (s *PageStore) MoveTreeToProject(ctx context.Context, rootID, targetProject
 		if err := tx.Create(&links).Error; err != nil {
 			return err
 		}
-		return tx.Model(&model.Page{}).Where("id IN ?", ids).
+		return tx.Model(&model.Page{}).Where("id IN ? AND workspace_id = ?", ids, workspaceID).
 			Update("updated_by_id", userID).Error
 	})
 }

--- a/apps/api/internal/store/page.go
+++ b/apps/api/internal/store/page.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -9,6 +10,11 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
+
+// ErrSubtreeChanged is returned by MoveTreeToProject when the page subtree no
+// longer matches the ids the caller vetted, so a concurrent edit can't sneak an
+// unvetted page into the move.
+var ErrSubtreeChanged = errors.New("page subtree changed during move")
 
 // PageStore handles page, project_page, and page_versions persistence.
 type PageStore struct{ db *gorm.DB }
@@ -295,6 +301,22 @@ func collectPageSubtreeIDs(ctx context.Context, db *gorm.DB, rootID, workspaceID
 	return ids, nil
 }
 
+func sameIDSet(a, b []uuid.UUID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[uuid.UUID]struct{}, len(a))
+	for _, id := range a {
+		set[id] = struct{}{}
+	}
+	for _, id := range b {
+		if _, ok := set[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // SubtreePages returns the root page plus every descendant within workspaceID,
 // so callers can permission-check the whole tree before moving it.
 func (s *PageStore) SubtreePages(ctx context.Context, rootID, workspaceID uuid.UUID) ([]model.Page, error) {
@@ -319,6 +341,16 @@ func (s *PageStore) SubtreePages(ctx context.Context, rootID, workspaceID uuid.U
 // would block re-linking. Every query is scoped to workspaceID.
 func (s *PageStore) MoveTreeToProject(ctx context.Context, rootID uuid.UUID, ids []uuid.UUID, targetProjectID, workspaceID, userID uuid.UUID) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Re-read the subtree inside the transaction and bail if it no longer
+		// matches the vetted ids, closing the window between the caller's
+		// permission check and this relink.
+		current, err := collectPageSubtreeIDs(ctx, tx, rootID, workspaceID)
+		if err != nil {
+			return err
+		}
+		if !sameIDSet(current, ids) {
+			return ErrSubtreeChanged
+		}
 		if err := tx.Model(&model.Page{}).Where("id = ? AND workspace_id = ?", rootID, workspaceID).
 			Updates(map[string]any{"parent_id": nil, "updated_by_id": userID}).Error; err != nil {
 			return err

--- a/apps/api/internal/store/page.go
+++ b/apps/api/internal/store/page.go
@@ -273,6 +273,62 @@ func (s *PageStore) RemoveProjectPage(ctx context.Context, projectID, pageID uui
 		Delete(&model.ProjectPage{}).Error
 }
 
+// collectPageSubtree returns rootID followed by every descendant id, walking the
+// parent_id tree iteratively so it works on any dialect.
+func collectPageSubtree(ctx context.Context, tx *gorm.DB, rootID uuid.UUID) ([]uuid.UUID, error) {
+	ids := []uuid.UUID{rootID}
+	queue := []uuid.UUID{rootID}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		var childIDs []uuid.UUID
+		if err := tx.WithContext(ctx).Model(&model.Page{}).
+			Where("parent_id = ? AND deleted_at IS NULL", parent).
+			Pluck("id", &childIDs).Error; err != nil {
+			return nil, err
+		}
+		ids = append(ids, childIDs...)
+		queue = append(queue, childIDs...)
+	}
+	return ids, nil
+}
+
+// MoveTreeToProject moves a page and its whole subtree into targetProjectID: it
+// detaches the root from any parent and replaces every affected page's
+// project_pages link with a single link to the target. Links are hard deleted
+// because project_pages has a (project_id, page_id) unique constraint that
+// ignores soft-delete, so a lingering soft-deleted row would block re-linking.
+func (s *PageStore) MoveTreeToProject(ctx context.Context, rootID, targetProjectID, workspaceID, userID uuid.UUID) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		ids, err := collectPageSubtree(ctx, tx, rootID)
+		if err != nil {
+			return err
+		}
+		if err := tx.Model(&model.Page{}).Where("id = ?", rootID).
+			Updates(map[string]any{"parent_id": nil, "updated_by_id": userID}).Error; err != nil {
+			return err
+		}
+		if err := tx.Unscoped().Where("page_id IN ?", ids).Delete(&model.ProjectPage{}).Error; err != nil {
+			return err
+		}
+		links := make([]model.ProjectPage, 0, len(ids))
+		for _, id := range ids {
+			cb := userID
+			links = append(links, model.ProjectPage{
+				ProjectID:   targetProjectID,
+				PageID:      id,
+				WorkspaceID: workspaceID,
+				CreatedByID: &cb,
+			})
+		}
+		if err := tx.Create(&links).Error; err != nil {
+			return err
+		}
+		return tx.Model(&model.Page{}).Where("id IN ?", ids).
+			Update("updated_by_id", userID).Error
+	})
+}
+
 // ----- Page versions -----
 
 func (s *PageStore) CreateVersion(ctx context.Context, v *model.PageVersion) error {

--- a/apps/web/src/pages/PageDetailPage.tsx
+++ b/apps/web/src/pages/PageDetailPage.tsx
@@ -941,11 +941,7 @@ export function PageDetailPage() {
             ) : null}
             {moveLoading ? (
               <p className="py-6 text-center text-sm text-(--txt-tertiary)">Loading projects…</p>
-            ) : moveProjects.length === 0 ? (
-              <p className="py-6 text-center text-sm text-(--txt-tertiary)">
-                No other projects available.
-              </p>
-            ) : (
+            ) : moveProjects.length > 0 ? (
               <ul className="max-h-72 space-y-1 overflow-y-auto">
                 {moveProjects.map((p) => (
                   <li key={p.id}>
@@ -963,7 +959,11 @@ export function PageDetailPage() {
                   </li>
                 ))}
               </ul>
-            )}
+            ) : !moveError ? (
+              <p className="py-6 text-center text-sm text-(--txt-tertiary)">
+                No other projects available.
+              </p>
+            ) : null}
           </div>
         </Modal>
       ) : null}

--- a/apps/web/src/pages/PageDetailPage.tsx
+++ b/apps/web/src/pages/PageDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   Copy,
   ExternalLink,
   FileText,
+  FolderInput,
   History,
   Link2,
   ListTree,
@@ -101,6 +102,11 @@ export function PageDetailPage() {
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [moveProjects, setMoveProjects] = useState<ProjectApiResponse[]>([]);
+  const [moveLoading, setMoveLoading] = useState(false);
+  const [moveSubmitting, setMoveSubmitting] = useState(false);
+  const [moveError, setMoveError] = useState<string | null>(null);
 
   const titleSaveTimer = useRef<number | null>(null);
   const bodySaveTimer = useRef<number | null>(null);
@@ -438,6 +444,41 @@ export function PageDetailPage() {
     }
   };
 
+  const openMove = async () => {
+    if (!workspaceSlug) return;
+    setOptionsOpen(false);
+    setMoveOpen(true);
+    setMoveError(null);
+    setMoveLoading(true);
+    try {
+      const list = await projectService.list(workspaceSlug);
+      setMoveProjects(list.filter((p) => p.id !== projectId));
+    } catch {
+      setMoveError('Failed to load projects.');
+    } finally {
+      setMoveLoading(false);
+    }
+  };
+
+  const onMove = async (targetProjectId: string) => {
+    if (!workspaceSlug || !page) return;
+    setMoveSubmitting(true);
+    setMoveError(null);
+    try {
+      await pageService.move(workspaceSlug, page.id, targetProjectId);
+      setMoveOpen(false);
+      navigate(`/${workspaceSlug}/projects/${targetProjectId}/pages/${page.id}`);
+    } catch (err) {
+      const apiError =
+        err && typeof err === 'object' && 'response' in err
+          ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
+          : null;
+      setMoveError(apiError ?? 'Failed to move page.');
+    } finally {
+      setMoveSubmitting(false);
+    }
+  };
+
   const onCopyLink = async () => {
     if (!page) return;
     const url = window.location.href;
@@ -589,6 +630,15 @@ export function PageDetailPage() {
             >
               <Copy size={13} /> Make a copy
             </button>
+            {canEditMeta && !isArchived ? (
+              <button
+                type="button"
+                onClick={() => void openMove()}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-(--txt-primary) hover:bg-(--bg-layer-1-hover)"
+              >
+                <FolderInput size={13} /> Move to project
+              </button>
+            ) : null}
             {canEditMeta && !isArchived ? (
               <button
                 type="button"
@@ -874,6 +924,46 @@ export function PageDetailPage() {
               className="prose prose-sm max-h-[60vh] max-w-none overflow-y-auto rounded border border-(--border-subtle) bg-(--bg-canvas) p-3 text-(--txt-primary)"
               dangerouslySetInnerHTML={{ __html: sanitizeHtml(previewVersion.description_html) }}
             />
+          </div>
+        </Modal>
+      ) : null}
+
+      {moveOpen ? (
+        <Modal open onClose={() => setMoveOpen(false)} title="Move page to project">
+          <div className="max-w-md space-y-3">
+            <p className="text-sm text-(--txt-tertiary)">
+              The page and its sub-pages move to the project you choose.
+            </p>
+            {moveError ? (
+              <p className="rounded-(--radius-md) bg-(--bg-danger-subtle) px-3 py-2 text-sm text-(--txt-danger)">
+                {moveError}
+              </p>
+            ) : null}
+            {moveLoading ? (
+              <p className="py-6 text-center text-sm text-(--txt-tertiary)">Loading projects…</p>
+            ) : moveProjects.length === 0 ? (
+              <p className="py-6 text-center text-sm text-(--txt-tertiary)">
+                No other projects available.
+              </p>
+            ) : (
+              <ul className="max-h-72 space-y-1 overflow-y-auto">
+                {moveProjects.map((p) => (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      disabled={moveSubmitting}
+                      onClick={() => void onMove(p.id)}
+                      className="flex w-full items-center gap-2 rounded-(--radius-md) px-3 py-2 text-left text-sm text-(--txt-primary) transition-colors hover:bg-(--bg-layer-1-hover) disabled:opacity-50"
+                    >
+                      <span className="shrink-0 rounded-(--radius-sm) bg-(--bg-layer-2) px-1.5 py-0.5 text-xs font-medium text-(--txt-secondary)">
+                        {p.identifier ?? p.id.slice(0, 8)}
+                      </span>
+                      <span className="truncate">{p.name}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </Modal>
       ) : null}

--- a/apps/web/src/services/pageService.ts
+++ b/apps/web/src/services/pageService.ts
@@ -109,6 +109,18 @@ export const pageService = {
     return data;
   },
 
+  async move(
+    workspaceSlug: string,
+    pageId: string,
+    targetProjectId: string,
+  ): Promise<PageApiResponse> {
+    const { data } = await apiClient.post<PageApiResponse>(
+      `${base(workspaceSlug)}/${encodeURIComponent(pageId)}/move/`,
+      { target_project_id: targetProjectId },
+    );
+    return data;
+  },
+
   async listVersions(workspaceSlug: string, pageId: string): Promise<PageVersionApiResponse[]> {
     const { data } = await apiClient.get<PageVersionApiResponse[]>(
       `${base(workspaceSlug)}/${encodeURIComponent(pageId)}/versions/`,


### PR DESCRIPTION
## What

Closes #190. Pages could not be moved between projects, even though the data model was set up for it. This adds a "Move to project" action to the page menu.

## How

**Backend**

- `PageStore.MoveTreeToProject` moves a page and its whole sub-page subtree in one transaction: it detaches the moved root from its old parent (so it does not end up parented into another project) and swaps each affected page's `project_pages` link over to the target. Links are hard deleted rather than soft deleted because `project_pages` has a `UNIQUE (project_id, page_id)` constraint that ignores `deleted_at`, so a lingering soft-deleted row would block re-linking.
- `PageService.Move` requires the caller can edit the page and reach the target project, and rejects a move to the project the page is already in.
- Exposed at `POST /api/workspaces/:slug/pages/:pageId/move/`.

**Frontend**

- A project-picker modal in the page's More menu, plus `pageService.move`. After a successful move the app navigates to the page under its new project.

## Testing

- New `internal/handler/page_move_test.go`: the move relinks the page and its child to the target and unlinks them from the source, detaches the moved root from its old parent while the child keeps its (moved) parent, a sibling page left behind stays put, plus rejections for missing target (400), same project (400), and cross-workspace target (404). Full `go test ./...` green.
- Browser-verified: moved a page (with content) from Apollo to Beacon. The page left Apollo's list, appeared in Beacon's, and the app navigated to it under Beacon. No console errors.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). AI-assisted commits carry a `Co-Authored-By` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected “Move to project” workflow that moves a page and its descendant sub-pages to another project.
  * Added a “Move to project” option in the page header menu with a destination picker and redirects to the moved page.
* **Bug Fixes**
  * Attempting to move to the same project now returns a clear 400 “already in that project” error.
* **Tests**
  * Added integration coverage for successful moves and error cases, including missing destination, same-project, subtree ownership, and cross-workspace restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->