### PR TITLE
fix(comments): return correct status codes for comment reactions

### DIFF
--- a/apps/api/internal/handler/comment.go
+++ b/apps/api/internal/handler/comment.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
@@ -8,6 +9,14 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
+
+// commentAccessNotFound reports whether err is one of the access/lookup errors
+// that should surface as a 404 to the client.
+func commentAccessNotFound(err error) bool {
+	return errors.Is(err, service.ErrCommentNotFound) ||
+		errors.Is(err, service.ErrProjectForbidden) ||
+		errors.Is(err, service.ErrProjectNotFound)
+}
 
 // CommentHandler serves issue comments.
 type CommentHandler struct {
@@ -209,7 +218,14 @@ func (h *CommentHandler) AddReaction(c *gin.Context) {
 	}
 	r, err := h.Comment.AddReaction(c.Request.Context(), slug, projectID, commentID, user.ID, body.Reaction)
 	if err != nil {
-		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+		switch {
+		case errors.Is(err, service.ErrReactionExists):
+			c.JSON(http.StatusConflict, gin.H{"error": "Already reacted"})
+		case commentAccessNotFound(err):
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add reaction"})
+		}
 		return
 	}
 	c.JSON(http.StatusCreated, r)
@@ -240,6 +256,10 @@ func (h *CommentHandler) RemoveReaction(c *gin.Context) {
 		return
 	}
 	if err := h.Comment.RemoveReaction(c.Request.Context(), slug, projectID, commentID, user.ID, reaction); err != nil {
+		if commentAccessNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove reaction"})
 		return
 	}

--- a/apps/api/internal/handler/comment_reaction_test.go
+++ b/apps/api/internal/handler/comment_reaction_test.go
@@ -1,0 +1,55 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComment_AddReaction_StatusCodes(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	comment := testutil.CreateComment(t, ts.DB, issue.ID, w.Project.ID, w.Workspace.ID, w.User.ID)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() +
+		"/issues/" + issue.ID.String() + "/comments/" + comment.ID.String() + "/reactions/"
+
+	// First reaction succeeds.
+	rr := ts.POST(base, map[string]any{"reaction": "👍"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+
+	// Reacting again with the same emoji is a conflict, not a leaked 409-for-all.
+	rr2 := ts.POST(base, map[string]any{"reaction": "👍"}, w.Session)
+	require.Equal(t, http.StatusConflict, rr2.Code, "body=%s", rr2.Body.String())
+
+	// A missing comment is a 404, not a 409.
+	missing := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() +
+		"/issues/" + issue.ID.String() + "/comments/" + uuid.NewString() + "/reactions/"
+	rr3 := ts.POST(missing, map[string]any{"reaction": "👍"}, w.Session)
+	require.Equal(t, http.StatusNotFound, rr3.Code, "body=%s", rr3.Body.String())
+}
+
+func TestComment_RemoveReaction_StatusCodes(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	comment := testutil.CreateComment(t, ts.DB, issue.ID, w.Project.ID, w.Workspace.ID, w.User.ID)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() +
+		"/issues/" + issue.ID.String() + "/comments/" + comment.ID.String() + "/reactions/"
+
+	// Add then remove succeeds.
+	require.Equal(t, http.StatusCreated, ts.POST(base, map[string]any{"reaction": "🎉"}, w.Session).Code)
+	rr := ts.DELETE(base+"%F0%9F%8E%89/", w.Session)
+	require.Equal(t, http.StatusNoContent, rr.Code, "body=%s", rr.Body.String())
+
+	// Removing from a missing comment is a 404, not a generic 500.
+	missing := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() +
+		"/issues/" + issue.ID.String() + "/comments/" + uuid.NewString() + "/reactions/x/"
+	rr2 := ts.DELETE(missing, w.Session)
+	require.Equal(t, http.StatusNotFound, rr2.Code, "body=%s", rr2.Body.String())
+}

--- a/apps/api/internal/service/comment.go
+++ b/apps/api/internal/service/comment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/Devlaner/devlane/api/internal/text"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 var ErrCommentNotFound = errors.New("comment not found")
@@ -188,8 +189,10 @@ func (s *CommentService) AddReaction(ctx context.Context, workspaceSlug string, 
 		WorkspaceID: c.WorkspaceID,
 	}
 	if err := s.reactions.Add(ctx, r); err != nil {
-		// Unique-constraint violation = already reacted, return existing row.
-		// We don't bother fetching it; caller can refetch the list.
+		// Unique-constraint violation = the user already reacted with this emoji.
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil, ErrReactionExists
+		}
 		return nil, err
 	}
 	return r, nil


### PR DESCRIPTION
## What

Closes #146. `CommentHandler.AddReaction` mapped **every** error to HTTP 409 and echoed the raw `err.Error()` back to the client, so a missing comment, a permission failure, or a DB error all looked like a duplicate-reaction conflict and leaked internal strings. `RemoveReaction` had the inverse problem: every failure became a generic 500.

## How

- `AddReaction` now switches on the service's sentinel errors: `ErrReactionExists` → 409 ("Already reacted"), a not-found / no-access error → 404, everything else → 500 with a generic message. No more raw `err.Error()` leakage.
- `RemoveReaction` returns 404 for not-found / no-access and only 500 for genuinely unexpected failures.
- `CommentService.AddReaction` translates the unique-constraint violation to `ErrReactionExists` (mirroring the issue-reaction service) instead of returning the raw GORM error.
- Added a small `commentAccessNotFound` helper so both handlers share the same not-found mapping as the rest of the comment handlers.

## Testing

New `internal/handler/comment_reaction_test.go`:
- First reaction → 201; the same reaction again → 409; reacting on a missing comment → 404 (was 409).
- Remove after add → 204; removing from a missing comment → 404 (was 500).

`go test ./internal/handler ./internal/service` green.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). AI-assisted commits carry a `Co-Authored-By` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reaction actions now return clearer status codes: `404 Not Found` for missing or inaccessible comments, `409 Conflict` for duplicate reactions, and `500` only for unexpected failures.
  * Removing a reaction now correctly reports missing comments as `404 Not Found` instead of a generic server error.

* **Tests**
  * Added coverage for adding and removing comment reactions, including success cases, duplicate reactions, and missing-comment responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->