### PR TITLE
fix(ui): keep Create Project form open when Escape dismisses a child picker

### DIFF
--- a/apps/web/src/components/CreateProjectModal.tsx
+++ b/apps/web/src/components/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Button, Input, Tooltip } from './ui';
 import { CoverImageModal } from './CoverImageModal';
@@ -86,7 +86,7 @@ export function CreateProjectModal({
   const [coverModalOpen, setCoverModalOpen] = useState(false);
   const [iconModalOpen, setIconModalOpen] = useState(false);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setName('');
     setIdentifier('');
     setDescription('');
@@ -97,7 +97,7 @@ export function CreateProjectModal({
     setProjectLeadId(null);
     setError('');
     onClose();
-  };
+  }, [onClose]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -132,10 +132,6 @@ export function CreateProjectModal({
   useEffect(() => {
     if (!open) return;
 
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleEscape);
     document.body.style.overflow = 'hidden';
 
     // Load workspace members for project lead dropdown
@@ -147,10 +143,22 @@ export function CreateProjectModal({
       });
 
     return () => {
-      document.removeEventListener('keydown', handleEscape);
       document.body.style.overflow = '';
     };
-  }, [open, onClose, workspaceSlug]);
+  }, [open, workspaceSlug]);
+
+  // Escape closes the whole form — but not while a nested cover/icon picker is
+  // open, since that picker handles Escape itself. Using handleClose (not the
+  // raw onClose) ensures the form state is reset so a reopen starts clean.
+  useEffect(() => {
+    if (!open) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || coverModalOpen || iconModalOpen) return;
+      handleClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [open, coverModalOpen, iconModalOpen, handleClose]);
 
   if (!open) return null;
 


### PR DESCRIPTION
## Summary

Closes #142.

Pressing **Escape** to dismiss the cover or icon picker inside the Create Project modal used to tear down the entire modal and discard everything the user had typed. The modal's Escape handler called the raw `onClose` (which does not reset form state), and because the picker registers its own Escape listener, a single keypress fired both handlers at once.

The Escape handler now:

- calls `handleClose()` instead of the raw `onClose`, so the form state is reset for a clean reopen, and
- no-ops while a child picker is open (`coverModalOpen || iconModalOpen`), so Escape only dismisses the picker and leaves the form (and typed data) intact.

The workspace-member fetch and body-overflow lock were split into their own effect so re-registering the Escape listener no longer refetches members.

## Testing

- `npm run typecheck` and `npm run lint` pass.
- Browser-verified the full flow:
  1. Type a project name, open the cover picker, press Escape → only the picker closes, the typed name is preserved.
  2. Press Escape again with no picker open → the whole form closes.
  3. Reopen the modal → fields start empty (state reset).

## AI assistance

This change was produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal behavior when using the Escape key.
  * Closing the project creation modal now consistently resets the form state.
  * Escape no longer closes the main modal while nested cover or icon pickers are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->