### PR TITLE
fix(ui): preserve AxiosError in the response interceptor

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -108,7 +108,10 @@ export function getApiErrorMessage(err: unknown): string {
 apiClient.interceptors.response.use(
   (response) => response,
   (error: AxiosError<ApiErrorResponse>) => {
-    const message = getApiErrorMessage(error);
-    return Promise.reject(new Error(message));
+    // Attach a user-facing message but keep rejecting the original AxiosError so
+    // callers can still branch on error.response / error.response.status /
+    // error.response.data. Replacing it with a bare Error dropped those fields.
+    error.message = getApiErrorMessage(error);
+    return Promise.reject(error);
   },
 );


### PR DESCRIPTION
## Summary

Closes #136.

The global Axios response interceptor rejected with a brand-new `Error(message)`, discarding the original `AxiosError` and with it `response`, `response.status`, and `response.data`. Call sites that branch on those fields had silently stopped working:

- `integrationService.githubGetProjectSync` checks `err.response.status === 404` to return `null` ("repo not linked yet"). With the field gone, a 404 threw instead of rendering the empty state.
- `InviteSignUpPage` and several `SettingsPage` handlers read `err.response.data.error` to surface the backend's specific validation message, and always fell back to a generic "Something went wrong."

The interceptor now attaches the friendly text to `error.message` and rejects the original `AxiosError`, so `error.message` consumers keep the readable text while status- and body-based branches work again.

## Testing

- `npm run typecheck` and `npm run lint` pass.
- Browser-verified against the running API: an authenticated request that 404s now rejects with an error where `isAxiosError === true`, `response.status === 404`, `response.data.error` is the backend message, and `message` is the friendly text. Before the fix the same request rejected with a bare `Error` (no `response`).

## AI assistance

This change was produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling so failed requests now keep their original error details while showing a clearer user-facing message.
  * This helps preserve response information such as status codes and server error data for more reliable troubleshooting and UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->