### PR TITLE
fix(ui): redirect to login when a session expires mid-use

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosError } from 'axios';
+import { dispatchAuthUnauthorized } from '../lib/authEvents';
 
 /**
  * Prefer env-driven API base (VITE_API_BASE_URL).
@@ -108,6 +109,14 @@ export function getApiErrorMessage(err: unknown): string {
 apiClient.interceptors.response.use(
   (response) => response,
   (error: AxiosError<ApiErrorResponse>) => {
+    // A 401 outside the auth endpoints means the session expired mid-use. Signal
+    // the app to drop it so the user lands on /login instead of a page where
+    // every request fails. Auth endpoints (wrong password, invalid magic code)
+    // also return 401, but their own forms handle that.
+    const url = error.config?.url ?? '';
+    if (error.response?.status === 401 && !url.includes('/auth/')) {
+      dispatchAuthUnauthorized();
+    }
     // Attach a user-facing message but keep rejecting the original AxiosError so
     // callers can still branch on error.response / error.response.status /
     // error.response.data. Replacing it with a bare Error dropped those fields.

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import type { User } from '../types';
 import type { UserApiResponse } from '../api/types';
 import { apiClient, clearApiBearerAuthHeader } from '../api/client';
 import { authService } from '../services/authService';
+import { AUTH_UNAUTHORIZED } from '../lib/authEvents';
 
 function mapApiUserToUser(api: UserApiResponse): User {
   const name =
@@ -65,6 +66,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  useEffect(() => {
+    // A 401 from any API call fires this. The server session is already gone, so
+    // just clear the client user and let ProtectedRoute redirect to /login.
+    // Don't call signOut here — that request would 401 as well.
+    const handleUnauthorized = () => {
+      clearApiBearerAuthHeader();
+      setUser(null);
+    };
+    window.addEventListener(AUTH_UNAUTHORIZED, handleUnauthorized);
+    return () => window.removeEventListener(AUTH_UNAUTHORIZED, handleUnauthorized);
   }, []);
 
   const setUserFromApi = useCallback((api: UserApiResponse) => {

--- a/apps/web/src/lib/authEvents.ts
+++ b/apps/web/src/lib/authEvents.ts
@@ -1,0 +1,7 @@
+export const AUTH_UNAUTHORIZED = 'devlane:auth-unauthorized';
+
+/** Fired when an API request returns 401 so the app can drop the expired session. */
+export function dispatchAuthUnauthorized() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(AUTH_UNAUTHORIZED));
+}


### PR DESCRIPTION
## Summary

Closes #137.

There was no global 401 handling. When a cookie session expired mid-use, individual service calls kept rejecting but `AuthContext` was never notified: `isAuthenticated` stayed `true`, no redirect happened, and the user was stranded on a protected page where every fetch failed.

Now:

- The response interceptor dispatches an `unauthorized` event on any `401` whose request is **not** an auth endpoint.
- `AuthProvider` listens for that event, clears the client user (without calling `signOut`, since that request would 401 too), and `ProtectedRoute` declaratively redirects to `/login`.
- Auth-endpoint 401s (wrong password, invalid magic code) are excluded so their own forms keep handling them.

The event lives in a small `lib/authEvents.ts` bus, matching the existing event-bus convention.

> **Stacked on #136.** This PR is based on `fix/preserve-axios-error` (#259), which restores `error.response.status` so the interceptor's 401 branch is reliable. Please merge #259 first; the base will then be retargeted to `main`.

## Testing

- `npm run typecheck` and `npm run lint` pass.
- Browser-verified end-to-end against the running API: a real `401` on a protected endpoint fired the event, cleared the session, and redirected to `/login`. The check was non-destructive (the request omitted credentials, so the real session cookie survived) and a reload logged straight back in (`GET /api/users/me/` returned `200`).

## AI assistance

This change was produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now automatically detects expired authentication sessions and clears the signed-in state when a 401 response is returned.
  * Users will be routed through the existing sign-in flow after their session expires, instead of continuing with stale credentials.

* **Bug Fixes**
  * Improved handling of unauthorized API responses so non-auth requests no longer leave the app in an inconsistent login state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->