### PR TITLE
fix(ui): stop destroying the comment editor mid-edit on refetch

### DIFF
--- a/apps/web/src/components/work-item/CommentEditor.tsx
+++ b/apps/web/src/components/work-item/CommentEditor.tsx
@@ -54,7 +54,7 @@ export function CommentEditor({
   submitLabel,
 }: CommentEditorProps) {
   const [access, setAccess] = useState<'INTERNAL' | 'EXTERNAL'>(initialAccess);
-  const [isEmpty, setIsEmpty] = useState(true);
+  const [isEmpty, setIsEmpty] = useState(() => normalize(initialHtml) === '');
   const membersRef = useRef<MentionMember[]>(mentionMembers ?? []);
   useEffect(() => {
     membersRef.current = mentionMembers ?? [];
@@ -87,16 +87,18 @@ export function CommentEditor({
     },
   });
 
+  // Reseed only when the incoming HTML genuinely differs from what's shown, so a
+  // comment-list refetch landing mid-edit doesn't wipe the draft or jump the
+  // cursor. emitUpdate:false keeps the seed from firing onUpdate / dirtying the
+  // doc. There's deliberately no editor.destroy() here — useEditor tears the
+  // instance down on unmount, and destroying it on an initialHtml change left a
+  // dead ProseMirror mounted mid-edit.
   useEffect(() => {
-    if (!editor) return;
-    if (initialHtml !== undefined) {
-      editor.commands.setContent(initialHtml || '');
-      const html = editor.getHTML().trim();
-      setIsEmpty(html === '<p></p>' || html === '');
+    if (!editor || initialHtml === undefined) return;
+    if (normalize(initialHtml) !== normalize(editor.getHTML())) {
+      editor.commands.setContent(initialHtml || '', { emitUpdate: false });
+      setIsEmpty(normalize(editor.getHTML()) === '');
     }
-    return () => {
-      editor.destroy();
-    };
   }, [editor, initialHtml]);
 
   if (!editor) return null;
@@ -269,6 +271,13 @@ export function CommentEditor({
       </div>
     </div>
   );
+}
+
+/** Treat empty, whitespace-only, and empty-paragraph HTML as the same value. */
+function normalize(html: string | undefined | null): string {
+  const s = (html ?? '').trim();
+  if (s === '' || s === '<p></p>' || s === '<p><br></p>') return '';
+  return s;
 }
 
 function Divider() {


### PR DESCRIPTION
## Summary

Closes #138.

The inline comment editor destroyed its own TipTap instance whenever `initialHtml` changed. The `[editor, initialHtml]` effect's cleanup called `editor.destroy()`, so a comment-list refetch landing while a comment was being edited tore down the live editor and left a dead ProseMirror mounted: typing and formatting stopped working and the console filled with destroyed-instance errors.

Changes:

- Removed the manual `editor.destroy()`. `useEditor` already tears the instance down on unmount, so an `initialHtml` change no longer kills a live editor.
- Reseeding now happens only when the incoming HTML genuinely differs from what's shown (compared via a small `normalize` helper, matching `DescriptionEditor`), and uses `{ emitUpdate: false }` so seeding no longer dirties the doc or fires `onUpdate`.
- The empty state is seeded from `initialHtml` at mount instead of via a mount-time effect, so the Send button is enabled immediately when editing existing content.

## Testing

- `npm run typecheck` and `npm run lint` pass.
- Browser-verified end-to-end (React StrictMode on): posted a comment, clicked Edit, and the inline editor mounted seeded with the comment, `contenteditable`, Send enabled, and no console errors. Edited the text, saved, and the update persisted; the editor unmounted cleanly (ProseMirror instance count returned to baseline). Deleted the test comment afterward.

## AI assistance

This change was produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment editor empty-state handling so blank, whitespace-only, and visually empty paragraph content are treated consistently.
  * Prevented the editor from unnecessarily resetting when incoming content hasn’t actually changed, reducing content flicker and preserving the current draft more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->