### PR TITLE
fix(ui): bucket calendar issues by their real day in non-UTC timezones

### DIFF
--- a/apps/web/src/components/work-item/layouts/IssueLayoutCalendar.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutCalendar.tsx
@@ -96,7 +96,7 @@ export function IssueLayoutCalendar({
 
         {/* Day cells */}
         {cells.map(({ date, inMonth }) => {
-          const key = isoDate(date.toISOString().slice(0, 10))!;
+          const key = localKey(date);
           const dayIssues = issuesByDate.map.get(key) ?? [];
           const isToday = sameDay(date, new Date(now));
           const visible = dayIssues.slice(0, MAX_PER_CELL);
@@ -203,12 +203,18 @@ function addMonths(d: Date, n: number): Date {
   return new Date(d.getFullYear(), d.getMonth() + n, 1);
 }
 
+// target_date/start_date arrive as a UTC-midnight ISO timestamp (or a bare
+// "YYYY-MM-DD"). The calendar day is the date portion itself; routing it through
+// a Date reads local components and shifts the day for non-UTC clients, so take
+// the leading date directly. Keys line up with the cell keys built by localKey.
 function isoDate(input: string | null | undefined): string | null {
   if (!input) return null;
-  // Accept "YYYY-MM-DD" or full ISO. Truncate to date only.
-  const t = Date.parse(input);
-  if (Number.isNaN(t)) return null;
-  const d = new Date(t);
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(input);
+  return match ? `${match[1]}-${match[2]}-${match[3]}` : null;
+}
+
+// Local calendar day (Y-M-D) of a Date built from local components.
+function localKey(d: Date): string {
   return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
 }
 


### PR DESCRIPTION
## Summary

Closes #140.

In the work-item **Calendar** layout, issues were bucketed into the wrong day cell for anyone outside UTC. Two date round-trips were to blame:

- Each cell's lookup key was built as `isoDate(date.toISOString().slice(0, 10))`. The cell `date` is a local-midnight `Date`, so for a positive-offset client `toISOString()` rolls back to the previous UTC day and the cell key ends up one day early. Every issue then rendered in the next cell (a due-Jun-20 issue landed in the Jun-21 cell), and the per-day counts and "+N more" were off too.
- `isoDate` parsed the `target_date` (`"YYYY-MM-DDT00:00:00Z"`) into a `Date` and read its local components, which shifts negative-offset clients the other way.

Fix:

- Cell keys now come from the date's local components (`localKey`), i.e. the calendar day the cell actually represents.
- `isoDate` now takes the leading `YYYY-MM-DD` of `target_date` directly (the calendar day the backend stored), with no `Date` round-trip.

Buckets and cells agree on the calendar day in every timezone now.

## Testing

- `npm run typecheck` and `npm run lint` pass.
- Browser-verified in **Asia/Baku (UTC+4)** — the reported repro timezone. In June 2026, "DUE-20th" (`target_date` 2026-06-20) now renders in the **day-20** cell and "Child of Alpha" (2026-06-26) in the **day-26** cell. Before the fix both were shifted +1 (day-21 / day-27).

## AI assistance

This change was produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar day cells to use the correct local date key, reducing mismatches in day-specific issue views.
  * Improved date handling for calendar entries so UTC-based timestamps display consistently across time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->