### PR TITLE
fix(api): write only changed issue columns to prevent lost updates

### DIFF
--- a/apps/api/internal/handler/issue_concurrent_update_test.go
+++ b/apps/api/internal/handler/issue_concurrent_update_test.go
@@ -1,0 +1,50 @@
+package handler_test
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Two PATCHes to different fields of the same issue, fired together, must both
+// persist. Before the fix the update did a full-row Save from an in-memory
+// snapshot, so whichever request committed last reverted the other's field.
+func TestIssue_ConcurrentUpdatesToDifferentFields_BothPersist(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+
+	for i := 0; i < 5; i++ {
+		issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+		base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() +
+			"/issues/" + issue.ID.String() + "/"
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		var priCode, nameCode int
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			priCode = ts.PATCH(base, map[string]any{"priority": "urgent"}, w.Session).Code
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			nameCode = ts.PATCH(base, map[string]any{"name": "renamed"}, w.Session).Code
+		}()
+		close(start) // release both at once to maximise interleaving
+		wg.Wait()
+
+		require.Equal(t, http.StatusOK, priCode)
+		require.Equal(t, http.StatusOK, nameCode)
+
+		var got model.Issue
+		require.NoError(t, ts.DB.First(&got, "id = ?", issue.ID).Error)
+		require.Equalf(t, "urgent", got.Priority, "priority change lost on iteration %d", i)
+		require.Equalf(t, "renamed", got.Name, "name change lost on iteration %d", i)
+	}
+}

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -645,41 +645,56 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 	prevParent := uuidString(issue.ParentID)
 	prevDescription := issue.DescriptionHTML
 
+	// Write only the columns this PATCH actually changed. A full-row Save would
+	// re-write every column from the in-memory snapshot, so a concurrent PATCH to
+	// a different field would be silently reverted (lost update).
+	changed := map[string]any{"updated_by_id": &userID}
 	if name != nil {
 		issue.Name = *name
+		changed["name"] = *name
 	}
 	if priority != nil {
 		issue.Priority = *priority
+		changed["priority"] = *priority
 	}
 	if description != nil {
 		issue.DescriptionHTML = *description
+		changed["description_html"] = *description
 	}
 	if stateID != nil {
 		issue.StateID = stateID
+		changed["state_id"] = stateID
 	}
 	if startDateSet {
 		issue.StartDate = startDate // nil clears the date
+		changed["start_date"] = startDate
 	}
 	if targetDateSet {
 		issue.TargetDate = targetDate
+		changed["target_date"] = targetDate
 	}
 	if parentID != nil {
 		issue.ParentID = parentID
+		changed["parent_id"] = parentID
 	}
 	if isDraft != nil {
 		issue.IsDraft = *isDraft
+		changed["is_draft"] = *isDraft
 	}
 	if issueType != nil && *issueType != "" {
 		issue.Type = *issueType
+		changed["type"] = *issueType
 	}
 	if estimatePointIDSet {
 		issue.EstimatePointID = estimatePointID
+		changed["estimate_point_id"] = estimatePointID
 	}
 	if sortOrder != nil {
 		issue.SortOrder = *sortOrder
+		changed["sort_order"] = *sortOrder
 	}
 	issue.UpdatedByID = &userID
-	if err := s.is.Update(ctx, issue); err != nil {
+	if err := s.is.UpdateFields(ctx, issue.ID, changed); err != nil {
 		return nil, err
 	}
 

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -695,6 +695,10 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 	}
 	issue.UpdatedByID = &userID
 	if err := s.is.UpdateFields(ctx, issue.ID, changed); err != nil {
+		// The issue was deleted between the load above and this write.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrIssueNotFound
+		}
 		return nil, err
 	}
 

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -155,6 +155,19 @@ func (s *IssueStore) Update(ctx context.Context, i *model.Issue) error {
 	return s.db.WithContext(ctx).Save(i).Error
 }
 
+// UpdateFields writes only the given columns for one issue. Unlike Update
+// (a full-row Save), a concurrent PATCH that changed a different field is not
+// clobbered, since each writer only touches the columns it actually changed.
+func (s *IssueStore) UpdateFields(ctx context.Context, issueID uuid.UUID, fields map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Model(&model.Issue{}).
+		Where("id = ? AND deleted_at IS NULL", issueID).
+		Updates(fields).Error
+}
+
 func (s *IssueStore) Delete(ctx context.Context, id uuid.UUID) error {
 	return s.db.WithContext(ctx).Where("id = ?", id).Delete(&model.Issue{}).Error
 }

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -162,10 +162,19 @@ func (s *IssueStore) UpdateFields(ctx context.Context, issueID uuid.UUID, fields
 	if len(fields) == 0 {
 		return nil
 	}
-	return s.db.WithContext(ctx).
+	res := s.db.WithContext(ctx).
 		Model(&model.Issue{}).
 		Where("id = ? AND deleted_at IS NULL", issueID).
-		Updates(fields).Error
+		Updates(fields)
+	if res.Error != nil {
+		return res.Error
+	}
+	// No matching live row means the issue was deleted since it was loaded; surface
+	// that instead of silently reporting success.
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 func (s *IssueStore) Delete(ctx context.Context, id uuid.UUID) error {

--- a/apps/api/internal/store/issue_update_test.go
+++ b/apps/api/internal/store/issue_update_test.go
@@ -1,0 +1,60 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/store"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Two writers hold the same snapshot and each change a different field. With a
+// column-scoped update, both changes survive; a full-row Save from either stale
+// snapshot would revert the other's field (the lost-update bug in #144).
+func TestIssueStore_UpdateFields_DoesNotClobberConcurrentColumn(t *testing.T) {
+	db := testutil.NewTestServer(t).DB
+	world := testutil.SeedWorld(t, db)
+	is := store.NewIssueStore(db)
+	ctx := context.Background()
+
+	issue := testutil.CreateIssue(t, db, world.Project.ID, world.Workspace.ID, world.User.ID)
+	originalName := issue.Name
+
+	// Writer B changes the name.
+	require.NoError(t, is.UpdateFields(ctx, issue.ID, map[string]any{"name": "changed-by-B"}))
+
+	// Writer A, still holding the pre-B snapshot, changes only the priority.
+	require.NoError(t, is.UpdateFields(ctx, issue.ID, map[string]any{"priority": "urgent"}))
+
+	var got model.Issue
+	require.NoError(t, db.First(&got, "id = ?", issue.ID).Error)
+	require.Equal(t, "urgent", got.Priority, "writer A's change should apply")
+	require.Equal(t, "changed-by-B", got.Name, "writer B's change must not be reverted")
+	require.NotEqual(t, originalName, got.Name)
+}
+
+// A nil pointer in the update map clears the column (the service relies on this
+// to clear start/target dates and the estimate).
+func TestIssueStore_UpdateFields_NilClearsColumn(t *testing.T) {
+	db := testutil.NewTestServer(t).DB
+	world := testutil.SeedWorld(t, db)
+	is := store.NewIssueStore(db)
+	ctx := context.Background()
+
+	issue := testutil.CreateIssue(t, db, world.Project.ID, world.Workspace.ID, world.User.ID)
+
+	due := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, is.UpdateFields(ctx, issue.ID, map[string]any{"target_date": &due}))
+	var withDate model.Issue
+	require.NoError(t, db.First(&withDate, "id = ?", issue.ID).Error)
+	require.NotNil(t, withDate.TargetDate)
+
+	var cleared *time.Time
+	require.NoError(t, is.UpdateFields(ctx, issue.ID, map[string]any{"target_date": cleared}))
+	var afterClear model.Issue
+	require.NoError(t, db.First(&afterClear, "id = ?", issue.ID).Error)
+	require.Nil(t, afterClear.TargetDate)
+}

--- a/apps/api/internal/store/issue_update_test.go
+++ b/apps/api/internal/store/issue_update_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // Two writers hold the same snapshot and each change a different field. With a
@@ -57,4 +59,13 @@ func TestIssueStore_UpdateFields_NilClearsColumn(t *testing.T) {
 	var afterClear model.Issue
 	require.NoError(t, db.First(&afterClear, "id = ?", issue.ID).Error)
 	require.Nil(t, afterClear.TargetDate)
+}
+
+// Updating a non-existent (or already-deleted) issue must not silently succeed.
+func TestIssueStore_UpdateFields_ReturnsNotFoundWhenMissing(t *testing.T) {
+	db := testutil.NewTestServer(t).DB
+	is := store.NewIssueStore(db)
+
+	err := is.UpdateFields(context.Background(), uuid.New(), map[string]any{"priority": "urgent"})
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
 }


### PR DESCRIPTION
## Summary

Closes #144.

Issue updates loaded the row via `GetByID`, mutated it in memory, then called `IssueStore.Update` (a full-row `db.Save`). Two concurrent `PATCH`es to **different** fields of the same issue each read-modify-write the *entire* row from their own snapshot, so whichever committed last silently reverted the other's change (a lost update — not the zero-value clobber pitfall, since the full row is loaded first).

The hot-path issue update now writes **only the columns the request actually changed**, via a new column-scoped `IssueStore.UpdateFields(id, map)` (`Model(...).Where("id = ?").Updates(map)`). Concurrent edits to different fields no longer clobber each other. The full-row `Save` stays for the other callers (GitHub webhook sync, epic conversion) that legitimately rewrite the whole row.

Nil values in the map still clear a column (dates / estimate), matching the previous behavior.

## Testing

- `go vet ./...` and the full `go test ./...` suite pass.
- **`store_test.TestIssueStore_UpdateFields_DoesNotClobberConcurrentColumn`** — deterministic: two writers change different columns; both survive (a stale full-row Save would revert one).
- **`store_test.TestIssueStore_UpdateFields_NilClearsColumn`** — a nil pointer clears the column.
- **`handler_test.TestIssue_ConcurrentUpdatesToDifferentFields_BothPersist`** — fires two simultaneous PATCHes (priority + name) through the full HTTP stack and asserts both persist. I confirmed this test **fails** against the old `Save` path (name/priority reverted) and passes with the fix.

## Notes / follow-up

The same read-modify-`Save` shape exists in `cycle.go`, `module.go`, `state.go`, `label.go`, `workspace.go`, `project.go`. This PR scopes the fix to the issue update hot path (where concurrent edits are common); the others can follow the same `UpdateFields` pattern in a separate change.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue editing to use partial field updates, preventing concurrent edits to different fields from overwriting each other.
  * Improved handling of cleared date fields so sending `null` properly removes the stored date.
  * Ensured missing or deleted issues are reported correctly instead of silently succeeding.
  * Added regression coverage for concurrent updates and partial-update behavior to reduce the chance of reintroducing these issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->