### PR TITLE
fix(ui): keep command palette options out of the tab order

### DIFF
--- a/apps/web/src/components/layout/GlobalCommandPalette.tsx
+++ b/apps/web/src/components/layout/GlobalCommandPalette.tsx
@@ -639,6 +639,10 @@ export function GlobalCommandPalette({
                           type="button"
                           role="option"
                           aria-selected={active}
+                          // Keep keyboard focus on the input so its arrow/Enter
+                          // handlers and the aria-activedescendant model stay in
+                          // control; Tab must not land on the options.
+                          tabIndex={-1}
                           ref={(el) => {
                             if (el) itemRefs.current.set(cmd.id, el);
                             else itemRefs.current.delete(cmd.id);


### PR DESCRIPTION
## Summary

Closes #152.

The global command palette drives selection through the input's arrow/Enter key handlers plus an `aria-activedescendant` model, but each option was rendered as a real `<button role="option">` with the default `tabIndex=0`. So pressing Tab moved keyboard focus onto the option buttons, at which point the input's arrow handlers no longer fired and arrow navigation stopped working.

The options now use `tabIndex={-1}`, so keyboard focus stays on the input and the `aria-activedescendant` model keeps control of navigation — which is the standard combobox/listbox pattern.

## Testing

- `npm run typecheck` and `npm run lint` pass.
- Browser-verified: opened the palette (Ctrl+K); all 15 options report `tabIndex === -1`; ArrowDown advanced `aria-activedescendant` (create-issue → drafts) while the input stayed focused; and Tab no longer lands on an option button (`activeIsOption` is false, no option is a tab stop).

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the command palette so focus stays on the search field while browsing options.
  * Prevented option buttons from being reached via Tab, making arrow keys and Enter work more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->