### PR TITLE
fix(api): keep draft work items out of the active project issue list

### DIFF
--- a/apps/api/internal/handler/issue_draft_list_test.go
+++ b/apps/api/internal/handler/issue_draft_list_test.go
@@ -1,0 +1,59 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func issueIDSet(t *testing.T, rr *httptest.ResponseRecorder) map[string]bool {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	var rows []struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &rows))
+	set := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		set[r.ID] = true
+	}
+	return set
+}
+
+// Drafts must stay out of the active project issue list but show up in the
+// draft list, and accepting a draft (is_draft=false) moves it into the active
+// list. Covers #123's acceptance criteria.
+func TestIssue_DraftsExcludedFromActiveList(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+
+	active := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	draft := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.NoError(t, ts.DB.Model(&model.Issue{}).
+		Where("id = ?", draft.ID).Update("is_draft", true).Error)
+
+	listURL := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/issues/"
+	draftsURL := "/api/workspaces/" + w.Workspace.Slug + "/draft-issues/"
+
+	// Active list excludes the draft.
+	active1 := issueIDSet(t, ts.GET(listURL, w.Session))
+	require.True(t, active1[active.ID.String()], "non-draft should be in the active list")
+	require.False(t, active1[draft.ID.String()], "draft must not appear in the active list")
+
+	// Draft list includes the draft and not the active issue.
+	drafts := issueIDSet(t, ts.GET(draftsURL, w.Session))
+	require.True(t, drafts[draft.ID.String()], "draft should appear in the draft list")
+	require.False(t, drafts[active.ID.String()], "non-draft should not be in the draft list")
+
+	// Accepting the draft moves it into the active list.
+	patchURL := listURL + draft.ID.String() + "/"
+	require.Equal(t, http.StatusOK,
+		ts.PATCH(patchURL, map[string]any{"is_draft": false}, w.Session).Code)
+	active2 := issueIDSet(t, ts.GET(listURL, w.Session))
+	require.True(t, active2[draft.ID.String()], "accepted draft should now appear in the active list")
+}

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -76,8 +76,10 @@ func (s *IssueStore) ListByIDs(ctx context.Context, ids []uuid.UUID) ([]model.Is
 
 func (s *IssueStore) ListByProjectID(ctx context.Context, projectID uuid.UUID, limit, offset int) ([]model.Issue, error) {
 	var list []model.Issue
+	// Drafts belong in Drafts / Intake, not the active project list. IS NOT TRUE
+	// keeps false and any legacy NULL rows while excluding only real drafts.
 	q := s.db.WithContext(ctx).
-		Where("project_id = ? AND deleted_at IS NULL AND archived_at IS NULL", projectID).
+		Where("project_id = ? AND deleted_at IS NULL AND archived_at IS NULL AND is_draft IS NOT TRUE", projectID).
 		Order("sort_order ASC, created_at DESC")
 	if limit > 0 {
 		q = q.Limit(limit)

--- a/apps/web/src/pages/IntakePage.tsx
+++ b/apps/web/src/pages/IntakePage.tsx
@@ -26,7 +26,9 @@ async function fetchProjectDrafts(
   projectId: string,
 ): Promise<IssueApiResponse[]> {
   const all: IssueApiResponse[] = [];
-  for (let offset = 0; offset < 10000; offset += DRAFT_PAGE_SIZE) {
+  // Keep paging until a short (or empty) page signals the end, so the number of
+  // drafts we can load isn't capped by an arbitrary bound.
+  for (let offset = 0; ; offset += DRAFT_PAGE_SIZE) {
     const batch = await issueService.listWorkspaceDrafts(workspaceSlug, {
       limit: DRAFT_PAGE_SIZE,
       offset,

--- a/apps/web/src/pages/IntakePage.tsx
+++ b/apps/web/src/pages/IntakePage.tsx
@@ -36,13 +36,15 @@ export function IntakePage() {
     Promise.all([
       workspaceService.getBySlug(workspaceSlug),
       projectService.get(workspaceSlug, projectId),
-      issueService.list(workspaceSlug, projectId, { limit: 500 }),
+      // Read from the draft list, not the active issue list (which no longer
+      // returns drafts), then narrow the workspace drafts to this project.
+      issueService.listWorkspaceDrafts(workspaceSlug, { limit: 500 }),
     ])
-      .then(([w, p, issues]) => {
+      .then(([w, p, workspaceDrafts]) => {
         if (cancelled) return;
         setWorkspace(w ?? null);
         setProject(p ?? null);
-        setDrafts((issues ?? []).filter((i) => i.is_draft));
+        setDrafts((workspaceDrafts ?? []).filter((i) => i.project_id === projectId));
       })
       .catch(() => {
         if (!cancelled) {

--- a/apps/web/src/pages/IntakePage.tsx
+++ b/apps/web/src/pages/IntakePage.tsx
@@ -16,6 +16,27 @@ const priorityVariant: Record<Priority, 'danger' | 'warning' | 'default' | 'neut
   none: 'neutral',
 };
 
+// The draft-issues endpoint caps each request's page size, so fetch every page
+// and keep only this project's drafts — otherwise a project's drafts beyond the
+// first page would silently never show up in Intake.
+const DRAFT_PAGE_SIZE = 100;
+
+async function fetchProjectDrafts(
+  workspaceSlug: string,
+  projectId: string,
+): Promise<IssueApiResponse[]> {
+  const all: IssueApiResponse[] = [];
+  for (let offset = 0; offset < 10000; offset += DRAFT_PAGE_SIZE) {
+    const batch = await issueService.listWorkspaceDrafts(workspaceSlug, {
+      limit: DRAFT_PAGE_SIZE,
+      offset,
+    });
+    all.push(...batch);
+    if (batch.length < DRAFT_PAGE_SIZE) break;
+  }
+  return all.filter((i) => i.project_id === projectId);
+}
+
 export function IntakePage() {
   const { workspaceSlug, projectId } = useParams<{ workspaceSlug: string; projectId: string }>();
   const [loading, setLoading] = useState(true);
@@ -37,14 +58,14 @@ export function IntakePage() {
       workspaceService.getBySlug(workspaceSlug),
       projectService.get(workspaceSlug, projectId),
       // Read from the draft list, not the active issue list (which no longer
-      // returns drafts), then narrow the workspace drafts to this project.
-      issueService.listWorkspaceDrafts(workspaceSlug, { limit: 500 }),
+      // returns drafts).
+      fetchProjectDrafts(workspaceSlug, projectId),
     ])
-      .then(([w, p, workspaceDrafts]) => {
+      .then(([w, p, projectDrafts]) => {
         if (cancelled) return;
         setWorkspace(w ?? null);
         setProject(p ?? null);
-        setDrafts((workspaceDrafts ?? []).filter((i) => i.project_id === projectId));
+        setDrafts(projectDrafts);
       })
       .catch(() => {
         if (!cancelled) {


### PR DESCRIPTION
## Summary

Closes #123.

Draft work items were leaking into the normal project issue list because `IssueStore.ListByProjectID` filtered only by `project_id`, `deleted_at`, and `archived_at`. Any project view built on that list — list, board, spreadsheet, calendar, gantt — could render drafts as active work.

- **Backend:** `ListByProjectID` now excludes drafts with `is_draft IS NOT TRUE` (keeps `false` and any legacy `NULL` rows, excludes only real drafts). It's the sole caller path for the active project list (`IssueService.List`), so nothing else is affected.
- **Frontend:** `IntakePage` previously fetched the active issue list and filtered `is_draft` client-side — which now returns no drafts. It reads the workspace draft list (`/draft-issues/`) and narrows it to the current project instead.

Draft listing on `/api/workspaces/:slug/draft-issues/` is unchanged, so Drafts and Intake still show drafts, and accepting a draft (`is_draft=false`) still moves it into the active list.

## Testing

- `go vet ./...` passes; the full `go test ./...` suite passes.
- **`handler_test.TestIssue_DraftsExcludedFromActiveList`** covers all of the issue's acceptance criteria: a draft is absent from the active project list, present in the draft list, and appears in the active list once accepted.
- Browser-verified end-to-end against the running API: created a draft in a project → it did **not** appear in the active issue list, **did** appear in the Intake queue; clicking **Accept** moved it into the active list and out of Intake. Cleaned up the test issue afterward.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active project issue listings now exclude real draft issues; drafts appear only in the drafts view.
  * Draft issues now move from the drafts list to the active list after conversion.
  * The intake page now loads draft issues via a dedicated drafts fetcher (with pagination) and shows only drafts for the current project.
* **Tests**
  * Added an API handler test validating draft listing behavior across active vs. draft endpoints, including the conversion flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->