### PR TITLE
feat(epic): add remove-issue-from-epic endpoint and detail-page control

### DIFF
--- a/apps/api/internal/handler/epic.go
+++ b/apps/api/internal/handler/epic.go
@@ -323,3 +323,37 @@ func (h *EpicHandler) AddIssueToEpic(c *gin.Context) {
 	}
 	c.Status(http.StatusNoContent)
 }
+
+// RemoveIssueFromEpic unlinks a child issue from an epic by clearing its parent.
+// DELETE /api/workspaces/:slug/projects/:projectId/epics/:epicId/issues/:issueId/
+func (h *EpicHandler) RemoveIssueFromEpic(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	eID, ok := epicID(c)
+	if !ok {
+		return
+	}
+	issueID, err := uuid.Parse(c.Param("issueId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid issue ID"})
+		return
+	}
+	if err := h.Issue.RemoveIssueFromEpic(c.Request.Context(), slug, projectID, eID, issueID, user.ID); err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove issue from epic"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/apps/api/internal/handler/epic_test.go
+++ b/apps/api/internal/handler/epic_test.go
@@ -84,6 +84,40 @@ func TestEpic_IssuesChild(t *testing.T) {
 	assert.Contains(t, rr3.Body.String(), issue.ID.String())
 }
 
+func TestEpic_RemoveIssue(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := epicBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// Create an epic and a child issue, and link them.
+	rr := ts.POST(base, map[string]any{"name": "Parent epic"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code)
+	epicID, _ := testutil.MustJSONMap(t, rr)["id"].(string)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+	require.Equal(
+		t,
+		http.StatusNoContent,
+		ts.POST(base+epicID+"/issues/", map[string]any{"issue_id": issue.ID.String()}, w.Session).Code,
+	)
+
+	del := base + epicID + "/issues/" + issue.ID.String() + "/"
+
+	// Requires authentication.
+	require.Equal(t, http.StatusUnauthorized, ts.DELETE(del, "").Code)
+
+	// An unparseable issue id is a bad request.
+	require.Equal(t, http.StatusBadRequest, ts.DELETE(base+epicID+"/issues/not-a-uuid/", w.Session).Code)
+
+	// Removing the child succeeds and detaches it from the epic.
+	require.Equal(t, http.StatusNoContent, ts.DELETE(del, w.Session).Code)
+	list := ts.GET(base+epicID+"/issues/", w.Session)
+	require.Equal(t, http.StatusOK, list.Code)
+	assert.NotContains(t, list.Body.String(), issue.ID.String())
+
+	// Removing an issue that is not (or no longer) a child returns not found.
+	require.Equal(t, http.StatusNotFound, ts.DELETE(del, w.Session).Code)
+}
+
 func TestEpic_NonMember404(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -394,6 +394,7 @@ func New(cfg Config) *gin.Engine {
 		api.DELETE("/workspaces/:slug/projects/:projectId/epics/:epicId/", epicHandler.DeleteEpic)
 		api.GET("/workspaces/:slug/projects/:projectId/epics/:epicId/issues/", epicHandler.ListEpicIssues)
 		api.POST("/workspaces/:slug/projects/:projectId/epics/:epicId/issues/", epicHandler.AddIssueToEpic)
+		api.DELETE("/workspaces/:slug/projects/:projectId/epics/:epicId/issues/:issueId/", epicHandler.RemoveIssueFromEpic)
 		api.GET("/workspaces/:slug/projects/:projectId/epics/:epicId/links/", issueLinkHandler.ListLinks)
 		api.POST("/workspaces/:slug/projects/:projectId/epics/:epicId/links/", issueLinkHandler.CreateLink)
 		api.PATCH("/workspaces/:slug/projects/:projectId/epics/:epicId/links/:linkId/", issueLinkHandler.UpdateLink)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -1263,3 +1263,22 @@ func (s *IssueService) AddIssueToEpic(ctx context.Context, workspaceSlug string,
 	issue.ParentID = &epicID
 	return s.is.Update(ctx, issue)
 }
+
+// RemoveIssueFromEpic detaches a child issue from an epic by clearing its
+// parent. It verifies the epic is reachable and that the issue is actually a
+// child of this epic before clearing, so removing an issue that belongs to a
+// different epic (or none) returns a not-found rather than silently succeeding.
+func (s *IssueService) RemoveIssueFromEpic(ctx context.Context, workspaceSlug string, projectID, epicID, issueID uuid.UUID, userID uuid.UUID) error {
+	if _, err := s.GetEpic(ctx, workspaceSlug, projectID, epicID, userID); err != nil {
+		return err
+	}
+	issue, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID)
+	if err != nil {
+		return err
+	}
+	if issue.ParentID == nil || *issue.ParentID != epicID {
+		return ErrIssueNotFound
+	}
+	issue.ParentID = nil
+	return s.is.Update(ctx, issue)
+}

--- a/apps/web/src/pages/EpicDetailPage.tsx
+++ b/apps/web/src/pages/EpicDetailPage.tsx
@@ -226,18 +226,19 @@ export function EpicDetailPage() {
                   <th className="px-4 py-2 font-medium text-(--txt-secondary)">Work item</th>
                   <th className="px-4 py-2 font-medium text-(--txt-secondary)">State</th>
                   <th className="px-4 py-2 font-medium text-(--txt-secondary)">Priority</th>
+                  <th className="w-10 px-4 py-2" aria-label="Actions" />
                 </tr>
               </thead>
               <tbody>
                 {issues.length === 0 ? (
                   <tr>
-                    <td colSpan={3} className="px-4 py-6 text-center text-xs text-(--txt-tertiary)">
+                    <td colSpan={4} className="px-4 py-6 text-center text-xs text-(--txt-tertiary)">
                       No work items yet.
                     </td>
                   </tr>
                 ) : (
                   issues.map((i) => (
-                    <tr key={i.id} className="border-t border-(--border-subtle)">
+                    <tr key={i.id} className="group border-t border-(--border-subtle)">
                       <td className="px-4 py-2">
                         <Link
                           to={`${projectBase}/issues/${i.id}`}
@@ -253,6 +254,30 @@ export function EpicDetailPage() {
                             {i.priority}
                           </Badge>
                         )}
+                      </td>
+                      <td className="px-4 py-2 text-right">
+                        <button
+                          type="button"
+                          title="Remove from epic"
+                          aria-label={`Remove ${i.name} from epic`}
+                          onClick={async () => {
+                            if (!workspaceSlug) return;
+                            try {
+                              await epicService.removeIssue(
+                                workspaceSlug,
+                                project.id,
+                                epic.id,
+                                i.id,
+                              );
+                              setIssues((prev) => prev.filter((x) => x.id !== i.id));
+                            } catch {
+                              setError('Failed to remove issue from epic.');
+                            }
+                          }}
+                          className="text-sm text-(--txt-tertiary) opacity-0 group-hover:opacity-100 hover:text-(--txt-danger-primary)"
+                        >
+                          ×
+                        </button>
                       </td>
                     </tr>
                   ))

--- a/apps/web/src/pages/EpicDetailPage.tsx
+++ b/apps/web/src/pages/EpicDetailPage.tsx
@@ -274,7 +274,7 @@ export function EpicDetailPage() {
                               setError('Failed to remove issue from epic.');
                             }
                           }}
-                          className="text-sm text-(--txt-tertiary) opacity-0 group-hover:opacity-100 hover:text-(--txt-danger-primary)"
+                          className="rounded-(--radius-sm) text-sm text-(--txt-tertiary) opacity-0 group-hover:opacity-100 hover:text-(--txt-danger-primary) focus-visible:text-(--txt-danger-primary) focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--border-focus)"
                         >
                           ×
                         </button>

--- a/apps/web/src/services/epicService.ts
+++ b/apps/web/src/services/epicService.ts
@@ -90,6 +90,17 @@ export const epicService = {
     );
   },
 
+  async removeIssue(
+    workspaceSlug: string,
+    projectId: string,
+    epicId: string,
+    issueId: string,
+  ): Promise<void> {
+    await apiClient.delete(
+      `${base(workspaceSlug, projectId)}/${encodeURIComponent(epicId)}/issues/${encodeURIComponent(issueId)}/`,
+    );
+  },
+
   async listLinks(
     workspaceSlug: string,
     projectId: string,


### PR DESCRIPTION
## Feature summary

Adds a symmetric "remove from epic" so a child issue can be detached from an epic directly, instead of only indirectly by clearing its parent through the generic issue update.

## Linked issues / discussion

Closes #192

## User-facing behavior

On the epic detail page, each child issue row now has a remove control (the same `×` style used for links). Clicking it detaches that issue from the epic. The issue itself is kept, it just no longer has the epic as its parent, and the work-items list updates immediately.

## What changed

### API (`apps/api/`)
- New route `DELETE /api/workspaces/:slug/projects/:projectId/epics/:epicId/issues/:issueId/` (`EpicHandler.RemoveIssueFromEpic`).
- New `IssueService.RemoveIssueFromEpic`: verifies the epic is reachable and that the issue is actually a child of this epic, then clears `parent_id`. Removing an issue that belongs to a different epic (or none) returns 404 rather than silently succeeding.

### UI (`apps/web/`)
- `epicService.removeIssue` mirrors the existing `addIssue`.
- Per-row remove control on `EpicDetailPage`, styled to match the existing link-removal button.

### Database
- No schema changes.

## Why this design

Mirrors the existing `AddIssueToEpic` pair exactly (same access checks, same store update) so the two stay symmetric. Clearing `parent_id` reuses the store's `Save`, which persists the nil pointer as `NULL`. The membership check keeps the endpoint honest so it can't be used to clear an arbitrary issue's parent.

## Test plan

- [x] `go vet ./...` and full `go test ./...` green (testcontainers).
- [x] `npm run typecheck`, `npm run lint`, `npm run build`, `prettier --check` all green.
- [x] Manual end-to-end (local stack, seeded via API):
  1. Added an issue to an epic, opened the epic detail page — the remove control renders.
  2. Clicked remove — the row disappears and the work-items count drops to 0.
  3. Verified via API: the issue's `parent_id` is now `null`, the epic has 0 children, the issue still exists in the project, and re-removing returns 404.

## Out of scope (follow-ups)

- None.

## Rollout notes

None.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] Trailing slashes on new routes match neighboring routes
- [x] No `--no-verify` bypass
- [x] Acceptance criteria from the linked issue are all met


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to unlink an issue from an epic (work item “Remove from epic” button in Epic details).
  * The “Work items” table now includes per-row actions to detach items directly.

* **Bug Fixes**
  * Improved handling for invalid IDs, missing epics/issues, and authorization when removing a work item from an epic.
  * Successfully detached items are immediately removed from the displayed list.

* **Tests**
  * Added coverage for the epic unlink flow, including success, bad requests, and not-found cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->