### PR TITLE
feat(ui): add ascending/descending toggle to work-item ordering

### DIFF
--- a/apps/web/src/components/project-saved-view/ProjectSavedViewDisplayDropdown.tsx
+++ b/apps/web/src/components/project-saved-view/ProjectSavedViewDisplayDropdown.tsx
@@ -3,6 +3,7 @@ import {
   type SavedViewDisplayPropertyId,
   type SavedViewGroupBy,
   type SavedViewOrderBy,
+  type SavedViewOrderDirection,
   ALL_SAVED_VIEW_DISPLAY_PROPERTIES,
   SAVED_VIEW_DISPLAY_PROPERTY_LABELS,
 } from '../../lib/projectSavedViewDisplay';
@@ -81,6 +82,11 @@ const ORDER_OPTIONS: { value: SavedViewOrderBy; label: string }[] = [
   { value: 'start_date', label: 'Start date' },
   { value: 'due_date', label: 'Due date' },
   { value: 'priority', label: 'Priority' },
+];
+
+const DIRECTION_OPTIONS: { value: SavedViewOrderDirection; label: string }[] = [
+  { value: 'asc', label: 'Ascending' },
+  { value: 'desc', label: 'Descending' },
 ];
 
 function CollapsibleSection(props: {
@@ -254,6 +260,27 @@ export function ProjectSavedViewDisplayDropdown() {
                     selected={settings.orderBy === opt.value}
                     onSelect={(v) => setSettings((p) => ({ ...p, orderBy: v }))}
                   />
+                ))}
+              </div>
+              <div
+                className="mx-2 mt-2 flex items-center gap-1"
+                role="group"
+                aria-label="Order direction"
+              >
+                {DIRECTION_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    aria-pressed={settings.orderDirection === opt.value}
+                    onClick={() => setSettings((p) => ({ ...p, orderDirection: opt.value }))}
+                    className={
+                      settings.orderDirection === opt.value
+                        ? 'flex-1 rounded-(--radius-md) bg-(--bg-layer-1-hover) px-2 py-1 text-[13px] text-(--txt-primary)'
+                        : 'flex-1 rounded-(--radius-md) px-2 py-1 text-[13px] text-(--txt-secondary) hover:bg-(--bg-layer-1-hover)'
+                    }
+                  >
+                    {opt.label}
+                  </button>
                 ))}
               </div>
               <div className="mx-2 my-2 border-t border-(--border-subtle)" />

--- a/apps/web/src/lib/issueListGroupAndSort.ts
+++ b/apps/web/src/lib/issueListGroupAndSort.ts
@@ -6,7 +6,11 @@ import type {
   ModuleApiResponse,
   WorkspaceMemberApiResponse,
 } from '../api/types';
-import type { SavedViewGroupBy, SavedViewOrderBy } from './projectSavedViewDisplay';
+import type {
+  SavedViewGroupBy,
+  SavedViewOrderBy,
+  SavedViewOrderDirection,
+} from './projectSavedViewDisplay';
 
 const NONE_STATE_KEY = '__no_state__';
 const ALL_GROUP_KEY = '__all__';
@@ -31,7 +35,16 @@ function pushUniq(arr: string[], id: string) {
 export function sortIssuesByOrder(
   list: IssueApiResponse[],
   orderBy: SavedViewOrderBy,
+  direction: SavedViewOrderDirection = 'asc',
 ): IssueApiResponse[] {
+  const sorted = sortAscending(list, orderBy);
+  return direction === 'desc' ? sorted.reverse() : sorted;
+}
+
+// The base (ascending) ordering for each order key. Descending is this list
+// reversed, so the toggle stays predictable regardless of the key's natural
+// direction.
+function sortAscending(list: IssueApiResponse[], orderBy: SavedViewOrderBy): IssueApiResponse[] {
   const out = [...list];
   switch (orderBy) {
     case 'manual':
@@ -84,6 +97,7 @@ export function buildGroupedIssues(params: {
   baseForGrouping: IssueApiResponse[];
   groupBy: SavedViewGroupBy;
   orderBy: SavedViewOrderBy;
+  orderDirection?: SavedViewOrderDirection;
   showEmptyGroups: boolean;
   states: StateApiResponse[];
   cycles: CycleApiResponse[];
@@ -95,6 +109,7 @@ export function buildGroupedIssues(params: {
     baseForGrouping,
     groupBy,
     orderBy,
+    orderDirection = 'asc',
     showEmptyGroups,
     states,
     cycles,
@@ -103,7 +118,7 @@ export function buildGroupedIssues(params: {
     members,
   } = params;
 
-  const sortIn = (arr: IssueApiResponse[]) => sortIssuesByOrder([...arr], orderBy);
+  const sortIn = (arr: IssueApiResponse[]) => sortIssuesByOrder([...arr], orderBy, orderDirection);
 
   const sortedStates = [...states].sort(
     (a, b) => (a.sequence ?? 0) - (b.sequence ?? 0) || a.name.localeCompare(b.name),

--- a/apps/web/src/lib/projectSavedViewDisplay.ts
+++ b/apps/web/src/lib/projectSavedViewDisplay.ts
@@ -31,10 +31,13 @@ export type SavedViewOrderBy =
   | 'due_date'
   | 'priority';
 
+export type SavedViewOrderDirection = 'asc' | 'desc';
+
 export interface SavedViewDisplaySettings {
   displayProperties: Set<SavedViewDisplayPropertyId>;
   groupBy: SavedViewGroupBy;
   orderBy: SavedViewOrderBy;
+  orderDirection: SavedViewOrderDirection;
   showSubWorkItems: boolean;
 }
 
@@ -58,6 +61,7 @@ export const DEFAULT_SAVED_VIEW_DISPLAY: SavedViewDisplaySettings = {
   displayProperties: new Set(ALL_SAVED_VIEW_DISPLAY_PROPERTIES),
   groupBy: 'states',
   orderBy: 'manual',
+  orderDirection: 'asc',
   showSubWorkItems: false,
 };
 
@@ -66,6 +70,7 @@ export function cloneDefaultSettings(): SavedViewDisplaySettings {
     displayProperties: new Set(DEFAULT_SAVED_VIEW_DISPLAY.displayProperties),
     groupBy: DEFAULT_SAVED_VIEW_DISPLAY.groupBy,
     orderBy: DEFAULT_SAVED_VIEW_DISPLAY.orderBy,
+    orderDirection: DEFAULT_SAVED_VIEW_DISPLAY.orderDirection,
     showSubWorkItems: DEFAULT_SAVED_VIEW_DISPLAY.showSubWorkItems,
   };
 }
@@ -78,8 +83,11 @@ export interface PersistedSavedViewDisplay {
   displayProperties: string[];
   groupBy: string;
   orderBy: string;
+  orderDirection: string;
   showSubWorkItems: boolean;
 }
+
+const ORDER_DIRECTIONS: SavedViewOrderDirection[] = ['asc', 'desc'];
 
 const GROUP_OPTIONS: SavedViewGroupBy[] = [
   'states',
@@ -119,10 +127,14 @@ export function parsePersistedSavedViewDisplay(
     const orderBy = ORDER_OPTIONS.includes(p.orderBy as SavedViewOrderBy)
       ? (p.orderBy as SavedViewOrderBy)
       : 'manual';
+    const orderDirection = ORDER_DIRECTIONS.includes(p.orderDirection as SavedViewOrderDirection)
+      ? (p.orderDirection as SavedViewOrderDirection)
+      : 'asc';
     return {
       displayProperties: props.size > 0 ? props : new Set(ALL_SAVED_VIEW_DISPLAY_PROPERTIES),
       groupBy,
       orderBy,
+      orderDirection,
       showSubWorkItems: Boolean(p.showSubWorkItems),
     };
   } catch {
@@ -135,6 +147,7 @@ export function serializeSettings(s: SavedViewDisplaySettings): string {
     displayProperties: [...s.displayProperties],
     groupBy: s.groupBy,
     orderBy: s.orderBy,
+    orderDirection: s.orderDirection,
     showSubWorkItems: s.showSubWorkItems,
   });
 }

--- a/apps/web/src/pages/ViewDetailPage.tsx
+++ b/apps/web/src/pages/ViewDetailPage.tsx
@@ -25,7 +25,8 @@ import type {
   ModuleApiResponse,
 } from '../api/types';
 import type { Priority } from '../types';
-import type { SavedViewDisplayPropertyId, SavedViewOrderBy } from '../lib/projectSavedViewDisplay';
+import type { SavedViewDisplayPropertyId } from '../lib/projectSavedViewDisplay';
+import { sortIssuesByOrder } from '../lib/issueListGroupAndSort';
 import { getImageUrl } from '../lib/utils';
 import { parseWorkspaceViewFiltersFromSearchParams } from '../types/workspaceViewFilters';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -45,56 +46,6 @@ const NONE_MODULE_KEY = '__no_module__';
 const NONE_LABEL_KEY = '__no_label__';
 const NONE_ASSIGNEE_KEY = '__no_assignee__';
 const NONE_CREATOR_KEY = '__no_creator__';
-
-const PRIORITY_RANK: Record<string, number> = {
-  urgent: 0,
-  high: 1,
-  medium: 2,
-  low: 3,
-  none: 4,
-};
-
-function sortIssuesList(list: IssueApiResponse[], orderBy: SavedViewOrderBy): IssueApiResponse[] {
-  const out = [...list];
-  switch (orderBy) {
-    case 'manual':
-      return out.sort((a, b) => {
-        const so = (a.sort_order ?? 0) - (b.sort_order ?? 0);
-        if (so !== 0) return so;
-        const seq = (a.sequence_id ?? 0) - (b.sequence_id ?? 0);
-        if (seq !== 0) return seq;
-        return a.name.localeCompare(b.name);
-      });
-    case 'last_created':
-      return out.sort(
-        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-      );
-    case 'last_updated':
-      return out.sort(
-        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-      );
-    case 'start_date':
-      return out.sort((a, b) => {
-        const as = a.start_date ? new Date(a.start_date).getTime() : Infinity;
-        const bs = b.start_date ? new Date(b.start_date).getTime() : Infinity;
-        return as - bs;
-      });
-    case 'due_date':
-      return out.sort((a, b) => {
-        const ad = a.target_date ? new Date(a.target_date).getTime() : Infinity;
-        const bd = b.target_date ? new Date(b.target_date).getTime() : Infinity;
-        return ad - bd;
-      });
-    case 'priority':
-      return out.sort((a, b) => {
-        const pa = PRIORITY_RANK[a.priority ?? 'none'] ?? 99;
-        const pb = PRIORITY_RANK[b.priority ?? 'none'] ?? 99;
-        return pa - pb;
-      });
-    default:
-      return out;
-  }
-}
 
 function formatShortDate(iso: string | null | undefined): string | null {
   if (!iso?.trim()) return null;
@@ -482,7 +433,9 @@ export function ViewDetailPage() {
 
   const groupedSections: GroupedSections = useMemo(() => {
     const orderBy = settings.orderBy;
-    const sortIn = (arr: IssueApiResponse[]) => sortIssuesList([...arr], orderBy);
+    const orderDirection = settings.orderDirection;
+    const sortIn = (arr: IssueApiResponse[]) =>
+      sortIssuesByOrder([...arr], orderBy, orderDirection);
 
     const groupBy = settings.groupBy;
 
@@ -710,6 +663,7 @@ export function ViewDetailPage() {
     modules,
     settings.groupBy,
     settings.orderBy,
+    settings.orderDirection,
     sortedStates,
     states,
   ]);


### PR DESCRIPTION
## Feature summary

Adds an ascending/descending toggle to the saved-view order-by control, so the same order key can be viewed in either direction.

## Linked issues / discussion

Closes #181

## User-facing behavior

In the saved-view Display dropdown, under "Order by", there's now an Ascending / Descending toggle. Picking Descending reverses the current ordering; the choice is remembered with the rest of the display settings (persisted per view in localStorage).

## What changed

### UI (`apps/web/`)
- `projectSavedViewDisplay.ts`: new `SavedViewOrderDirection` (`'asc' | 'desc'`) on `SavedViewDisplaySettings`, wired through the defaults, clone, and the persist parse/serialize (defaults to `asc`, older persisted settings included).
- `issueListGroupAndSort.ts`: `sortIssuesByOrder` takes a `direction`; descending is the ascending result reversed, so the toggle behaves consistently for every order key. `buildGroupedIssues` accepts and forwards `orderDirection`.
- `ProjectSavedViewDisplayDropdown.tsx`: the Ascending/Descending toggle.
- `ViewDetailPage.tsx`: reuses the shared `sortIssuesByOrder` (removing a duplicate local sorter) and passes the direction.

### Database
- No schema changes.

## Why this design

Reversing the ascending result keeps the toggle predictable regardless of a key's natural direction (e.g. "last created" is newest-first ascending, oldest-first descending), and reuses one sort implementation instead of two.

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run build`, `prettier --check` all green.
- [x] Manual end-to-end on a saved view with four work items:
  1. Opened Display, Order by "Manual" (ascending) showed RKT-1, RKT-2, RKT-3, RKT-4.
  2. Clicked Descending, the list reversed to RKT-4, RKT-3, RKT-2, RKT-1 and the toggle stays selected.
- [x] Tested with both light and dark theme.

## Out of scope (follow-ups)

- The project work-items list and module pages use a separate display model; extending the toggle there can be a follow-up.

## Rollout notes

None.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] No `--no-verify` bypass
- [x] Acceptance criteria from the linked issue are all met


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an ascending/descending order toggle for saved views.
  * Issue lists now respect the selected order direction when sorting grouped sections.

* **Bug Fixes**
  * Saved view settings now consistently preserve the chosen sort direction when loading and saving.
  * Grouped issue sorting now updates correctly when the order direction changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->