### PR TITLE
feat(cycle): validate cycle/module dates and warn on overlapping cycles

### DIFF
--- a/apps/api/internal/handler/cycle.go
+++ b/apps/api/internal/handler/cycle.go
@@ -90,6 +90,10 @@ func (h *CycleHandler) Create(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 			return
 		}
+		if err == service.ErrInvalidCycleDates {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create cycle"})
 		return
 	}
@@ -172,6 +176,10 @@ func (h *CycleHandler) Update(c *gin.Context) {
 	if err != nil {
 		if err == service.ErrCycleNotFound || err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		if err == service.ErrInvalidCycleDates {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update cycle"})

--- a/apps/api/internal/handler/cycle_test.go
+++ b/apps/api/internal/handler/cycle_test.go
@@ -52,6 +52,32 @@ func TestCycle_CRUD(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, rr5.Code)
 }
 
+func TestCycle_RejectsInvalidDates(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := cycleBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// End before start is rejected on create.
+	rr := ts.POST(base, map[string]any{
+		"name":       "Backwards",
+		"start_date": "2026-02-10T00:00:00Z",
+		"end_date":   "2026-02-01T00:00:00Z",
+	}, w.Session)
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
+
+	// A valid range is accepted, then an update that inverts it is rejected.
+	ok := ts.POST(base, map[string]any{
+		"name":       "Sprint",
+		"start_date": "2026-02-01T00:00:00Z",
+		"end_date":   "2026-02-10T00:00:00Z",
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, ok.Code, "body=%s", ok.Body.String())
+	id, _ := testutil.MustJSONMap(t, ok)["id"].(string)
+
+	bad := ts.PATCH(base+id+"/", map[string]any{"end_date": "2026-01-01T00:00:00Z"}, w.Session)
+	require.Equal(t, http.StatusBadRequest, bad.Code, "body=%s", bad.Body.String())
+}
+
 func TestCycle_Issues_AddListRemove(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/apps/api/internal/handler/module.go
+++ b/apps/api/internal/handler/module.go
@@ -128,6 +128,10 @@ func (h *ModuleHandler) Create(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 			return
 		}
+		if err == service.ErrInvalidModuleDates {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create module"})
 		return
 	}
@@ -223,6 +227,10 @@ func (h *ModuleHandler) Update(c *gin.Context) {
 	if err != nil {
 		if err == service.ErrModuleNotFound || err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		if err == service.ErrInvalidModuleDates {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update module"})

--- a/apps/api/internal/handler/module_test.go
+++ b/apps/api/internal/handler/module_test.go
@@ -52,6 +52,28 @@ func TestModule_CRUD(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, rr5.Code)
 }
 
+func TestModule_RejectsInvalidDates(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := moduleBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// Target before start is rejected.
+	rr := ts.POST(base, map[string]any{
+		"name":        "Backwards",
+		"start_date":  "2026-02-10",
+		"target_date": "2026-02-01",
+	}, w.Session)
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", rr.Body.String())
+
+	// A valid range is accepted.
+	ok := ts.POST(base, map[string]any{
+		"name":        "Module",
+		"start_date":  "2026-02-01",
+		"target_date": "2026-02-10",
+	}, w.Session)
+	require.Equal(t, http.StatusCreated, ok.Code, "body=%s", ok.Body.String())
+}
+
 func TestModule_Issues_AddListRemove(t *testing.T) {
 	ts := testutil.NewTestServer(t)
 	w := testutil.SeedWorld(t, ts.DB)

--- a/apps/api/internal/service/cycle.go
+++ b/apps/api/internal/service/cycle.go
@@ -39,6 +39,20 @@ func computeCycleStatus(start, end *time.Time) string {
 
 var ErrCycleNotFound = errors.New("cycle not found")
 
+// ErrInvalidCycleDates is returned when a cycle's start date falls after its
+// end date.
+var ErrInvalidCycleDates = errors.New("cycle start date must be on or before the end date")
+
+// validateCycleDates rejects a start that falls after the end. Either date may
+// be nil (a draft or open-ended cycle); the check only applies when both are
+// set.
+func validateCycleDates(start, end *time.Time) error {
+	if start != nil && end != nil && end.Before(*start) {
+		return ErrInvalidCycleDates
+	}
+	return nil
+}
+
 // CycleService handles cycle business logic.
 type CycleService struct {
 	cs *store.CycleStore
@@ -97,6 +111,9 @@ func (s *CycleService) Create(ctx context.Context, workspaceSlug string, project
 	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
 		return nil, err
 	}
+	if err := validateCycleDates(startDate, endDate); err != nil {
+		return nil, err
+	}
 	wrk, _ := s.ws.GetBySlug(ctx, workspaceSlug)
 	cy := &model.Cycle{
 		Name:        name,
@@ -151,6 +168,9 @@ func (s *CycleService) Update(ctx context.Context, workspaceSlug string, project
 	}
 	if endDateSet {
 		cy.EndDate = endDate
+	}
+	if err := validateCycleDates(cy.StartDate, cy.EndDate); err != nil {
+		return nil, err
 	}
 	if err := s.cs.Update(ctx, cy); err != nil {
 		return nil, err

--- a/apps/api/internal/service/module.go
+++ b/apps/api/internal/service/module.go
@@ -13,6 +13,19 @@ import (
 
 var ErrModuleNotFound = errors.New("module not found")
 
+// ErrInvalidModuleDates is returned when a module's start date falls after its
+// target date.
+var ErrInvalidModuleDates = errors.New("module start date must be on or before the target date")
+
+// validateModuleDates rejects a start that falls after the target. Either date
+// may be nil; the check only applies when both are set.
+func validateModuleDates(start, target *time.Time) error {
+	if start != nil && target != nil && target.Before(*start) {
+		return ErrInvalidModuleDates
+	}
+	return nil
+}
+
 // ModuleService handles module business logic.
 type ModuleService struct {
 	ms *store.ModuleStore
@@ -79,6 +92,9 @@ func (s *ModuleService) List(ctx context.Context, workspaceSlug string, projectI
 
 func (s *ModuleService) Create(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, name, description, status string, startDate, targetDate *time.Time, leadID *uuid.UUID, memberIDs []uuid.UUID) (*model.Module, error) {
 	if err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return nil, err
+	}
+	if err := validateModuleDates(startDate, targetDate); err != nil {
 		return nil, err
 	}
 	wrk, _ := s.ws.GetBySlug(ctx, workspaceSlug)
@@ -169,6 +185,9 @@ func (s *ModuleService) Update(ctx context.Context, workspaceSlug string, projec
 	}
 	if targetDateSet {
 		mod.TargetDate = targetDate
+	}
+	if err := validateModuleDates(mod.StartDate, mod.TargetDate); err != nil {
+		return nil, err
 	}
 	if leadIDSet {
 		mod.LeadID = leadID

--- a/apps/web/src/components/CreateCycleModal.tsx
+++ b/apps/web/src/components/CreateCycleModal.tsx
@@ -7,6 +7,8 @@ import { projectService } from '../services/projectService';
 import { cycleService } from '../services/cycleService';
 import type { CycleApiResponse, ProjectApiResponse } from '../api/types';
 import { formatISODateDisplay } from '../lib/dateOnly';
+import { overlappingCycles } from '../lib/cycleOverlap';
+import { apiErrorMessage } from '../lib/apiError';
 
 const IconCalendar = () => (
   <svg
@@ -87,6 +89,7 @@ export function CreateCycleModal({
   const [description, setDescription] = useState('');
   const [startDate, setStartDate] = useState<string | null>(null);
   const [endDate, setEndDate] = useState<string | null>(null);
+  const [siblingCycles, setSiblingCycles] = useState<CycleApiResponse[]>([]);
   const [dateModalOpen, setDateModalOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -98,6 +101,26 @@ export function CreateCycleModal({
       .then((list) => setProjects(list ?? []))
       .catch(() => setProjects([]));
   }, [open, workspaceSlug]);
+
+  // Sibling cycles in the selected project, to warn (not block) on overlap.
+  useEffect(() => {
+    if (!open || !selectedProjectId) {
+      setSiblingCycles([]);
+      return;
+    }
+    let cancelled = false;
+    cycleService
+      .list(workspaceSlug, selectedProjectId)
+      .then((list) => {
+        if (!cancelled) setSiblingCycles(list ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setSiblingCycles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, workspaceSlug, selectedProjectId]);
 
   useEffect(() => {
     if (!open) {
@@ -118,6 +141,11 @@ export function CreateCycleModal({
     projects.find((p) => p.id === selectedProjectId) ??
     projects.find((p) => p.id === projectId) ??
     null;
+
+  const overlapNames = useMemo(
+    () => overlappingCycles(siblingCycles, startDate, endDate).map((c) => c.name),
+    [siblingCycles, startDate, endDate],
+  );
 
   const filteredProjects = useMemo(() => {
     const q = projectSearch.trim().toLowerCase();
@@ -143,7 +171,7 @@ export function CreateCycleModal({
       onClose();
       onCreated?.(created, selectedProjectId);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create cycle.');
+      setError(apiErrorMessage(err, 'Failed to create cycle.'));
     } finally {
       setSubmitting(false);
     }
@@ -269,6 +297,13 @@ export function CreateCycleModal({
             </span>
             {formatDateRangeDisplay(startDate, endDate)}
           </button>
+
+          {overlapNames.length > 0 && (
+            <p className="text-sm text-(--txt-warning-primary)">
+              These dates overlap {overlapNames.length === 1 ? 'the cycle' : 'cycles'}{' '}
+              {overlapNames.join(', ')}.
+            </p>
+          )}
 
           {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
         </form>

--- a/apps/web/src/components/CreateModuleModal.tsx
+++ b/apps/web/src/components/CreateModuleModal.tsx
@@ -8,6 +8,7 @@ import type { ModuleApiResponse } from '../api/types';
 import type { WorkspaceMemberApiResponse } from '../api/types';
 import { formatISODateDisplay } from '../lib/dateOnly';
 import { MODULE_STATUSES } from '../lib/moduleStatuses';
+import { apiErrorMessage } from '../lib/apiError';
 
 function formatDateRangeDisplay(start: string | null, end: string | null): string {
   if (!start && !end) return 'Start date → End date';
@@ -125,7 +126,7 @@ export function CreateModuleModal({
       onClose();
       onCreated?.(created);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create module.');
+      setError(apiErrorMessage(err, 'Failed to create module.'));
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/components/UpdateCycleModal.tsx
+++ b/apps/web/src/components/UpdateCycleModal.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Modal, Button, Input } from './ui';
 import { DateRangeModal } from './workspace-views/DateRangeModal';
 import { cycleService } from '../services/cycleService';
 import type { CycleApiResponse } from '../api/types';
 import { formatISODateDisplay } from '../lib/dateOnly';
+import { apiErrorMessage } from '../lib/apiError';
+import { overlappingCycles } from '../lib/cycleOverlap';
 
 const IconCalendar = () => (
   <svg
@@ -56,6 +58,7 @@ export function UpdateCycleModal({
   const [dateModalOpen, setDateModalOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [siblingCycles, setSiblingCycles] = useState<CycleApiResponse[]>([]);
 
   useEffect(() => {
     if (!open || !cycle) return;
@@ -66,6 +69,31 @@ export function UpdateCycleModal({
     setDateModalOpen(false);
     setError(null);
   }, [open, cycle]);
+
+  // Other cycles in the project, to warn (not block) on overlap.
+  useEffect(() => {
+    if (!open || !projectId) {
+      setSiblingCycles([]);
+      return;
+    }
+    let cancelled = false;
+    cycleService
+      .list(workspaceSlug, projectId)
+      .then((list) => {
+        if (!cancelled) setSiblingCycles(list ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setSiblingCycles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, workspaceSlug, projectId]);
+
+  const overlapNames = useMemo(
+    () => overlappingCycles(siblingCycles, startDate, endDate, cycle?.id).map((c) => c.name),
+    [siblingCycles, startDate, endDate, cycle?.id],
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -85,7 +113,7 @@ export function UpdateCycleModal({
       onClose();
       onUpdated?.(updated);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update cycle.');
+      setError(apiErrorMessage(err, 'Failed to update cycle.'));
     } finally {
       setSubmitting(false);
     }
@@ -143,6 +171,13 @@ export function UpdateCycleModal({
             </span>
             {formatDateRangeDisplay(startDate, endDate)}
           </button>
+
+          {overlapNames.length > 0 && (
+            <p className="text-sm text-(--txt-warning-primary)">
+              These dates overlap {overlapNames.length === 1 ? 'the cycle' : 'cycles'}{' '}
+              {overlapNames.join(', ')}.
+            </p>
+          )}
 
           {error && <p className="text-sm text-(--txt-danger-primary)">{error}</p>}
         </form>

--- a/apps/web/src/components/UpdateModuleModal.tsx
+++ b/apps/web/src/components/UpdateModuleModal.tsx
@@ -7,6 +7,7 @@ import { moduleService } from '../services/moduleService';
 import type { ModuleApiResponse, WorkspaceMemberApiResponse } from '../api/types';
 import { formatISODateDisplay } from '../lib/dateOnly';
 import { MODULE_STATUSES } from '../lib/moduleStatuses';
+import { apiErrorMessage } from '../lib/apiError';
 
 function formatDateRangeDisplay(start: string | null, end: string | null): string {
   if (!start && !end) return 'Start date → End date';
@@ -128,7 +129,7 @@ export function UpdateModuleModal({
       onUpdated?.(updated);
       onClose();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to update module');
+      setError(apiErrorMessage(e, 'Failed to update module.'));
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/lib/apiError.ts
+++ b/apps/web/src/lib/apiError.ts
@@ -1,0 +1,12 @@
+/**
+ * Extracts a human-readable message from an axios-style API error. The API
+ * returns `{ "error": "..." }` on failure, so surface that when present and
+ * fall back to a caller-supplied message otherwise (e.g. network errors).
+ */
+export function apiErrorMessage(err: unknown, fallback: string): string {
+  const data = (err as { response?: { data?: { error?: unknown } } })?.response?.data;
+  if (data && typeof data.error === 'string' && data.error.trim()) {
+    return data.error;
+  }
+  return fallback;
+}

--- a/apps/web/src/lib/cycleOverlap.ts
+++ b/apps/web/src/lib/cycleOverlap.ts
@@ -1,0 +1,33 @@
+import type { CycleApiResponse } from '../api/types';
+
+/** True when two closed date ranges overlap. Parses to timestamps so it is
+ *  safe across date-only and full-timestamp string formats. */
+function rangesOverlap(aStart: string, aEnd: string, bStart: string, bEnd: string): boolean {
+  const as = Date.parse(aStart);
+  const ae = Date.parse(aEnd);
+  const bs = Date.parse(bStart);
+  const be = Date.parse(bEnd);
+  if ([as, ae, bs, be].some(Number.isNaN)) return false;
+  return as <= be && bs <= ae;
+}
+
+/**
+ * Cycles whose date range overlaps [start, end], excluding the cycle with id
+ * `excludeId`. Cycles missing either date are ignored. Used to warn (not block)
+ * about overlapping cycles in the same project.
+ */
+export function overlappingCycles(
+  cycles: CycleApiResponse[],
+  start: string | null,
+  end: string | null,
+  excludeId?: string,
+): CycleApiResponse[] {
+  if (!start || !end) return [];
+  return cycles.filter(
+    (c) =>
+      c.id !== excludeId &&
+      !!c.start_date &&
+      !!c.end_date &&
+      rangesOverlap(start, end, c.start_date, c.end_date),
+  );
+}


### PR DESCRIPTION
## Feature summary

Cycle and module dates are now validated (start must be on or before the end/target), and creating or editing a cycle warns when its range overlaps another cycle in the same project.

## Linked issues / discussion

Closes #186

## User-facing behavior

- Saving a cycle or module with a start date after its end/target date is rejected with a clear message shown in the modal.
- In the cycle create/update modal, choosing a range that overlaps an existing cycle shows a non-blocking warning naming the overlapping cycle(s). It does not prevent saving, since overlapping cycles are sometimes intentional.

## What changed

### API (`apps/api/`)
- `service/cycle.go`, `service/module.go`: `validateCycleDates` / `validateModuleDates` reject start-after-end on create and update (`ErrInvalidCycleDates` / `ErrInvalidModuleDates`).
- `handler/cycle.go`, `handler/module.go`: map those to `400` with the message.

### UI (`apps/web/`)
- `lib/apiError.ts`: shared helper to surface the server's `{ "error": ... }` message; wired into the cycle and module create/update modals.
- `lib/cycleOverlap.ts`: `overlappingCycles` helper (timestamp-based range check).
- `CreateCycleModal` / `UpdateCycleModal`: load the project's cycles and show the overlap warning (update excludes the cycle being edited).

### Database
- No schema changes.

## Why this design

Start-after-end is always invalid, so it is a hard 400. Overlap is a warning rather than a block because overlapping cycles can be legitimate; the check is done against the project's cycles the modal already loads, so no new endpoint is needed.

## Test plan

- [x] `go vet ./...` and full `go test ./...` green (testcontainers).
- [x] `npm run typecheck`, `npm run lint`, `npm run build`, `prettier --check` green.
- [x] New Go tests: `TestCycle_RejectsInvalidDates`, `TestModule_RejectsInvalidDates` (400 on inverted dates, 201 on valid).
- [x] Manual: seeded a cycle Mar 1-10, opened the create-cycle modal with an overlapping range, and saw "These dates overlap the cycle Sprint A." with the save button still enabled.

## Out of scope (follow-ups)

- Overlap warning for modules (modules can overlap freely by design; not requested).

## Rollout notes

None.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] Trailing slashes on new routes match neighboring routes
- [x] No `--no-verify` bypass
- [x] Acceptance criteria from the linked issue are all met


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date-range validation for cycles and modules on create and update.
  * Cycle forms now show a non-blocking warning when the selected dates overlap existing cycles.
  * Improved API error messages shown in the cycle and module forms.

* **Bug Fixes**
  * Invalid date ranges now return a clear client-facing error instead of a generic failure.
  * Added coverage for invalid date handling in cycle and module workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->