### PR TITLE
fix(docs): use dark/light-aware star-history chart embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ AI-assisted contributions are accepted, but must be disclosed — note the tool 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Devlaner/devlane&type=date&legend=top-left)](https://www.star-history.com/#Devlaner/devlane&type=date&legend=top-left)
+<a href="https://www.star-history.com/?repos=Devlaner%2Fdevlane&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Devlaner/devlane&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Devlaner/devlane&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Devlaner/devlane&type=date&legend=top-left" />
+  </picture>
+</a>
 
 ## License
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History display to use a responsive embed that adapts to light and dark themes.
  * Improved fallback behavior so the chart still displays consistently across different devices and browser settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->