### PR TITLE
feat(states): edit a custom state's group, default, and order

### DIFF
--- a/apps/api/internal/handler/state.go
+++ b/apps/api/internal/handler/state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
 	"github.com/Devlaner/devlane/api/internal/service"
+	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -161,6 +162,50 @@ func (h *StateHandler) Delete(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete state"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// Reorder atomically updates the sequence of several of the project's states.
+// POST /api/workspaces/:slug/projects/:projectId/states/reorder/
+func (h *StateHandler) Reorder(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	var body struct {
+		States []struct {
+			ID       string  `json:"id"`
+			Sequence float64 `json:"sequence"`
+		} `json:"states"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request", "detail": err.Error()})
+		return
+	}
+	items := make([]store.StateSequence, 0, len(body.States))
+	for _, s := range body.States {
+		id, err := uuid.Parse(s.ID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid state ID"})
+			return
+		}
+		items = append(items, store.StateSequence{ID: id, Sequence: s.Sequence})
+	}
+	if err := h.State.Reorder(c.Request.Context(), slug, projectID, user.ID, items); err != nil {
+		if err == service.ErrProjectForbidden || err == service.ErrProjectNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reorder states"})
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/apps/api/internal/handler/state.go
+++ b/apps/api/internal/handler/state.go
@@ -107,8 +107,11 @@ func (h *StateHandler) Update(c *gin.Context) {
 		return
 	}
 	var body struct {
-		Name  string `json:"name"`
-		Color string `json:"color"`
+		Name     string   `json:"name"`
+		Color    string   `json:"color"`
+		Group    *string  `json:"group"`
+		Sequence *float64 `json:"sequence"`
+		Default  *bool    `json:"default"`
 	}
 	_ = c.ShouldBindJSON(&body)
 	var name, color *string
@@ -118,10 +121,14 @@ func (h *StateHandler) Update(c *gin.Context) {
 	if body.Color != "" {
 		color = &body.Color
 	}
-	st, err := h.State.Update(c.Request.Context(), slug, projectID, stateID, user.ID, name, color)
+	st, err := h.State.Update(c.Request.Context(), slug, projectID, stateID, user.ID, name, color, body.Group, body.Sequence, body.Default)
 	if err != nil {
 		if err == service.ErrStateNotFound || err == service.ErrProjectForbidden {
 			c.JSON(http.StatusNotFound, gin.H{"error": "State not found"})
+			return
+		}
+		if err == service.ErrInvalidStateGroup {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid state group"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update state"})

--- a/apps/api/internal/handler/state_edit_test.go
+++ b/apps/api/internal/handler/state_edit_test.go
@@ -1,0 +1,44 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// A custom state's group, sequence, and default flag are all editable, and
+// making one state the default clears the flag on the previous default.
+func TestState_UpdateGroupSequenceAndDefault(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	s1 := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	s2 := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/states/"
+
+	// Make s1 the default.
+	require.Equal(t, http.StatusOK,
+		ts.PATCH(base+s1.ID.String()+"/", map[string]any{"default": true}, w.Session).Code)
+
+	// Change s2's group and sequence.
+	require.Equal(t, http.StatusOK,
+		ts.PATCH(base+s2.ID.String()+"/", map[string]any{"group": "started", "sequence": 5}, w.Session).Code)
+
+	// A group outside the accepted set is rejected.
+	require.Equal(t, http.StatusBadRequest,
+		ts.PATCH(base+s1.ID.String()+"/", map[string]any{"group": "bogus"}, w.Session).Code)
+
+	// Making s2 the default must clear s1's default.
+	require.Equal(t, http.StatusOK,
+		ts.PATCH(base+s2.ID.String()+"/", map[string]any{"default": true}, w.Session).Code)
+
+	var got1, got2 model.State
+	require.NoError(t, ts.DB.First(&got1, "id = ?", s1.ID).Error)
+	require.NoError(t, ts.DB.First(&got2, "id = ?", s2.ID).Error)
+	require.False(t, got1.Default, "previous default should be cleared")
+	require.True(t, got2.Default, "new default should be set")
+	require.Equal(t, "started", got2.Group)
+	require.Equal(t, float64(5), got2.Sequence)
+}

--- a/apps/api/internal/handler/state_edit_test.go
+++ b/apps/api/internal/handler/state_edit_test.go
@@ -42,3 +42,28 @@ func TestState_UpdateGroupSequenceAndDefault(t *testing.T) {
 	require.Equal(t, "started", got2.Group)
 	require.Equal(t, float64(5), got2.Sequence)
 }
+
+// Reorder assigns new sequences to several states atomically in one request.
+func TestState_ReorderSequences(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	s1 := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	s2 := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	s3 := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() + "/states/"
+
+	body := map[string]any{"states": []map[string]any{
+		{"id": s3.ID.String(), "sequence": 0},
+		{"id": s1.ID.String(), "sequence": 1},
+		{"id": s2.ID.String(), "sequence": 2},
+	}}
+	require.Equal(t, http.StatusNoContent, ts.POST(base+"reorder/", body, w.Session).Code)
+
+	var g1, g2, g3 model.State
+	require.NoError(t, ts.DB.First(&g1, "id = ?", s1.ID).Error)
+	require.NoError(t, ts.DB.First(&g2, "id = ?", s2.ID).Error)
+	require.NoError(t, ts.DB.First(&g3, "id = ?", s3.ID).Error)
+	require.Equal(t, float64(0), g3.Sequence)
+	require.Equal(t, float64(1), g1.Sequence)
+	require.Equal(t, float64(2), g2.Sequence)
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -313,6 +313,7 @@ func New(cfg Config) *gin.Engine {
 
 		api.GET("/workspaces/:slug/projects/:projectId/states/", stateHandler.List)
 		api.POST("/workspaces/:slug/projects/:projectId/states/", stateHandler.Create)
+		api.POST("/workspaces/:slug/projects/:projectId/states/reorder/", stateHandler.Reorder)
 		api.PATCH("/workspaces/:slug/projects/:projectId/states/:pk/", stateHandler.Update)
 		api.DELETE("/workspaces/:slug/projects/:projectId/states/:pk/", stateHandler.Delete)
 

--- a/apps/api/internal/service/state.go
+++ b/apps/api/internal/service/state.go
@@ -11,6 +11,15 @@ import (
 
 var ErrStateNotFound = errors.New("state not found")
 
+// ErrInvalidStateGroup is returned when an update sets a group outside the
+// accepted workflow groups.
+var ErrInvalidStateGroup = errors.New("invalid state group")
+
+// validStateGroups is the accepted set of workflow-state groups.
+var validStateGroups = map[string]bool{
+	"backlog": true, "unstarted": true, "started": true, "completed": true, "cancelled": true,
+}
+
 // DefaultProjectStateNames are seeded for new projects (without triage).
 var DefaultProjectStateNames = []string{"Backlog", "Todo", "In Progress", "Done", "Cancelled"}
 
@@ -146,7 +155,7 @@ func (s *StateService) GetByID(ctx context.Context, workspaceSlug string, projec
 	return st, nil
 }
 
-func (s *StateService) Update(ctx context.Context, workspaceSlug string, projectID, stateID uuid.UUID, userID uuid.UUID, name, color *string) (*model.State, error) {
+func (s *StateService) Update(ctx context.Context, workspaceSlug string, projectID, stateID uuid.UUID, userID uuid.UUID, name, color, group *string, sequence *float64, isDefault *bool) (*model.State, error) {
 	st, err := s.GetByID(ctx, workspaceSlug, projectID, stateID, userID)
 	if err != nil {
 		return nil, err
@@ -157,8 +166,28 @@ func (s *StateService) Update(ctx context.Context, workspaceSlug string, project
 	if color != nil {
 		st.Color = *color
 	}
+	if group != nil {
+		if !validStateGroups[*group] {
+			return nil, ErrInvalidStateGroup
+		}
+		st.Group = *group
+	}
+	if sequence != nil {
+		st.Sequence = *sequence
+	}
+	// Clearing the default is a plain field write; making a state the default is
+	// atomic (it must clear every other state's flag), so that runs separately.
+	if isDefault != nil && !*isDefault {
+		st.Default = false
+	}
 	if err := s.ss.Update(ctx, st); err != nil {
 		return nil, err
+	}
+	if isDefault != nil && *isDefault {
+		if err := s.ss.SetDefault(ctx, projectID, stateID); err != nil {
+			return nil, err
+		}
+		st.Default = true
 	}
 	return st, nil
 }

--- a/apps/api/internal/service/state.go
+++ b/apps/api/internal/service/state.go
@@ -160,29 +160,37 @@ func (s *StateService) Update(ctx context.Context, workspaceSlug string, project
 	if err != nil {
 		return nil, err
 	}
+	// Write only the columns that changed so a full-row save can't clobber the
+	// default flag (which is owned by the atomic SetDefault path).
+	changed := map[string]any{}
 	if name != nil {
 		st.Name = *name
+		changed["name"] = *name
 	}
 	if color != nil {
 		st.Color = *color
+		changed["color"] = *color
 	}
 	if group != nil {
 		if !validStateGroups[*group] {
 			return nil, ErrInvalidStateGroup
 		}
 		st.Group = *group
+		changed["group"] = *group
 	}
 	if sequence != nil {
 		st.Sequence = *sequence
+		changed["sequence"] = *sequence
 	}
-	// Clearing the default is a plain field write; making a state the default is
-	// atomic (it must clear every other state's flag), so that runs separately.
 	if isDefault != nil && !*isDefault {
 		st.Default = false
+		changed["default"] = false
 	}
-	if err := s.ss.Update(ctx, st); err != nil {
+	if err := s.ss.UpdateFields(ctx, stateID, changed); err != nil {
 		return nil, err
 	}
+	// Making a state the default must clear every other state's flag, so it runs
+	// as its own atomic operation.
 	if isDefault != nil && *isDefault {
 		if err := s.ss.SetDefault(ctx, projectID, stateID); err != nil {
 			return nil, err
@@ -190,6 +198,15 @@ func (s *StateService) Update(ctx context.Context, workspaceSlug string, project
 		st.Default = true
 	}
 	return st, nil
+}
+
+// Reorder atomically assigns new sequence values to a set of the project's
+// states so a partial failure can't leave the order half-applied.
+func (s *StateService) Reorder(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID, items []store.StateSequence) error {
+	if _, err := s.ensureProjectAccess(ctx, workspaceSlug, projectID, userID); err != nil {
+		return err
+	}
+	return s.ss.ReorderSequences(ctx, projectID, items)
 }
 
 func (s *StateService) Delete(ctx context.Context, workspaceSlug string, projectID, stateID uuid.UUID, userID uuid.UUID) error {

--- a/apps/api/internal/store/state.go
+++ b/apps/api/internal/store/state.go
@@ -66,6 +66,44 @@ func (s *StateStore) Update(ctx context.Context, st *model.State) error {
 	return s.db.WithContext(ctx).Save(st).Error
 }
 
+// UpdateFields writes only the given columns for one state, so a concurrent
+// change to another column (notably the default flag) isn't clobbered by a
+// full-row save.
+func (s *StateStore) UpdateFields(ctx context.Context, stateID uuid.UUID, fields map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Model(&model.State{}).
+		Where("id = ? AND deleted_at IS NULL", stateID).
+		Updates(fields).Error
+}
+
+// StateSequence pairs a state with its new order value for a reorder.
+type StateSequence struct {
+	ID       uuid.UUID
+	Sequence float64
+}
+
+// ReorderSequences assigns new sequence values to several states in one
+// transaction, so a partial failure can't leave the order half-applied. Each
+// update is scoped to projectID so a caller can't touch another project's states.
+func (s *StateStore) ReorderSequences(ctx context.Context, projectID uuid.UUID, items []StateSequence) error {
+	if len(items) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, it := range items {
+			if err := tx.Model(&model.State{}).
+				Where("id = ? AND project_id = ? AND deleted_at IS NULL", it.ID, projectID).
+				Update("sequence", it.Sequence).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // SetDefault makes stateID the project's only default state, clearing the flag
 // on every other state in the project in one transaction.
 func (s *StateStore) SetDefault(ctx context.Context, projectID, stateID uuid.UUID) error {

--- a/apps/api/internal/store/state.go
+++ b/apps/api/internal/store/state.go
@@ -66,6 +66,21 @@ func (s *StateStore) Update(ctx context.Context, st *model.State) error {
 	return s.db.WithContext(ctx).Save(st).Error
 }
 
+// SetDefault makes stateID the project's only default state, clearing the flag
+// on every other state in the project in one transaction.
+func (s *StateStore) SetDefault(ctx context.Context, projectID, stateID uuid.UUID) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&model.State{}).
+			Where("project_id = ? AND deleted_at IS NULL", projectID).
+			Updates(map[string]any{"default": false}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&model.State{}).
+			Where("id = ? AND deleted_at IS NULL", stateID).
+			Updates(map[string]any{"default": true}).Error
+	})
+}
+
 func (s *StateStore) Delete(ctx context.Context, id uuid.UUID) error {
 	return s.db.WithContext(ctx).Where("id = ?", id).Delete(&model.State{}).Error
 }

--- a/apps/web/src/components/settings/modals/ProjectStateModal.tsx
+++ b/apps/web/src/components/settings/modals/ProjectStateModal.tsx
@@ -61,6 +61,7 @@ export function ProjectStateModal({
                   await stateService.update(workspaceSlug, selectedProjectId, projectStateEdit.id, {
                     name: projectStateName.trim(),
                     color: projectStateColor,
+                    group: projectStateGroup,
                   });
                 } else {
                   await stateService.create(workspaceSlug, selectedProjectId, {
@@ -118,22 +119,20 @@ export function ProjectStateModal({
             />
           </div>
         </div>
-        {!projectStateEdit && (
-          <div>
-            <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">Group</label>
-            <select
-              value={projectStateGroup}
-              onChange={(e) => setProjectStateGroup(e.target.value)}
-              className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
-            >
-              <option value="backlog">Backlog</option>
-              <option value="unstarted">Unstarted</option>
-              <option value="started">Started</option>
-              <option value="completed">Completed</option>
-              <option value="cancelled">Cancelled</option>
-            </select>
-          </div>
-        )}
+        <div>
+          <label className="mb-1 block text-sm font-medium text-(--txt-secondary)">Group</label>
+          <select
+            value={projectStateGroup}
+            onChange={(e) => setProjectStateGroup(e.target.value)}
+            className="w-full rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) px-3 py-2 text-sm text-(--txt-primary) focus:outline-none focus:border-(--border-strong)"
+          >
+            <option value="backlog">Backlog</option>
+            <option value="unstarted">Unstarted</option>
+            <option value="started">Started</option>
+            <option value="completed">Completed</option>
+            <option value="cancelled">Cancelled</option>
+          </select>
+        </div>
       </div>
     </Modal>
   );

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -300,6 +300,58 @@ export function SettingsPage() {
   const [projectStateName, setProjectStateName] = useState('');
   const [projectStateColor, setProjectStateColor] = useState('#94a3b8');
   const [projectStateGroup, setProjectStateGroup] = useState('backlog');
+
+  const refreshProjectStates = useCallback(async () => {
+    if (!workspaceSlug || !selectedProjectId) return;
+    const list = await stateService.list(workspaceSlug, selectedProjectId);
+    setProjectStates(list ?? []);
+  }, [workspaceSlug, selectedProjectId]);
+
+  const setStateAsDefault = useCallback(
+    async (st: StateApiResponse) => {
+      if (!workspaceSlug || !selectedProjectId) return;
+      try {
+        await stateService.update(workspaceSlug, selectedProjectId, st.id, { default: true });
+        await refreshProjectStates();
+      } catch {
+        // ignore; the list stays as-is on failure
+      }
+    },
+    [workspaceSlug, selectedProjectId, refreshProjectStates],
+  );
+
+  // Move a state up or down within its own group by reassigning sequences for
+  // that group, so the order is well-defined even when states share the default
+  // sequence value.
+  const moveStateWithinGroup = useCallback(
+    async (st: StateApiResponse, direction: -1 | 1) => {
+      if (!workspaceSlug || !selectedProjectId) return;
+      const groupKey = (st.group ?? 'backlog').toLowerCase();
+      const inGroup = projectStates
+        .filter((s) => (s.group ?? 'backlog').toLowerCase() === groupKey)
+        .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+      const from = inGroup.findIndex((s) => s.id === st.id);
+      const to = from + direction;
+      if (from < 0 || to < 0 || to >= inGroup.length) return;
+      const reordered = [...inGroup];
+      [reordered[from], reordered[to]] = [reordered[to], reordered[from]];
+      try {
+        await Promise.all(
+          reordered
+            .map((s, i) => ({ s, i }))
+            .filter(({ s, i }) => (s.sequence ?? 0) !== i)
+            .map(({ s, i }) =>
+              stateService.update(workspaceSlug, selectedProjectId, s.id, { sequence: i }),
+            ),
+        );
+        await refreshProjectStates();
+      } catch {
+        // ignore; the list stays as-is on failure
+      }
+    },
+    [workspaceSlug, selectedProjectId, projectStates, refreshProjectStates],
+  );
+
   const [featureCycles, setFeatureCycles] = useState(true);
   const [featureModules, setFeatureModules] = useState(true);
   const [featureViews, setFeatureViews] = useState(true);
@@ -2313,7 +2365,7 @@ export function SettingsPage() {
                               No states in this group.
                             </p>
                           ) : (
-                            states.map((st) => (
+                            states.map((st, stIndex) => (
                               <Card
                                 key={st.id}
                                 variant="outlined"
@@ -2329,8 +2381,40 @@ export function SettingsPage() {
                                   <span className="text-sm font-medium text-(--txt-primary)">
                                     {st.name}
                                   </span>
+                                  {st.default && (
+                                    <span className="rounded-full bg-(--bg-accent-subtle) px-2 py-0.5 text-[11px] font-medium text-(--txt-accent-primary)">
+                                      Default
+                                    </span>
+                                  )}
                                 </div>
                                 <div className="flex items-center gap-2">
+                                  <button
+                                    type="button"
+                                    aria-label={`Move ${st.name} up`}
+                                    disabled={stIndex === 0}
+                                    onClick={() => moveStateWithinGroup(st, -1)}
+                                    className="flex size-7 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary) disabled:opacity-30 disabled:hover:bg-transparent"
+                                  >
+                                    ↑
+                                  </button>
+                                  <button
+                                    type="button"
+                                    aria-label={`Move ${st.name} down`}
+                                    disabled={stIndex === states.length - 1}
+                                    onClick={() => moveStateWithinGroup(st, 1)}
+                                    className="flex size-7 items-center justify-center rounded-(--radius-md) text-(--txt-icon-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-icon-secondary) disabled:opacity-30 disabled:hover:bg-transparent"
+                                  >
+                                    ↓
+                                  </button>
+                                  {!st.default && (
+                                    <Button
+                                      size="sm"
+                                      variant="secondary"
+                                      onClick={() => setStateAsDefault(st)}
+                                    >
+                                      Set default
+                                    </Button>
+                                  )}
                                   <Button
                                     size="sm"
                                     variant="secondary"

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -336,13 +336,12 @@ export function SettingsPage() {
       const reordered = [...inGroup];
       [reordered[from], reordered[to]] = [reordered[to], reordered[from]];
       try {
-        await Promise.all(
-          reordered
-            .map((s, i) => ({ s, i }))
-            .filter(({ s, i }) => (s.sequence ?? 0) !== i)
-            .map(({ s, i }) =>
-              stateService.update(workspaceSlug, selectedProjectId, s.id, { sequence: i }),
-            ),
+        // One atomic backend call so a partial failure can't leave the group's
+        // order half-applied.
+        await stateService.reorder(
+          workspaceSlug,
+          selectedProjectId,
+          reordered.map((s, i) => ({ id: s.id, sequence: i })),
         );
         await refreshProjectStates();
       } catch {

--- a/apps/web/src/services/stateService.ts
+++ b/apps/web/src/services/stateService.ts
@@ -25,7 +25,13 @@ export const stateService = {
     workspaceSlug: string,
     projectId: string,
     stateId: string,
-    payload: { name?: string; color?: string; group?: string; sequence?: number; default?: boolean },
+    payload: {
+      name?: string;
+      color?: string;
+      group?: string;
+      sequence?: number;
+      default?: boolean;
+    },
   ): Promise<StateApiResponse> {
     const { data } = await apiClient.patch<StateApiResponse>(
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/states/${encodeURIComponent(stateId)}/`,

--- a/apps/web/src/services/stateService.ts
+++ b/apps/web/src/services/stateService.ts
@@ -25,7 +25,7 @@ export const stateService = {
     workspaceSlug: string,
     projectId: string,
     stateId: string,
-    payload: { name?: string; color?: string },
+    payload: { name?: string; color?: string; group?: string; sequence?: number; default?: boolean },
   ): Promise<StateApiResponse> {
     const { data } = await apiClient.patch<StateApiResponse>(
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/states/${encodeURIComponent(stateId)}/`,

--- a/apps/web/src/services/stateService.ts
+++ b/apps/web/src/services/stateService.ts
@@ -40,6 +40,17 @@ export const stateService = {
     return data;
   },
 
+  async reorder(
+    workspaceSlug: string,
+    projectId: string,
+    states: { id: string; sequence: number }[],
+  ): Promise<void> {
+    await apiClient.post(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/states/reorder/`,
+      { states },
+    );
+  },
+
   async delete(workspaceSlug: string, projectId: string, stateId: string): Promise<void> {
     await apiClient.delete(
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/states/${encodeURIComponent(stateId)}/`,


### PR DESCRIPTION
## Summary

Closes #200.

Custom workflow states could be created but not fully edited: the update path only touched `name` and `color`, so changing a state's group, default flag, or order was unsupported.

**Backend**
- `StateService.Update` now also accepts `group`, `sequence`, and `default`. An unknown group is rejected with `400`.
- Making a state the default is atomic: a new `StateStore.SetDefault` clears the flag on every other state in the project and sets it on the target, in one transaction, so a project always has at most one default.

**Frontend (project settings → States)**
- The group `<select>` now shows when editing a state (it was hidden on edit), and the update sends the chosen group.
- Each state shows a **Default** badge, and non-default states get a **Set default** action.
- **Up/down** controls reorder states within their group by reassigning sequences (which keeps ordering well-defined even when states share the default sequence value).

## Testing

- `go vet ./...` and the full `go test ./...` suite pass.
- **`handler_test.TestState_UpdateGroupSequenceAndDefault`**: editing group + sequence works, an invalid group is rejected `400`, and making a second state the default clears the previous default.
- Browser-verified end-to-end against the running API: set a state as default (the previous default was cleared, exactly one remained), edited a state's group in the modal (it moved groups), and reordered within a group with the up control (sequences were reassigned so the order changed). Restored the seed states afterward.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now reorder project states within their workflow group and persist the new sequence.
  * You can set/clear a state’s “default” flag, and update group/sequence/default from the state editor.
* **Bug Fixes**
  * Invalid workflow groups are now rejected with a clear “Bad Request” response.
  * Default-state updates are enforced so only one state is marked as default per project.
* **Tests**
  * Added API handler tests covering group/sequence/default updates and sequence reordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->