### PR TITLE
feat(issues): description version history with restore

### DIFF
--- a/apps/api/internal/handler/issue.go
+++ b/apps/api/internal/handler/issue.go
@@ -357,6 +357,71 @@ func (h *IssueHandler) ListAssignees(c *gin.Context) {
 	c.JSON(http.StatusOK, ids)
 }
 
+// ListDescriptionVersions returns the issue's description history (newest first).
+// GET /api/workspaces/:slug/projects/:projectId/issues/:pk/description-versions/
+func (h *IssueHandler) ListDescriptionVersions(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	issueID, ok := issueID(c)
+	if !ok {
+		return
+	}
+	versions, err := h.Issue.ListDescriptionVersions(c.Request.Context(), slug, projectID, issueID, user.ID)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Issue not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list description versions"})
+		return
+	}
+	c.JSON(http.StatusOK, versions)
+}
+
+// RestoreDescriptionVersion sets the issue description back to a past version.
+// POST /api/workspaces/:slug/projects/:projectId/issues/:pk/description-versions/:versionId/restore/
+func (h *IssueHandler) RestoreDescriptionVersion(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	projectID, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+		return
+	}
+	issueID, ok := issueID(c)
+	if !ok {
+		return
+	}
+	versionID, err := uuid.Parse(c.Param("versionId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid version ID"})
+		return
+	}
+	issue, err := h.Issue.RestoreDescriptionVersion(c.Request.Context(), slug, projectID, issueID, versionID, user.ID)
+	if err != nil {
+		if err == service.ErrIssueNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Issue not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to restore description version"})
+		return
+	}
+	c.JSON(http.StatusOK, issue)
+}
+
 // AddAssignee adds an assignee to the issue.
 // POST /api/workspaces/:slug/projects/:projectId/issues/:pk/assignees/
 func (h *IssueHandler) AddAssignee(c *gin.Context) {

--- a/apps/api/internal/handler/issue_description_version_test.go
+++ b/apps/api/internal/handler/issue_description_version_test.go
@@ -1,0 +1,50 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Editing a work item's description records a version of the previous text, the
+// history lists them newest-first, and restoring an older version reverts the
+// description (snapshotting the current one first so the restore is undoable).
+func TestIssue_DescriptionVersionHistoryAndRestore(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, w.Project.ID, w.Workspace.ID, w.User.ID)
+
+	base := "/api/workspaces/" + w.Workspace.Slug + "/projects/" + w.Project.ID.String() +
+		"/issues/" + issue.ID.String() + "/"
+	versionsURL := base + "description-versions/"
+
+	// First edit: snapshots the empty original. Second edit: snapshots "v1".
+	require.Equal(t, http.StatusOK, ts.PATCH(base, map[string]any{"description": "<p>v1</p>"}, w.Session).Code)
+	require.Equal(t, http.StatusOK, ts.PATCH(base, map[string]any{"description": "<p>v2</p>"}, w.Session).Code)
+
+	var versions []model.IssueDescriptionVersion
+	rr := ts.GET(versionsURL, w.Session)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &versions))
+	require.Len(t, versions, 2, "two edits should leave two prior-description snapshots")
+	require.Equal(t, "<p>v1</p>", versions[0].DescriptionHTML, "newest snapshot is the pre-v2 text")
+
+	// Restore the v1 snapshot; the description reverts and the current v2 is kept.
+	restoreURL := versionsURL + versions[0].ID.String() + "/restore/"
+	require.Equal(t, http.StatusOK, ts.POST(restoreURL, nil, w.Session).Code)
+
+	var got model.Issue
+	require.NoError(t, ts.DB.First(&got, "id = ?", issue.ID).Error)
+	require.Equal(t, "<p>v1</p>", got.DescriptionHTML, "restore should revert the description")
+
+	// The pre-restore v2 was snapshotted, so history now has three entries.
+	rr2 := ts.GET(versionsURL, w.Session)
+	var versions2 []model.IssueDescriptionVersion
+	require.NoError(t, json.Unmarshal(rr2.Body.Bytes(), &versions2))
+	require.Len(t, versions2, 3)
+	require.Equal(t, "<p>v2</p>", versions2[0].DescriptionHTML, "restore snapshots the replaced text")
+}

--- a/apps/api/internal/model/issue_description_version.go
+++ b/apps/api/internal/model/issue_description_version.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// IssueDescriptionVersion is an immutable snapshot of a work item's description,
+// recorded whenever the description changes so users can browse history and
+// restore an earlier version. Matches the issue_description_versions table.
+type IssueDescriptionVersion struct {
+	ID              uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	IssueID         uuid.UUID  `gorm:"type:uuid;not null" json:"issue_id"`
+	DescriptionHTML string     `gorm:"column:description_html;type:text" json:"description_html"`
+	CreatedByID     *uuid.UUID `gorm:"type:uuid" json:"created_by_id,omitempty"`
+	OwnedByID       *uuid.UUID `gorm:"type:uuid" json:"owned_by_id,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+}
+
+func (IssueDescriptionVersion) TableName() string { return "issue_description_versions" }
+
+func (v *IssueDescriptionVersion) BeforeCreate(tx *gorm.DB) error {
+	if v.ID == uuid.Nil {
+		v.ID = uuid.New()
+	}
+	return nil
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -336,6 +336,8 @@ func New(cfg Config) *gin.Engine {
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/assignees/", issueHandler.AddAssignee)
 		api.PUT("/workspaces/:slug/projects/:projectId/issues/:pk/assignees/", issueHandler.ReplaceAssignees)
 		api.DELETE("/workspaces/:slug/projects/:projectId/issues/:pk/assignees/:assigneeId/", issueHandler.RemoveAssignee)
+		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/description-versions/", issueHandler.ListDescriptionVersions)
+		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/description-versions/:versionId/restore/", issueHandler.RestoreDescriptionVersion)
 		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/activities/", issueHandler.ListActivities)
 		api.GET("/workspaces/:slug/projects/:projectId/issues/:pk/issue-relation/", issueHandler.ListRelations)
 		api.POST("/workspaces/:slug/projects/:projectId/issues/:pk/issue-relation/", issueHandler.CreateRelations)

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -739,6 +739,14 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 				s.notify.IssueMentioned(ctx, issue, userID, added, "description")
 			}
 		}
+		// Snapshot the pre-edit description so history can be browsed and restored.
+		// Fire-and-forget: a version write must not fail the update.
+		_ = s.is.CreateDescriptionVersion(ctx, &model.IssueDescriptionVersion{
+			IssueID:         issue.ID,
+			DescriptionHTML: prevDescription,
+			CreatedByID:     &userID,
+			OwnedByID:       &userID,
+		})
 	}
 
 	if assigneeIDs != nil {
@@ -819,6 +827,43 @@ func (s *IssueService) ListAssignees(ctx context.Context, workspaceSlug string, 
 		return nil, err
 	}
 	return s.is.ListAssigneesForIssue(ctx, issueID)
+}
+
+// ListDescriptionVersions returns the issue's description history (newest first).
+func (s *IssueService) ListDescriptionVersions(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID) ([]model.IssueDescriptionVersion, error) {
+	if _, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID); err != nil {
+		return nil, err
+	}
+	return s.is.ListDescriptionVersions(ctx, issueID)
+}
+
+// RestoreDescriptionVersion sets the issue's description back to a past version.
+// The current description is snapshotted first so a restore is itself undoable.
+func (s *IssueService) RestoreDescriptionVersion(ctx context.Context, workspaceSlug string, projectID, issueID, versionID uuid.UUID, userID uuid.UUID) (*model.Issue, error) {
+	issue, err := s.GetByID(ctx, workspaceSlug, projectID, issueID, userID)
+	if err != nil {
+		return nil, err
+	}
+	version, err := s.is.GetDescriptionVersion(ctx, versionID)
+	if err != nil || version.IssueID != issue.ID {
+		return nil, ErrIssueNotFound
+	}
+	if version.DescriptionHTML == issue.DescriptionHTML {
+		return issue, nil // nothing to restore
+	}
+	// Snapshot the current description before overwriting it.
+	_ = s.is.CreateDescriptionVersion(ctx, &model.IssueDescriptionVersion{
+		IssueID:         issue.ID,
+		DescriptionHTML: issue.DescriptionHTML,
+		CreatedByID:     &userID,
+		OwnedByID:       &userID,
+	})
+	issue.DescriptionHTML = version.DescriptionHTML
+	issue.UpdatedByID = &userID
+	if err := s.is.Update(ctx, issue); err != nil {
+		return nil, err
+	}
+	return issue, nil
 }
 
 func (s *IssueService) AddAssignee(ctx context.Context, workspaceSlug string, projectID, issueID uuid.UUID, userID uuid.UUID, assigneeID uuid.UUID) error {

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -678,6 +678,19 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 	if sortOrder != nil {
 		issue.SortOrder = *sortOrder
 	}
+	// Snapshot the previous description before it's overwritten, so the history
+	// is complete and recoverable. Done before the save so a snapshot failure
+	// aborts the edit rather than silently losing the prior text.
+	if description != nil && prevDescription != issue.DescriptionHTML {
+		if err := s.is.CreateDescriptionVersion(ctx, &model.IssueDescriptionVersion{
+			IssueID:         issue.ID,
+			DescriptionHTML: prevDescription,
+			CreatedByID:     &userID,
+			OwnedByID:       &userID,
+		}); err != nil {
+			return nil, err
+		}
+	}
 	issue.UpdatedByID = &userID
 	if err := s.is.Update(ctx, issue); err != nil {
 		return nil, err
@@ -739,14 +752,6 @@ func (s *IssueService) Update(ctx context.Context, workspaceSlug string, project
 				s.notify.IssueMentioned(ctx, issue, userID, added, "description")
 			}
 		}
-		// Snapshot the pre-edit description so history can be browsed and restored.
-		// Fire-and-forget: a version write must not fail the update.
-		_ = s.is.CreateDescriptionVersion(ctx, &model.IssueDescriptionVersion{
-			IssueID:         issue.ID,
-			DescriptionHTML: prevDescription,
-			CreatedByID:     &userID,
-			OwnedByID:       &userID,
-		})
 	}
 
 	if assigneeIDs != nil {
@@ -851,13 +856,16 @@ func (s *IssueService) RestoreDescriptionVersion(ctx context.Context, workspaceS
 	if version.DescriptionHTML == issue.DescriptionHTML {
 		return issue, nil // nothing to restore
 	}
-	// Snapshot the current description before overwriting it.
-	_ = s.is.CreateDescriptionVersion(ctx, &model.IssueDescriptionVersion{
+	// Snapshot the current description before overwriting it. Abort on failure so
+	// a restore never destroys the current text without recording it first.
+	if err := s.is.CreateDescriptionVersion(ctx, &model.IssueDescriptionVersion{
 		IssueID:         issue.ID,
 		DescriptionHTML: issue.DescriptionHTML,
 		CreatedByID:     &userID,
 		OwnedByID:       &userID,
-	})
+	}); err != nil {
+		return nil, err
+	}
 	issue.DescriptionHTML = version.DescriptionHTML
 	issue.UpdatedByID = &userID
 	if err := s.is.Update(ctx, issue); err != nil {

--- a/apps/api/internal/store/issue.go
+++ b/apps/api/internal/store/issue.go
@@ -161,6 +161,31 @@ func (s *IssueStore) Delete(ctx context.Context, id uuid.UUID) error {
 	return s.db.WithContext(ctx).Where("id = ?", id).Delete(&model.Issue{}).Error
 }
 
+// ----- Issue description versions -----
+
+func (s *IssueStore) CreateDescriptionVersion(ctx context.Context, v *model.IssueDescriptionVersion) error {
+	return s.db.WithContext(ctx).Create(v).Error
+}
+
+// ListDescriptionVersions returns an issue's description history, newest first.
+func (s *IssueStore) ListDescriptionVersions(ctx context.Context, issueID uuid.UUID) ([]model.IssueDescriptionVersion, error) {
+	var list []model.IssueDescriptionVersion
+	err := s.db.WithContext(ctx).
+		Where("issue_id = ?", issueID).
+		Order("created_at DESC").
+		Find(&list).Error
+	return list, err
+}
+
+func (s *IssueStore) GetDescriptionVersion(ctx context.Context, versionID uuid.UUID) (*model.IssueDescriptionVersion, error) {
+	var v model.IssueDescriptionVersion
+	err := s.db.WithContext(ctx).Where("id = ?", versionID).First(&v).Error
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
 // BulkUpdateFields updates the given columns for many issues scoped to a
 // project. Returns the number of rows affected.
 func (s *IssueStore) BulkUpdateFields(ctx context.Context, projectID uuid.UUID, ids []uuid.UUID, updates map[string]any) (int64, error) {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -741,6 +741,15 @@ export interface PageVersionApiResponse {
   updated_at: string;
 }
 
+export interface IssueDescriptionVersionApiResponse {
+  id: string;
+  issue_id: string;
+  description_html?: string;
+  created_by_id?: string | null;
+  owned_by_id?: string | null;
+  created_at: string;
+}
+
 /**
  * Reason a notification was created. Server-set; drives how the inbox row renders.
  */

--- a/apps/web/src/components/work-item/DescriptionHistoryModal.tsx
+++ b/apps/web/src/components/work-item/DescriptionHistoryModal.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import { Modal, Button } from '../ui';
+import { issueService } from '../../services/issueService';
+import { sanitizeHtml } from '../../lib/sanitize';
+import type { IssueApiResponse, IssueDescriptionVersionApiResponse } from '../../api/types';
+
+interface DescriptionHistoryModalProps {
+  open: boolean;
+  onClose: () => void;
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+  authorLabel: (userId: string | null | undefined) => string;
+  onRestored: (issue: IssueApiResponse) => void;
+}
+
+/** Lists a work item's saved description versions and lets the user restore one. */
+export function DescriptionHistoryModal({
+  open,
+  onClose,
+  workspaceSlug,
+  projectId,
+  issueId,
+  authorLabel,
+  onRestored,
+}: DescriptionHistoryModalProps) {
+  const [versions, setVersions] = useState<IssueDescriptionVersionApiResponse[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    issueService
+      .listDescriptionVersions(workspaceSlug, projectId, issueId)
+      .then((list) => {
+        if (!cancelled) setVersions(list ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load version history.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, workspaceSlug, projectId, issueId]);
+
+  const restore = async (versionId: string) => {
+    setRestoringId(versionId);
+    setError(null);
+    try {
+      const updated = await issueService.restoreDescriptionVersion(
+        workspaceSlug,
+        projectId,
+        issueId,
+        versionId,
+      );
+      onRestored(updated);
+      onClose();
+    } catch {
+      setError('Could not restore this version.');
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Description history" className="max-w-2xl">
+      {error && (
+        <p className="mb-3 rounded-(--radius-md) bg-(--bg-danger-subtle) px-3 py-2 text-sm text-(--txt-danger-primary)">
+          {error}
+        </p>
+      )}
+      {loading ? (
+        <p className="py-6 text-center text-sm text-(--txt-tertiary)">Loading history…</p>
+      ) : versions.length === 0 ? (
+        <p className="py-6 text-center text-sm text-(--txt-tertiary)">
+          No previous versions yet. Edits to the description are recorded here.
+        </p>
+      ) : (
+        <ul className="max-h-[60vh] space-y-3 overflow-y-auto">
+          {versions.map((v) => (
+            <li
+              key={v.id}
+              className="rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1) p-3"
+            >
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="min-w-0 text-xs text-(--txt-tertiary)">
+                  <span className="text-(--txt-secondary)">{authorLabel(v.created_by_id)}</span>
+                  {' · '}
+                  {new Date(v.created_at).toLocaleString()}
+                </div>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={restoringId === v.id}
+                  onClick={() => restore(v.id)}
+                >
+                  {restoringId === v.id ? 'Restoring…' : 'Restore'}
+                </Button>
+              </div>
+              <div
+                className="prose prose-sm max-h-40 max-w-none overflow-y-auto text-sm text-(--txt-secondary)"
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(v.description_html) }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/components/work-item/DescriptionHistoryModal.tsx
+++ b/apps/web/src/components/work-item/DescriptionHistoryModal.tsx
@@ -98,7 +98,7 @@ export function DescriptionHistoryModal({
                 <Button
                   size="sm"
                   variant="secondary"
-                  disabled={restoringId === v.id}
+                  disabled={restoringId !== null}
                   onClick={() => restore(v.id)}
                 >
                   {restoringId === v.id ? 'Restoring…' : 'Restore'}

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { Dropdown, DatePickerTrigger, CommentEditor } from '../components/work-item';
 import { sanitizeHtml } from '../lib/sanitize';
 import { DescriptionEditor } from '../components/work-item/DescriptionEditor';
+import { DescriptionHistoryModal } from '../components/work-item/DescriptionHistoryModal';
 import { IssueReactions } from '../components/work-item/IssueReactions';
 import { IssueActivityFeed } from '../components/work-item/IssueActivityFeed';
 import { CommentReactions } from '../components/work-item/CommentReactions';
@@ -87,6 +88,7 @@ export function IssueDetailPage() {
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [issue, setIssue] = useState<IssueApiResponse | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [labels, setLabels] = useState<LabelApiResponse[]>([]);
   const [cycles, setCycles] = useState<CycleApiResponse[]>([]);
@@ -536,8 +538,15 @@ export function IssueDetailPage() {
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="space-y-6 lg:col-span-2">
           <Card>
-            <CardHeader className="text-sm font-medium text-(--txt-secondary)">
-              Description
+            <CardHeader className="flex items-center justify-between text-sm font-medium text-(--txt-secondary)">
+              <span>Description</span>
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(true)}
+                className="rounded-(--radius-md) px-2 py-1 text-xs font-normal text-(--txt-tertiary) hover:bg-(--bg-layer-1-hover) hover:text-(--txt-secondary)"
+              >
+                History
+              </button>
             </CardHeader>
             <CardContent>
               <DescriptionEditor
@@ -1429,6 +1438,17 @@ export function IssueDetailPage() {
           }
         }}
       />
+      {workspaceSlug && projectId && issueId && (
+        <DescriptionHistoryModal
+          open={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+          workspaceSlug={workspaceSlug}
+          projectId={projectId}
+          issueId={issueId}
+          authorLabel={getMemberLabel}
+          onRestored={(updated) => setIssue(updated)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/services/issueService.ts
+++ b/apps/web/src/services/issueService.ts
@@ -7,6 +7,7 @@ import type {
   IssueRelationApiResponse,
   IssueRelationType,
   IssueReactionApiResponse,
+  IssueDescriptionVersionApiResponse,
   CreateIssueRequest,
 } from '../api/types';
 
@@ -118,6 +119,29 @@ export const issueService = {
   ): Promise<IssueActivityApiResponse[]> {
     const { data } = await apiClient.get<IssueActivityApiResponse[]>(
       `${base(workspaceSlug, projectId, issueId)}/activities/`,
+    );
+    return data;
+  },
+
+  async listDescriptionVersions(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+  ): Promise<IssueDescriptionVersionApiResponse[]> {
+    const { data } = await apiClient.get<IssueDescriptionVersionApiResponse[]>(
+      `${base(workspaceSlug, projectId, issueId)}/description-versions/`,
+    );
+    return data;
+  },
+
+  async restoreDescriptionVersion(
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    versionId: string,
+  ): Promise<IssueApiResponse> {
+    const { data } = await apiClient.post<IssueApiResponse>(
+      `${base(workspaceSlug, projectId, issueId)}/description-versions/${encodeURIComponent(versionId)}/restore/`,
     );
     return data;
   },


### PR DESCRIPTION
## Summary

Closes #172.

Work-item descriptions were overwritten in place with no history, unlike pages which already have versioning. The `issue_description_versions` table already existed in the base schema but was never wired to any store, service, handler, route, or UI, so the capability was dormant.

**Backend**
- Editing a description now snapshots the *previous* text into `issue_description_versions` (fire-and-forget, so a version write can't fail the update).
- New `IssueStore` methods (create / list / get version) and `IssueService.ListDescriptionVersions` / `RestoreDescriptionVersion`, mirroring the existing page-versions design.
- Restoring a version snapshots the current description first, so a restore is itself undoable.
- Routes: `GET …/issues/:pk/description-versions/` and `POST …/issues/:pk/description-versions/:versionId/restore/`.

**Frontend**
- A **History** control on the work-item description opens a modal that lists past versions with author + time and a sanitized preview, each with a **Restore** button.

No migration is needed — the table already exists in `000001_init_schema`.

## Testing

- `go vet ./...` and the full `go test ./...` suite pass.
- **`handler_test.TestIssue_DescriptionVersionHistoryAndRestore`**: two edits leave two prior-description snapshots (newest first); restoring the older one reverts the description and snapshots the replaced text (history grows to three).
- Browser-verified end-to-end against the running API: made two description edits, opened **History** (both versions listed with previews), clicked **Restore** on the older one, and the description reverted while the modal closed; the pre-restore text was snapshotted. Reset the description afterward.

## AI assistance

Produced with the help of Claude Code (Claude Opus 4.8). See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added issue description history with APIs to list saved description snapshots and restore a chosen version.
  * Introduced a “History” button on the issue details page and a modal to view versions and restore them.
* **Bug Fixes**
  * Improved handling for missing/inaccessible history entries with consistent success/error responses.
  * Ensured updates automatically save the prior description and restores preserve the replaced text in history.
* **Tests**
  * Added coverage for history listing and restoring flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->