### PR TITLE
fix: include issue events in user activity feed

### DIFF
--- a/apps/api/internal/handler/auth_test.go
+++ b/apps/api/internal/handler/auth_test.go
@@ -1,10 +1,13 @@
 package handler_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/model"
+	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/Devlaner/devlane/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -483,4 +486,47 @@ func TestAuth_UserActivity_OK(t *testing.T) {
 
 	rr := ts.GET("/api/users/me/activity/", session)
 	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+}
+
+func TestAuth_UserActivity_IncludesIssueActivity(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	world := testutil.SeedWorld(t, ts.DB)
+	issue := testutil.CreateIssue(t, ts.DB, world.Project.ID, world.Workspace.ID, world.User.ID)
+	comment := testutil.CreateComment(t, ts.DB, issue.ID, world.Project.ID, world.Workspace.ID, world.User.ID)
+	field := "priority"
+	oldValue := "none"
+	newValue := "high"
+	actorID := world.User.ID
+	err := store.NewIssueActivityStore(ts.DB).Create(context.Background(), &model.IssueActivity{
+		IssueID:     &issue.ID,
+		ProjectID:   world.Project.ID,
+		WorkspaceID: world.Workspace.ID,
+		Verb:        "updated",
+		Field:       &field,
+		OldValue:    &oldValue,
+		NewValue:    &newValue,
+		ActorID:     &actorID,
+		CreatedByID: &actorID,
+	})
+	require.NoError(t, err)
+
+	rr := ts.GET("/api/users/me/activity/", world.Session)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	body := testutil.MustJSONMap(t, rr)
+	activities, ok := body["activities"].([]any)
+	require.True(t, ok)
+	require.Len(t, activities, 2)
+
+	types := make([]string, 0, len(activities))
+	for _, item := range activities {
+		activity, ok := item.(map[string]any)
+		require.True(t, ok)
+		types = append(types, activity["type"].(string))
+		assert.Equal(t, issue.ID.String(), activity["issue_id"])
+		assert.Equal(t, issue.Name, activity["issue_name"])
+	}
+	assert.Contains(t, types, "comment")
+	assert.Contains(t, types, "issue_activity")
+	assert.Contains(t, rr.Body.String(), comment.Comment)
+	assert.Contains(t, rr.Body.String(), "Updated priority from none to high")
 }

--- a/apps/api/internal/handler/user.go
+++ b/apps/api/internal/handler/user.go
@@ -2,9 +2,12 @@ package handler
 
 import (
 	"net/http"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/Devlaner/devlane/api/internal/middleware"
+	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -12,11 +15,12 @@ import (
 
 // UserHandler handles user-scoped endpoints (activity, etc.).
 type UserHandler struct {
-	Comments *store.CommentStore
-	Issues   *store.IssueStore
+	Comments   *store.CommentStore
+	Issues     *store.IssueStore
+	Activities *store.IssueActivityStore
 }
 
-// GetActivity returns the current user's activity feed (comments for now).
+// GetActivity returns the current user's recent activity feed.
 // GET /api/users/me/activity/
 func (h *UserHandler) GetActivity(c *gin.Context) {
 	user := middleware.GetUser(c)
@@ -34,13 +38,22 @@ func (h *UserHandler) GetActivity(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load activity"})
 		return
 	}
-	if len(comments) == 0 {
-		c.JSON(http.StatusOK, gin.H{"activities": []gin.H{}})
-		return
+	var issueActivities []model.IssueActivity
+	if h.Activities != nil {
+		issueActivities, err = h.Activities.ListByActorID(ctx, user.ID, 50)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load activity"})
+			return
+		}
 	}
 	issueIDSet := make(map[uuid.UUID]bool)
 	for _, co := range comments {
 		issueIDSet[co.IssueID] = true
+	}
+	for _, a := range issueActivities {
+		if a.IssueID != nil {
+			issueIDSet[*a.IssueID] = true
+		}
 	}
 	issueIDs := make([]uuid.UUID, 0, len(issueIDSet))
 	for id := range issueIDSet {
@@ -55,8 +68,7 @@ func (h *UserHandler) GetActivity(c *gin.Context) {
 	for _, i := range issues {
 		issueMap[i.ID.String()] = i.Name
 	}
-	// Build activity list (comments only for now)
-	activities := make([]gin.H, 0, len(comments))
+	activities := make([]userActivityItem, 0, len(comments)+len(issueActivities))
 	for _, co := range comments {
 		desc := "Commented"
 		if co.Comment != "" {
@@ -67,16 +79,101 @@ func (h *UserHandler) GetActivity(c *gin.Context) {
 			desc = snippet
 		}
 		issueName := issueMap[co.IssueID.String()]
-		activities = append(activities, gin.H{
-			"id":           co.ID.String(),
-			"type":         "comment",
-			"created_at":   co.CreatedAt,
-			"description":  desc,
-			"issue_id":     co.IssueID.String(),
-			"issue_name":   issueName,
-			"workspace_id": co.WorkspaceID.String(),
-			"project_id":   co.ProjectID.String(),
+		activities = append(activities, userActivityItem{
+			createdAt: co.CreatedAt,
+			body: gin.H{
+				"id":           co.ID.String(),
+				"type":         "comment",
+				"created_at":   co.CreatedAt,
+				"description":  desc,
+				"issue_id":     co.IssueID.String(),
+				"issue_name":   issueName,
+				"workspace_id": co.WorkspaceID.String(),
+				"project_id":   co.ProjectID.String(),
+			},
 		})
 	}
-	c.JSON(http.StatusOK, gin.H{"activities": activities})
+	for _, a := range issueActivities {
+		// Comment rows already carry the comment body in this feed; skip the
+		// lower-fidelity activity bookkeeping rows to avoid duplicate entries.
+		if isCommentActivity(a) {
+			continue
+		}
+		issueID := ""
+		issueName := ""
+		if a.IssueID != nil {
+			issueID = a.IssueID.String()
+			issueName = issueMap[issueID]
+		}
+		activities = append(activities, userActivityItem{
+			createdAt: a.CreatedAt,
+			body: gin.H{
+				"id":           a.ID.String(),
+				"type":         "issue_activity",
+				"created_at":   a.CreatedAt,
+				"description":  issueActivityDescription(a),
+				"issue_id":     issueID,
+				"issue_name":   issueName,
+				"workspace_id": a.WorkspaceID.String(),
+				"project_id":   a.ProjectID.String(),
+			},
+		})
+	}
+	sort.SliceStable(activities, func(i, j int) bool {
+		return activities[i].createdAt.After(activities[j].createdAt)
+	})
+	if len(activities) > 50 {
+		activities = activities[:50]
+	}
+	out := make([]gin.H, 0, len(activities))
+	for _, activity := range activities {
+		out = append(out, activity.body)
+	}
+	c.JSON(http.StatusOK, gin.H{"activities": out})
+}
+
+type userActivityItem struct {
+	createdAt time.Time
+	body      gin.H
+}
+
+func isCommentActivity(a model.IssueActivity) bool {
+	if a.Field == nil {
+		return false
+	}
+	return *a.Field == "comment_added" || *a.Field == "comment_updated" || *a.Field == "comment_removed"
+}
+
+func issueActivityDescription(a model.IssueActivity) string {
+	if a.Comment != nil && strings.TrimSpace(*a.Comment) != "" {
+		return strings.TrimSpace(*a.Comment)
+	}
+	if a.Verb == "created" {
+		return "Created issue"
+	}
+	if a.Verb == "deleted" {
+		return "Deleted issue"
+	}
+	if a.Field == nil || *a.Field == "" {
+		return titleWord(a.Verb)
+	}
+	field := strings.ReplaceAll(*a.Field, "_", " ")
+	if a.OldValue != nil && a.NewValue != nil {
+		return "Updated " + field + " from " + *a.OldValue + " to " + *a.NewValue
+	}
+	if a.NewValue != nil {
+		return "Updated " + field + " to " + *a.NewValue
+	}
+	if a.OldValue != nil {
+		return "Updated " + field + " from " + *a.OldValue
+	}
+	return "Updated " + field
+}
+
+func titleWord(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -249,7 +249,7 @@ func New(cfg Config) *gin.Engine {
 	workspaceLinkHandler := &handler.WorkspaceLinkHandler{Link: workspaceLinkSvc}
 	stickyHandler := &handler.StickyHandler{Sticky: stickySvc}
 	recentVisitHandler := &handler.RecentVisitHandler{Recent: recentVisitSvc}
-	userHandler := &handler.UserHandler{Comments: commentStore, Issues: issueStore}
+	userHandler := &handler.UserHandler{Comments: commentStore, Issues: issueStore, Activities: issueActivityStore}
 
 	// Protected API: require auth
 	api := r.Group("/api")

--- a/apps/api/internal/store/issue_activity.go
+++ b/apps/api/internal/store/issue_activity.go
@@ -26,3 +26,18 @@ func (s *IssueActivityStore) ListByIssueID(ctx context.Context, issueID uuid.UUI
 		Find(&list).Error
 	return list, err
 }
+
+// ListByActorID returns recent issue activity performed by the given user,
+// newest first. This powers the user-scoped activity feed.
+func (s *IssueActivityStore) ListByActorID(ctx context.Context, actorID uuid.UUID, limit int) ([]model.IssueActivity, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var list []model.IssueActivity
+	err := s.db.WithContext(ctx).
+		Where("actor_id = ? AND deleted_at IS NULL", actorID).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&list).Error
+	return list, err
+}


### PR DESCRIPTION
## Summary

Expands the profile/account activity feed so it includes issue activity events in addition to user comments. This surfaces existing issue create/update activity that was already being captured but not shown in the user-scoped feed.

## Linked issues

Closes #210

## Type of change

- [x] Feature (`feat:`) — user-visible new capability
- [ ] Bug fix (`fix:`) — corrects broken behavior
- [ ] Refactor (`refactor:`) — no behavior change, internal only
- [ ] Performance (`perf:`) — measurable improvement
- [ ] Documentation (`docs:`) — README / CLAUDE.md / planning docs only
- [ ] Tests (`test:`) — adds or corrects tests
- [ ] Chore (`chore:`) — deps, tooling, CI, formatting
- [ ] Style (`style:`) — visual / theming polish only

## Surface

- [x] API (`apps/api/`)
- [ ] UI (`apps/web/`)
- [ ] Database migration (`apps/api/migrations/`)
- [ ] Background jobs (RabbitMQ / queue)
- [ ] Instance settings / Admin UI
- [ ] Infra / Docker / CI

## What changed

- Added issue activity lookup by actor so user-scoped feeds can include issue events.
- Updated `/api/users/me/activity/` to merge comment activity and issue activity, sort newest first, and keep the response capped.
- Skipped duplicate comment bookkeeping events because comment rows already provide richer feed entries.
- Added regression coverage for a feed containing both a comment and an issue priority update.

## Why this approach

This reuses the existing `issue_activities` table and activity-writing paths instead of adding a new feed model. The endpoint response shape stays compatible with the current UI while expanding the activity types it can return.

## Database / migrations

No schema changes.

- [ ] Added `apps/api/migrations/NNNNNN_<name>.up.sql` AND matching `.down.sql`
- [ ] Migration is idempotent / safe to re-run on a fresh DB
- [ ] Migration applied cleanly via `database.RunMigrations` on startup

## Breaking changes

- [x] No
- [ ] Yes — described below

## Test plan

- [x] `npm run validate` (root) — typecheck + lint + prettier + go vet + go test
- [x] `cd apps/api && go test ./internal/handler -run 'TestAuth_UserActivity'`
- [x] `cd apps/api && go test ./...`
- [ ] Manual smoke test of the affected flow:
  - Open account/profile activity and verify issue updates appear alongside comments.

## Screenshots / recordings (UI changes)

No UI changes.

| Before | After |
| ------ | ----- |
|        |       |

## Rollout notes

None.

## AI assistance

- [ ] No AI tools were used for this PR
- [x] AI tools were used — tool(s): `Codex` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is ≤ 100 chars
- [x] Hooks ran cleanly (no `--no-verify` bypass)
- [x] Trailing slashes on new routes match the surrounding pattern
- [x] New env vars added to `internal/config/config.go` and documented above
- [x] No secrets, tokens, or `.env` values committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User activity now includes issue updates alongside comments, giving a more complete timeline.
  * Activity items are combined into a single feed, ordered by recency, and limited to the most recent 50 entries.
  * Issue changes are shown in a readable format, such as “Updated priority from none to high.”

* **Bug Fixes**
  * Prevents duplicate entries when issue activity already represents comment-related actions.
  * Ensures the activity page returns both comment and issue update events consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->