### PR TITLE
chore: relicense Devlane under the MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,62 +1,21 @@
-Devlane Software License
+MIT License
 
 Copyright (c) 2026 Devlane
-
-----------------------------------------------------------------------
-1. MIT License Grant
-----------------------------------------------------------------------
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, and distribute copies of the Software,
-and to permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-----------------------------------------------------------------------
-2. Additional Use Restriction (Non‑Commercial Resale / Hosting)
-----------------------------------------------------------------------
-
-Notwithstanding any other provision of this License, you may not "Sell" the
-Software or any service whose primary value is access to, or use of,
-the Software.
-
-"Sell" means:
-  (a) licensing, sublicensing, distributing, or otherwise making the Software,
-      or derivative works of the Software, available to third parties
-      for a fee, subscription charge, or other commercial consideration; or
-  (b) providing a hosted, managed, or software‑as‑a‑service offering where
-      the primary purpose of the service is to enable third parties to access
-      or use the Software (with or without modifications).
-
-For clarity, the following are permitted under this License:
-  - Using the Software internally for personal, educational, or commercial
-    purposes within your own individual or organizational environment.
-  - Using the Software as an internal tool to help you deliver your own
-    products or services, where customers are not being charged for access
-    to Devlane itself.
-  - Sharing the Software (with or without modifications) without charging
-    a fee specifically for the Software or for hosted access to Devlane.
-
-----------------------------------------------------------------------
-3. Disclaimer of Warranty
-----------------------------------------------------------------------
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-----------------------------------------------------------------------
-4. Open Source Status
-----------------------------------------------------------------------
-
-Because of the additional restriction in Section 2, this License does not
-meet the Open Source Initiative (OSI) definition of "open source" and the
-Software should not be described as OSI‑approved open source software.
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ AI-assisted contributions are accepted, but must be disclosed — note the tool 
 
 ## License
 
-This project is licensed under the **Devlane Software License**. It grants you broad use and modification rights (MIT-style) but does not allow selling the software or offering it as a hosted/subscription service to third parties. See [LICENSE](LICENSE) for the full text. This license is not OSI-approved open source.
+This project is licensed under the [MIT License](LICENSE), an OSI-approved open source license.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "devlane",
       "version": "1.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",


### PR DESCRIPTION
## What

Replaces the custom **Devlane Software License** with the standard **MIT License**.

The previous license was MIT-style but added a non-commercial "Additional Use Restriction" that prohibited reselling or offering a hosted/SaaS version of the Software. This PR drops that restriction and adopts plain MIT, so Devlane is fully open source with no commercial-use limits.

## Why

To make Devlane a genuinely open, permissively-licensed project that teams and contributors can use, self-host, and build on without restriction.

## Change

- `LICENSE`: custom Devlane Software License → standard MIT License (same 2026 Devlane copyright).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the custom software license text with the standard MIT License.
  * Updated the README License section to point to the MIT terms.
* **Chores**
  * Set the package license metadata to **MIT**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->