### PR TITLE
feat(estimates): show the real estimate value in view and module list rows

### DIFF
--- a/apps/web/src/pages/ModuleDetailPage.tsx
+++ b/apps/web/src/pages/ModuleDetailPage.tsx
@@ -10,6 +10,7 @@ import { issueService } from '../services/issueService';
 import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
 import { cycleService } from '../services/cycleService';
+import { estimateService } from '../services/estimateService';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
@@ -19,6 +20,7 @@ import type {
   LabelApiResponse,
   WorkspaceMemberApiResponse,
   CycleApiResponse,
+  EstimateApiResponse,
 } from '../api/types';
 import type { Priority } from '../types';
 import type { SavedViewDisplayPropertyId } from '../lib/projectSavedViewDisplay';
@@ -191,6 +193,7 @@ export function ModuleDetailPage() {
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [labels, setLabels] = useState<LabelApiResponse[]>([]);
   const [cycles, setCycles] = useState<CycleApiResponse[]>([]);
+  const [estimates, setEstimates] = useState<EstimateApiResponse[]>([]);
   const [projectModules, setProjectModules] = useState<ModuleApiResponse[]>([]);
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
@@ -292,12 +295,14 @@ export function ModuleDetailPage() {
       cycleService.list(workspaceSlug, projectId),
       workspaceService.listMembers(workspaceSlug),
       projectService.list(workspaceSlug),
+      estimateService.list(workspaceSlug, projectId),
     ])
-      .then(([w, p, mods, iss, st, lab, cyc, mem, proj]) => {
+      .then(([w, p, mods, iss, st, lab, cyc, mem, proj, est]) => {
         if (cancelled) return;
         setWorkspace(w ?? null);
         setProject(p ?? null);
         setProjectModules(mods ?? []);
+        setEstimates(est ?? []);
         const key = moduleId.trim().toLowerCase();
         const found =
           (mods ?? []).find((x) => x.id === moduleId) ??
@@ -325,6 +330,7 @@ export function ModuleDetailPage() {
           setCycles([]);
           setMembers([]);
           setProjects([]);
+          setEstimates([]);
         }
       })
       .finally(() => {
@@ -487,6 +493,13 @@ export function ModuleDetailPage() {
     return id ? (projectModules.find((m) => m.id === id)?.name ?? '—') : '—';
   };
 
+  const estimateValue = (issue: IssueApiResponse) => {
+    if (!issue.estimate_point_id) return '—';
+    return (
+      estimates.flatMap((e) => e.points).find((p) => p.id === issue.estimate_point_id)?.value ?? '—'
+    );
+  };
+
   const dp = listDisplay.displayProperties;
   const hasCol = (id: SavedViewDisplayPropertyId) => dp.has(id);
 
@@ -602,7 +615,12 @@ export function ModuleDetailPage() {
               </span>
             ) : null}
             {hasCol('estimate') ? (
-              <span className="text-[11px] text-(--txt-secondary)">—</span>
+              <span
+                className="min-w-6 text-center text-[11px] text-(--txt-secondary)"
+                title="Estimate"
+              >
+                {estimateValue(issue)}
+              </span>
             ) : null}
             {hasCol('module') ? (
               <span

--- a/apps/web/src/pages/ViewDetailPage.tsx
+++ b/apps/web/src/pages/ViewDetailPage.tsx
@@ -13,6 +13,7 @@ import { stateService } from '../services/stateService';
 import { labelService } from '../services/labelService';
 import { cycleService } from '../services/cycleService';
 import { moduleService } from '../services/moduleService';
+import { estimateService } from '../services/estimateService';
 import { viewService } from '../services/viewService';
 import type {
   IssueApiResponse,
@@ -24,6 +25,7 @@ import type {
   WorkspaceMemberApiResponse,
   CycleApiResponse,
   ModuleApiResponse,
+  EstimateApiResponse,
 } from '../api/types';
 import type { Priority } from '../types';
 import type { SavedViewDisplayPropertyId } from '../lib/projectSavedViewDisplay';
@@ -174,6 +176,7 @@ export function ViewDetailPage() {
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [cycles, setCycles] = useState<CycleApiResponse[]>([]);
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);
+  const [estimates, setEstimates] = useState<EstimateApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [issuesLoading, setIssuesLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -276,8 +279,9 @@ export function ViewDetailPage() {
       workspaceService.listMembers(workspaceSlug),
       cycleService.list(workspaceSlug, projectId),
       moduleService.list(workspaceSlug, projectId),
+      estimateService.list(workspaceSlug, projectId),
     ])
-      .then(([w, p, list, iss, st, lab, mem, cy, mod]) => {
+      .then(([w, p, list, iss, st, lab, mem, cy, mod, est]) => {
         if (cancelled) return;
         setWorkspace(w);
         setProject(p);
@@ -288,6 +292,7 @@ export function ViewDetailPage() {
         setMembers(mem ?? []);
         setCycles(cy ?? []);
         setModules(mod ?? []);
+        setEstimates(est ?? []);
       })
       .catch(() => {
         if (!cancelled) {
@@ -300,6 +305,7 @@ export function ViewDetailPage() {
           setMembers([]);
           setCycles([]);
           setModules([]);
+          setEstimates([]);
         }
       })
       .finally(() => {
@@ -848,6 +854,13 @@ export function ViewDetailPage() {
     return id ? (modules.find((m) => m.id === id)?.name ?? '—') : '—';
   };
 
+  const estimateValue = (issue: IssueApiResponse) => {
+    if (!issue.estimate_point_id) return '—';
+    return (
+      estimates.flatMap((e) => e.points).find((p) => p.id === issue.estimate_point_id)?.value ?? '—'
+    );
+  };
+
   const totalIssueCount = groupedSections.order.reduce(
     (n, key) => n + (groupedSections.groups.get(key)?.length ?? 0),
     0,
@@ -1022,7 +1035,12 @@ export function ViewDetailPage() {
                                 </span>
                               ) : null}
                               {hasCol('estimate') ? (
-                                <span className="text-[11px] text-(--txt-secondary)">—</span>
+                                <span
+                                  className="min-w-6 text-center text-[11px] text-(--txt-secondary)"
+                                  title="Estimate"
+                                >
+                                  {estimateValue(issue)}
+                                </span>
                               ) : null}
                               {hasCol('module') ? (
                                 <span


### PR DESCRIPTION
## Feature summary

The estimate column in the project **view** and **module** work-item lists rendered a hardcoded placeholder instead of the work item's real estimate. Both now resolve and display the actual estimate point value. This finishes the last user-facing gap in estimates (the systems + points + issue-detail picker landed in #222/#223).

## Linked issues / discussion

Closes #127

## User-facing behavior

In a project View and a Module's work-item list, when the Estimate display column is enabled, each row now shows the work item's estimate (e.g. `5`) instead of a dash. Work items with no estimate still show `—`.

## What changed

- `apps/web/src/pages/ViewDetailPage.tsx` and `apps/web/src/pages/ModuleDetailPage.tsx`: load the project's estimates alongside the other project data, and add an `estimateValue(issue)` helper that resolves `issue.estimate_point_id` against the loaded estimate points (the same resolution the issue-detail estimate picker uses). The estimate column renders that value.

## Why this design

The issue-detail page already resolves an estimate point as `estimates.flatMap(e => e.points).find(p => p.id === estimate_point_id).value`. Reusing that exact approach keeps the list rows consistent with the detail view and avoids a new endpoint (estimates are already a per-project list).

## Test plan

- [x] `npm run typecheck`, `npm run lint` (full) green.
- [x] Manual E2E against the running stack: created a "Points" estimate (1/2/3/5/8), assigned `5` to a work item, added it to a module, and confirmed the module list row shows **5** in the estimate column (previously `—`). Screenshot verified.

## Out of scope (follow-ups)

- The **workspace-wide** custom-view spreadsheet (`WorkspaceViewsPage`) still renders placeholder cells for estimate as well as module/cycle/link/attachment. Those cells span multiple projects and would need cross-project estimate/module resolution — a separate, broader gap than this issue.
- The repo has no web unit-test harness (testing is Go-only per `npm run validate`), so this is verified via typecheck/lint/build + manual E2E rather than a new UI test.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] Acceptance criteria from the linked issue are met (estimate now shown in list rows)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added work-item estimate values to module and view detail pages.
  * Estimate values are now matched to each work item and displayed in the estimate column.

* **Bug Fixes**
  * Estimate data now clears correctly when loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->