### PR TITLE
feat(issues): apply the project default state to new work items

### DIFF
--- a/apps/api/internal/handler/issue_default_state_test.go
+++ b/apps/api/internal/handler/issue_default_state_test.go
@@ -1,0 +1,32 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// A new work item created without an explicit state lands in the project's
+// default state; an explicit state is respected. Covers #199.
+func TestIssue_Create_UsesProjectDefaultState(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	base := issueBase(w.Workspace.Slug, w.Project.ID.String())
+
+	// A non-default state and a default state in the project.
+	other := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	def := testutil.CreateState(t, ts.DB, w.Project.ID, w.Workspace.ID)
+	require.NoError(t, ts.DB.Exec(`UPDATE states SET "default" = TRUE WHERE id = ?`, def.ID).Error)
+
+	// No state provided -> default state is applied.
+	rr := ts.POST(base, map[string]any{"name": "Auto-stated"}, w.Session)
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	require.Equal(t, def.ID.String(), testutil.MustJSONMap(t, rr)["state_id"])
+
+	// Explicit state -> respected, not overridden by the default.
+	rr2 := ts.POST(base, map[string]any{"name": "Explicit", "state_id": other.ID.String()}, w.Session)
+	require.Equal(t, http.StatusCreated, rr2.Code, "body=%s", rr2.Body.String())
+	require.Equal(t, other.ID.String(), testutil.MustJSONMap(t, rr2)["state_id"])
+}

--- a/apps/api/internal/service/issue.go
+++ b/apps/api/internal/service/issue.go
@@ -571,6 +571,12 @@ func (s *IssueService) Create(ctx context.Context, workspaceSlug string, project
 	}
 	if stateID != nil {
 		issue.StateID = stateID
+	} else if s.states != nil {
+		// No state chosen: fall back to the project's default state so new work
+		// items land in the configured starting state instead of no state.
+		if def, derr := s.states.GetDefaultByProjectID(ctx, projectID); derr == nil && def != nil {
+			issue.StateID = &def.ID
+		}
 	}
 	if startDate != nil {
 		issue.StartDate = startDate

--- a/apps/api/internal/store/state.go
+++ b/apps/api/internal/store/state.go
@@ -62,6 +62,24 @@ func (s *StateStore) ListByProjectID(ctx context.Context, projectID uuid.UUID) (
 	return list, err
 }
 
+// GetDefaultByProjectID returns the project's default state (the one marked
+// default), or nil when none is set. When several are somehow marked, the
+// lowest-sequence one wins for determinism.
+func (s *StateStore) GetDefaultByProjectID(ctx context.Context, projectID uuid.UUID) (*model.State, error) {
+	var st model.State
+	err := s.db.WithContext(ctx).
+		Where(`project_id = ? AND deleted_at IS NULL AND "default" = TRUE`, projectID).
+		Order("sequence ASC, created_at ASC").
+		First(&st).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &st, nil
+}
+
 func (s *StateStore) Update(ctx context.Context, st *model.State) error {
 	return s.db.WithContext(ctx).Save(st).Error
 }


### PR DESCRIPTION
## Feature summary

A project already has a default work-item state — it's seeded as **Backlog** and you can change which state is the default in **Project settings → States**. The gap was that creating a work item *without* picking a state left it with no state at all, so that default never actually did anything. Now new items fall back to the project's default state.

## Linked issues / discussion

Closes #199

## User-facing behavior

Mark a state as default in Project settings → States (already supported), then create a work item without choosing a state — it lands in that default state instead of showing up with no state.

## What changed

- `store/state.go`: `GetDefaultByProjectID` returns the project's state marked `default` (lowest sequence wins if several, for determinism).
- `service/issue.go`: in `Create`, when no `state_id` is supplied, fall back to the project's default state. An explicit `state_id` is still respected.

## Why this design

The repo already has a per-state `default` flag (seeded + settable in the States settings UI and used elsewhere for board grouping), so the clean fix is to make work-item creation honor it, rather than wiring up the separate, unused `project.default_state_id` column and introducing a second way to express the same thing. Happy to switch to the `default_state_id` approach instead if you'd prefer that — flag it and I'll adjust.

## Test plan

- [x] `go vet ./...` and full `go test ./...` green (testcontainers).
- [x] New `TestIssue_Create_UsesProjectDefaultState`: a work item created with no state gets the project's default state; an explicit state is respected.

## Out of scope (follow-ups)

- The legacy `project.default_state_id` column stays unused; it could be dropped in a later cleanup.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] No migration needed
- [x] No `--no-verify` bypass on the commit (full suite ran on pre-commit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New issues now automatically use the project’s default state when no state is selected.
  * Explicitly selected states continue to be preserved when creating issues.

* **Bug Fixes**
  * Improved default-state selection for projects with multiple default states by applying a consistent ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->