### PR TITLE
feat(work-item): render sub work items as an integrated section

### DIFF
--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -733,7 +733,7 @@ export function IssueDetailPage() {
                       <li key={ch.id}>
                         <Link
                           to={`${baseUrl}/issues/${ch.id}`}
-                          className="flex items-center gap-2 py-2 hover:bg-(--bg-layer-1-hover)"
+                          className="flex items-center gap-2 rounded-(--radius-sm) py-2 hover:bg-(--bg-layer-1-hover) focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--brand-default)"
                         >
                           <span
                             className="size-2.5 shrink-0 rounded-full border border-(--border-subtle)"

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -717,21 +717,43 @@ export function IssueDetailPage() {
 
           {children.length > 0 && (
             <Card>
-              <CardHeader className="text-sm font-medium text-(--txt-secondary)">
-                Sub-work items
+              <CardHeader className="flex items-center gap-2 text-sm font-medium text-(--txt-secondary)">
+                <span>Sub-work items</span>
+                <span className="rounded-full bg-(--bg-layer-2) px-1.5 text-xs text-(--txt-tertiary)">
+                  {children.length}
+                </span>
               </CardHeader>
               <CardContent>
-                <ul className="space-y-2">
-                  {children.map((ch) => (
-                    <li key={ch.id}>
-                      <Link
-                        to={`${baseUrl}/issues/${ch.id}`}
-                        className="text-sm text-(--txt-accent-primary) hover:underline"
-                      >
-                        {ch.name}
-                      </Link>
-                    </li>
-                  ))}
+                <ul className="divide-y divide-(--border-subtle)">
+                  {children.map((ch) => {
+                    const childState = ch.state_id
+                      ? (states.find((s) => s.id === ch.state_id) ?? null)
+                      : null;
+                    return (
+                      <li key={ch.id}>
+                        <Link
+                          to={`${baseUrl}/issues/${ch.id}`}
+                          className="flex items-center gap-2 py-2 hover:bg-(--bg-layer-1-hover)"
+                        >
+                          <span
+                            className="size-2.5 shrink-0 rounded-full border border-(--border-subtle)"
+                            style={{ backgroundColor: childState?.color ?? 'transparent' }}
+                            title={childState?.name ?? 'No state'}
+                          />
+                          <span className="shrink-0 text-[11px] font-medium text-(--txt-tertiary)">
+                            {project.identifier ?? project.id.slice(0, 8)}-
+                            {ch.sequence_id ?? ch.id.slice(-4)}
+                          </span>
+                          <span className="truncate text-sm text-(--txt-primary)">{ch.name}</span>
+                          {ch.priority && ch.priority !== 'none' && (
+                            <span className="ml-auto shrink-0">
+                              <PriorityIcon priority={ch.priority as Priority} />
+                            </span>
+                          )}
+                        </Link>
+                      </li>
+                    );
+                  })}
                 </ul>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Feature summary

The sub-work-items section on a work item was just a bare list of name links, which felt disconnected from the parent (the point raised in the issue). Each sub-item now renders as a compact, informative row so sub-items read as part of the parent.

## Linked issues / discussion

Closes #106

## User-facing behavior

On a work item's detail page, the "Sub-work items" section now shows a count and renders each child as a row with its state (color dot + name on hover), identifier, name (link), and priority — instead of a plain text link.

## What changed

- `apps/web/src/pages/IssueDetailPage.tsx`: reworked the Sub-work items card. Added a count on the header and, per child, a state indicator, `{identifier}-{sequence_id}`, the name, and a priority icon. Reuses the existing state lookup and `PriorityIcon` already used elsewhere on the page. Presentational only — no data-model or backend changes, and the existing "Add sub-work item" action is untouched.

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run build` green.
- [x] Manual E2E against the running stack: created a parent with two sub-items (different states/priorities) and confirmed the section renders each as "state · id · name · priority" with a count, and each row links to the child.

## Note

The issue is an open-ended UX suggestion with no specific acceptance criteria, so this is a focused, low-risk take on "make sub work items feel part of the parent." Happy to adjust the direction if you had something more specific in mind.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] UI-only; no backend/migration
- [x] No `--no-verify` bypass on the commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Upgraded the “Sub-work items” section with a structured card layout and item count.
  - Added state indicators, formatted issue identifiers, and priority icons where applicable.
  - Improved visual separation between sub-work items for easier scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->