### PR TITLE
feat(projects): add project archive and restore

### DIFF
--- a/apps/api/internal/handler/project.go
+++ b/apps/api/internal/handler/project.go
@@ -372,6 +372,66 @@ func (h *ProjectHandler) Delete(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// Archive archives a project (hides it from active lists; not deleted).
+// POST /api/workspaces/:slug/projects/:projectId/archive/
+func (h *ProjectHandler) Archive(c *gin.Context) {
+	h.setArchived(c, true)
+}
+
+// Restore un-archives a project.
+// DELETE /api/workspaces/:slug/projects/:projectId/archive/
+func (h *ProjectHandler) Restore(c *gin.Context) {
+	h.setArchived(c, false)
+}
+
+func (h *ProjectHandler) setArchived(c *gin.Context, archived bool) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	slug := c.Param("slug")
+	pid, ok := projectID(c)
+	if !ok {
+		return
+	}
+	var err error
+	if archived {
+		err = h.Project.Archive(c.Request.Context(), slug, pid, user.ID)
+	} else {
+		err = h.Project.Restore(c.Request.Context(), slug, pid, user.ID)
+	}
+	if err != nil {
+		if err == service.ErrProjectNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Project not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update project"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ListArchived returns the workspace's archived projects.
+// GET /api/workspaces/:slug/archived-projects/
+func (h *ProjectHandler) ListArchived(c *gin.Context) {
+	user := middleware.GetUser(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
+	list, err := h.Project.ListArchived(c.Request.Context(), c.Param("slug"), user.ID)
+	if err != nil {
+		if err == service.ErrProjectNotFound || err == service.ErrProjectForbidden {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Workspace not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list archived projects"})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+
 // ListMembers returns project members.
 // GET /api/workspaces/:slug/projects/:projectId/members/
 func (h *ProjectHandler) ListMembers(c *gin.Context) {

--- a/apps/api/internal/handler/project_archive_test.go
+++ b/apps/api/internal/handler/project_archive_test.go
@@ -1,0 +1,60 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Devlaner/devlane/api/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func projectIDsIn(t *testing.T, body string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	var list []map[string]any
+	if err := json.Unmarshal([]byte(body), &list); err != nil {
+		return out
+	}
+	for _, p := range list {
+		if id, ok := p["id"].(string); ok {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+// Archiving a project hides it from the active list and surfaces it under
+// archived-projects; restoring reverses that. Covers #128.
+func TestProject_ArchiveRestore(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	pid := w.Project.ID.String()
+	activeURL := "/api/workspaces/" + w.Workspace.Slug + "/projects/"
+	archivedURL := "/api/workspaces/" + w.Workspace.Slug + "/archived-projects/"
+	archiveURL := activeURL + pid + "/archive/"
+
+	// Baseline: project is active.
+	require.True(t, projectIDsIn(t, ts.GET(activeURL, w.Session).Body.String())[pid])
+
+	// Archive it.
+	require.Equal(t, http.StatusNoContent, ts.POST(archiveURL, nil, w.Session).Code)
+	require.False(t, projectIDsIn(t, ts.GET(activeURL, w.Session).Body.String())[pid], "archived project hidden from active list")
+	require.True(t, projectIDsIn(t, ts.GET(archivedURL, w.Session).Body.String())[pid], "archived project listed under archived")
+
+	// Restore it.
+	require.Equal(t, http.StatusNoContent, ts.DELETE(archiveURL, w.Session).Code)
+	require.True(t, projectIDsIn(t, ts.GET(activeURL, w.Session).Body.String())[pid], "restored project back in active list")
+	require.False(t, projectIDsIn(t, ts.GET(archivedURL, w.Session).Body.String())[pid])
+}
+
+// A non-member cannot archive a project.
+func TestProject_Archive_NonMemberForbidden(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	w := testutil.SeedWorld(t, ts.DB)
+	stranger := testutil.CreateUser(t, ts.DB)
+	strangerSession := testutil.LoginAs(t, ts.DB, stranger)
+
+	rr := ts.POST("/api/workspaces/"+w.Workspace.Slug+"/projects/"+w.Project.ID.String()+"/archive/", nil, strangerSession)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/apps/api/internal/model/project.go
+++ b/apps/api/internal/model/project.go
@@ -82,6 +82,9 @@ type Project struct {
 	// CloseIn is the number of months after which inactive (non-terminal) work
 	// items are auto-closed into the project's cancelled state. 0 disables it.
 	CloseIn int `gorm:"column:close_in;default:0" json:"close_in"`
+	// ArchivedAt is set when the project is archived; nil for active projects.
+	// Archived projects are hidden from the active project lists but not deleted.
+	ArchivedAt *time.Time `gorm:"column:archived_at;type:timestamptz" json:"archived_at,omitempty"`
 }
 
 func (Project) TableName() string { return "projects" }

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -322,6 +322,7 @@ func New(cfg Config) *gin.Engine {
 		api.POST("/workspaces/:slug/projects/join/", projectHandler.JoinByToken)
 		api.GET("/workspaces/:slug/draft-issues/", issueHandler.ListWorkspaceDrafts)
 		api.GET("/workspaces/:slug/archived-issues/", issueHandler.ListWorkspaceArchived)
+		api.GET("/workspaces/:slug/archived-projects/", projectHandler.ListArchived)
 		api.GET("/workspaces/:slug/search/", searchHandler.Search)
 
 		api.GET("/workspaces/:slug/projects/", projectHandler.List)
@@ -329,6 +330,8 @@ func New(cfg Config) *gin.Engine {
 		api.GET("/workspaces/:slug/projects/:projectId/", projectHandler.Get)
 		api.PATCH("/workspaces/:slug/projects/:projectId/", projectHandler.Update)
 		api.DELETE("/workspaces/:slug/projects/:projectId/", projectHandler.Delete)
+		api.POST("/workspaces/:slug/projects/:projectId/archive/", projectHandler.Archive)
+		api.DELETE("/workspaces/:slug/projects/:projectId/archive/", projectHandler.Restore)
 		api.POST("/workspaces/:slug/projects/:projectId/favorite", favoriteHandler.AddFavoriteProject)
 		api.DELETE("/workspaces/:slug/projects/:projectId/favorite", favoriteHandler.RemoveFavoriteProject)
 		api.GET("/workspaces/:slug/projects/:projectId/members/", projectHandler.ListMembers)

--- a/apps/api/internal/service/project.go
+++ b/apps/api/internal/service/project.go
@@ -233,6 +233,47 @@ func (s *ProjectService) Delete(ctx context.Context, workspaceSlug string, proje
 	return s.ps.Delete(ctx, projectID)
 }
 
+// Archive hides a project from the active lists without deleting it. Requires
+// project admin, like Delete.
+func (s *ProjectService) Archive(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) error {
+	p, err := s.GetByID(ctx, workspaceSlug, projectID, userID)
+	if err != nil {
+		return err
+	}
+	if err := s.requireProjectAdmin(ctx, p.WorkspaceID, p.ID, userID); err != nil {
+		return err
+	}
+	return s.ps.SetArchived(ctx, projectID, true)
+}
+
+// Restore brings an archived project back into the active lists.
+func (s *ProjectService) Restore(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) error {
+	p, err := s.GetByID(ctx, workspaceSlug, projectID, userID)
+	if err != nil {
+		return err
+	}
+	if err := s.requireProjectAdmin(ctx, p.WorkspaceID, p.ID, userID); err != nil {
+		return err
+	}
+	return s.ps.SetArchived(ctx, projectID, false)
+}
+
+// ListArchived returns the workspace's archived projects the user may see.
+func (s *ProjectService) ListArchived(ctx context.Context, workspaceSlug string, userID uuid.UUID) ([]model.Project, error) {
+	wrk, err := s.ws.GetBySlug(ctx, workspaceSlug)
+	if err != nil {
+		return nil, ErrProjectNotFound
+	}
+	ok, _ := s.ws.IsMember(ctx, wrk.ID, userID)
+	if !ok {
+		return nil, ErrProjectForbidden
+	}
+	if s.isWorkspaceAdmin(ctx, wrk.ID, userID) {
+		return s.ps.ListArchivedByWorkspaceID(ctx, wrk.ID)
+	}
+	return s.ps.ListArchivedVisibleByWorkspaceID(ctx, wrk.ID, userID)
+}
+
 func (s *ProjectService) ListMembers(ctx context.Context, workspaceSlug string, projectID uuid.UUID, userID uuid.UUID) ([]model.ProjectMember, error) {
 	_, err := s.GetByID(ctx, workspaceSlug, projectID, userID)
 	if err != nil {

--- a/apps/api/internal/store/project.go
+++ b/apps/api/internal/store/project.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/google/uuid"
@@ -51,8 +52,46 @@ func (s *ProjectStore) GetByID(ctx context.Context, id uuid.UUID) (*model.Projec
 
 func (s *ProjectStore) ListByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]model.Project, error) {
 	var list []model.Project
-	err := s.db.WithContext(ctx).Where("workspace_id = ? AND deleted_at IS NULL", workspaceID).Order("created_at ASC").Find(&list).Error
+	err := s.db.WithContext(ctx).Where("workspace_id = ? AND deleted_at IS NULL AND archived_at IS NULL", workspaceID).Order("created_at ASC").Find(&list).Error
 	return list, err
+}
+
+// ListArchivedByWorkspaceID returns the workspace's archived (non-deleted)
+// projects, most recently archived first.
+func (s *ProjectStore) ListArchivedByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]model.Project, error) {
+	var list []model.Project
+	err := s.db.WithContext(ctx).
+		Where("workspace_id = ? AND deleted_at IS NULL AND archived_at IS NOT NULL", workspaceID).
+		Order("archived_at DESC").Find(&list).Error
+	return list, err
+}
+
+// ListArchivedVisibleByWorkspaceID returns archived projects a user may see:
+// public ones plus any (public or secret) they belong to.
+func (s *ProjectStore) ListArchivedVisibleByWorkspaceID(ctx context.Context, workspaceID, userID uuid.UUID) ([]model.Project, error) {
+	var list []model.Project
+	memberProjects := s.db.Model(&model.ProjectMember{}).
+		Select("project_id").
+		Where("member_id = ? AND deleted_at IS NULL", userID)
+	err := s.db.WithContext(ctx).
+		Where("workspace_id = ? AND deleted_at IS NULL AND archived_at IS NOT NULL", workspaceID).
+		Where("network = ? OR id IN (?)", model.NetworkPublic, memberProjects).
+		Order("archived_at DESC").
+		Find(&list).Error
+	return list, err
+}
+
+// SetArchived archives (sets archived_at) or restores (clears it) a project.
+func (s *ProjectStore) SetArchived(ctx context.Context, id uuid.UUID, archived bool) error {
+	var val interface{}
+	if archived {
+		val = time.Now()
+	} else {
+		val = nil
+	}
+	return s.db.WithContext(ctx).Model(&model.Project{}).
+		Where("id = ?", id).
+		UpdateColumn("archived_at", val).Error
 }
 
 // ListVisibleByWorkspaceID returns the projects a user may see: every public
@@ -63,7 +102,7 @@ func (s *ProjectStore) ListVisibleByWorkspaceID(ctx context.Context, workspaceID
 		Select("project_id").
 		Where("member_id = ? AND deleted_at IS NULL", userID)
 	err := s.db.WithContext(ctx).
-		Where("workspace_id = ? AND deleted_at IS NULL", workspaceID).
+		Where("workspace_id = ? AND deleted_at IS NULL AND archived_at IS NULL", workspaceID).
 		Where("network = ? OR id IN (?)", model.NetworkPublic, memberProjects).
 		Order("created_at ASC").
 		Find(&list).Error

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -110,6 +110,8 @@ export interface ProjectApiResponse {
   archive_in?: number;
   /** Auto-close: months of inactivity after which active items are closed (0 = off). */
   close_in?: number;
+  /** Set when the project is archived; absent/null for active projects. */
+  archived_at?: string | null;
   created_at?: string;
   updated_at?: string;
 }

--- a/apps/web/src/pages/ArchivesPage.tsx
+++ b/apps/web/src/pages/ArchivesPage.tsx
@@ -25,6 +25,8 @@ export function ArchivesPage() {
 
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
+  const [archivedProjects, setArchivedProjects] = useState<ProjectApiResponse[]>([]);
+  const [restoringProjectId, setRestoringProjectId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
@@ -43,14 +45,16 @@ export function ArchivesPage() {
       // Fetch one extra to detect whether more pages exist.
       issueService.listWorkspaceArchived(workspaceSlug, { limit: ARCHIVES_PAGE_SIZE + 1 }),
       projectService.list(workspaceSlug).catch(() => [] as ProjectApiResponse[]),
+      projectService.listArchived(workspaceSlug).catch(() => [] as ProjectApiResponse[]),
     ])
-      .then(([archived, projs]) => {
+      .then(([archived, projs, archProjs]) => {
         if (cancelled) return;
         const page = archived.slice(0, ARCHIVES_PAGE_SIZE);
         setHasMore(archived.length > ARCHIVES_PAGE_SIZE);
         setIssues(page);
         setFetchedCount(page.length);
         setProjects(projs ?? []);
+        setArchivedProjects(archProjs ?? []);
         setError(null);
       })
       .catch(() => {
@@ -102,6 +106,19 @@ export function ArchivesPage() {
     }
   };
 
+  const restoreProject = async (project: ProjectApiResponse) => {
+    if (!workspaceSlug || restoringProjectId) return;
+    setRestoringProjectId(project.id);
+    try {
+      await projectService.restore(workspaceSlug, project.id);
+      setArchivedProjects((prev) => prev.filter((p) => p.id !== project.id));
+    } catch {
+      setError('Could not restore that project.');
+    } finally {
+      setRestoringProjectId(null);
+    }
+  };
+
   const displayId = (issue: IssueApiResponse) => {
     const p = projectById.get(issue.project_id);
     const prefix = p?.identifier ?? p?.id.slice(0, 8) ?? issue.project_id.slice(0, 8);
@@ -121,6 +138,36 @@ export function ArchivesPage() {
         <p className="rounded-(--radius-md) bg-(--bg-danger-subtle) px-3 py-2 text-sm text-(--txt-danger-primary)">
           {error}
         </p>
+      )}
+
+      {!loading && archivedProjects.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium text-(--txt-secondary)">Archived projects</h2>
+          <ul className="divide-y divide-(--border-subtle) overflow-hidden rounded-(--radius-md) border border-(--border-subtle) bg-(--bg-surface-1)">
+            {archivedProjects.map((project) => (
+              <li
+                key={project.id}
+                className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-(--bg-layer-1-hover)"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium text-(--txt-primary)">
+                  {project.name}
+                </span>
+                <span className="shrink-0 text-xs text-(--txt-tertiary)">
+                  Archived {formatArchivedAt(project.archived_at)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void restoreProject(project)}
+                  disabled={restoringProjectId === project.id}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-(--radius-md) border border-(--border-subtle) px-2 py-1 text-xs text-(--txt-secondary) transition-colors hover:bg-(--bg-layer-1-hover) hover:text-(--txt-primary) disabled:opacity-50"
+                >
+                  <ArchiveRestore className="size-3.5" />
+                  {restoringProjectId === project.id ? 'Restoring…' : 'Restore'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
 
       {loading ? (

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -457,6 +457,7 @@ export function SettingsPage() {
   const [projectMembersSearch, setProjectMembersSearch] = useState('');
   const [projectUpdateLoading, setProjectUpdateLoading] = useState(false);
   const [projectUpdateError, setProjectUpdateError] = useState<string | null>(null);
+  const [archivingProject, setArchivingProject] = useState(false);
   const [inviteTarget, setInviteTarget] = useState<'workspace' | 'project' | null>(null);
   const [projectLabelModalOpen, setProjectLabelModalOpen] = useState(false);
   const [projectLabelEdit, setProjectLabelEdit] = useState<LabelApiResponse | null>(null);
@@ -2000,6 +2001,36 @@ export function SettingsPage() {
                     year: 'numeric',
                   })}
                 </p>
+              )}
+              {workspaceSlug && selectedProjectId && (
+                <div className="mt-4 flex items-center justify-between gap-4 rounded-(--radius-md) border border-(--border-subtle) px-4 py-3">
+                  <div>
+                    <p className="text-sm font-medium text-(--txt-primary)">Archive project</p>
+                    <p className="mt-0.5 text-sm text-(--txt-secondary)">
+                      Hide this project and its work from the workspace. You can restore it later
+                      from Archives.
+                    </p>
+                  </div>
+                  <Button
+                    variant="secondary"
+                    className="shrink-0 text-(--txt-danger-primary)"
+                    disabled={archivingProject}
+                    onClick={async () => {
+                      if (!workspaceSlug || !selectedProjectId) return;
+                      setArchivingProject(true);
+                      try {
+                        await projectService.archive(workspaceSlug, selectedProjectId);
+                        setProjects((prev) => prev.filter((p) => p.id !== selectedProjectId));
+                        navigate(`/${workspaceSlug}`);
+                      } catch {
+                        setProjectUpdateError('Failed to archive project.');
+                        setArchivingProject(false);
+                      }
+                    }}
+                  >
+                    {archivingProject ? 'Archiving…' : 'Archive project'}
+                  </Button>
+                </div>
               )}
               {workspaceSlug && selectedProjectId && (
                 <>

--- a/apps/web/src/services/projectService.ts
+++ b/apps/web/src/services/projectService.ts
@@ -82,6 +82,28 @@ export const projectService = {
     return data;
   },
 
+  /** List the workspace's archived projects. */
+  async listArchived(workspaceSlug: string): Promise<ProjectApiResponse[]> {
+    const { data } = await apiClient.get<ProjectApiResponse[]>(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/archived-projects/`,
+    );
+    return Array.isArray(data) ? data : [];
+  },
+
+  /** Archive a project (hides it from active lists; not deleted). */
+  async archive(workspaceSlug: string, projectId: string): Promise<void> {
+    await apiClient.post(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/archive/`,
+    );
+  },
+
+  /** Restore an archived project. */
+  async restore(workspaceSlug: string, projectId: string): Promise<void> {
+    await apiClient.delete(
+      `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/archive/`,
+    );
+  },
+
   async listMembers(workspaceSlug: string, projectId: string): Promise<ProjectMemberApiResponse[]> {
     const { data } = await apiClient.get<ProjectMemberApiResponse[]>(
       `/api/workspaces/${encodeURIComponent(workspaceSlug)}/projects/${encodeURIComponent(projectId)}/members/`,


### PR DESCRIPTION
## Feature summary

The archive views shipped for work items (list + restore) but not for projects — a project could only be deleted, never archived. Projects can now be archived (hidden from the active lists and sidebar, not deleted) and restored, which closes the remaining piece of this issue.

## Linked issues / discussion

Closes #128

## User-facing behavior

- Project settings → General has an **Archive project** action. Archiving hides the project and its work from the workspace (sidebar, project pickers, active lists) and returns you to the workspace.
- The **Archives** page now has an **Archived projects** section listing archived projects with a **Restore** button that brings a project back.

## What changed

### API (`apps/api/`)
- `model/project.go`: `Project.ArchivedAt` (the `archived_at` column already exists in the schema, so no migration).
- `store/project.go`: `SetArchived`, `ListArchivedByWorkspaceID`, `ListArchivedVisibleByWorkspaceID`, and `archived_at IS NULL` filters on `ListByWorkspaceID` / `ListVisibleByWorkspaceID` so archived projects drop out of the active lists.
- `service/project.go`: `Archive` / `Restore` (require project admin, like Delete) and `ListArchived` (workspace-visible).
- `handler/project.go` + router: `POST` / `DELETE .../projects/:projectId/archive/` and `GET .../archived-projects/`.

### UI (`apps/web/`)
- `projectService` archive/restore/listArchived; an Archive action in project settings; an Archived-projects section with restore on the Archives page.

### Database
- **No migration** — `projects.archived_at` already exists in the initial schema.

## Test plan

- [x] `go vet ./...` and full `go test ./...` green (testcontainers).
- [x] New tests: `TestProject_ArchiveRestore` (archive hides from active list + shows under archived; restore reverses it) and `TestProject_Archive_NonMemberForbidden`.
- [x] `npm run typecheck`, `npm run lint`, `npm run build` green.
- [x] Manual E2E against the running stack: archived a project from its settings → it left the sidebar/active list and appeared under Archives → Archived projects; restored it from Archives → back in the active list. Verified the active/archived project lists via the API at each step.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is <= 100 chars
- [x] No migration (column pre-exists)
- [x] Trailing slashes on new routes match neighboring routes
- [x] No `--no-verify` bypass on the commit
