### PR TITLE
feat(work-item): add sub-group-by (swimlanes) to project work items

### DIFF
--- a/apps/web/src/components/layout/ModuleDetailHeader.tsx
+++ b/apps/web/src/components/layout/ModuleDetailHeader.tsx
@@ -665,7 +665,11 @@ export function ModuleDetailHeader({
             </span>
           }
         >
-          <ProjectIssuesDisplayPanel display={display} setDisplay={setDisplay} />
+          <ProjectIssuesDisplayPanel
+            display={display}
+            setDisplay={setDisplay}
+            enableSubGroup={false}
+          />
         </Dropdown>
 
         <Link

--- a/apps/web/src/components/project-issues/ProjectIssuesDisplayPanel.tsx
+++ b/apps/web/src/components/project-issues/ProjectIssuesDisplayPanel.tsx
@@ -4,7 +4,10 @@ import {
   ALL_SAVED_VIEW_DISPLAY_PROPERTIES,
   SAVED_VIEW_DISPLAY_PROPERTY_LABELS,
 } from '../../lib/projectSavedViewDisplay';
-import type { ProjectIssuesDisplayState } from '../../lib/projectIssuesDisplay';
+import {
+  normalizeSubGroupBy,
+  type ProjectIssuesDisplayState,
+} from '../../lib/projectIssuesDisplay';
 
 const IconChevronDown = () => (
   <svg
@@ -48,7 +51,7 @@ const IconCheck = () => (
   </svg>
 );
 
-type SectionId = 'properties' | 'group' | 'order';
+type SectionId = 'properties' | 'group' | 'subgroup' | 'order';
 
 /** Order matches the work-items Display reference. */
 const GROUP_OPTIONS: { value: SavedViewGroupBy; label: string }[] = [
@@ -130,14 +133,27 @@ const displayPanelCheckboxClass =
 export interface ProjectIssuesDisplayPanelProps {
   display: ProjectIssuesDisplayState;
   setDisplay: React.Dispatch<React.SetStateAction<ProjectIssuesDisplayState>>;
+  /** Show the "Sub-group by" control. Off where the layout doesn't render it. */
+  enableSubGroup?: boolean;
 }
 
-export function ProjectIssuesDisplayPanel({ display, setDisplay }: ProjectIssuesDisplayPanelProps) {
+export function ProjectIssuesDisplayPanel({
+  display,
+  setDisplay,
+  enableSubGroup = true,
+}: ProjectIssuesDisplayPanelProps) {
   const [sections, setSections] = useState<Record<SectionId, boolean>>({
     properties: true,
     group: true,
+    subgroup: true,
     order: true,
   });
+
+  // Sub-group options exclude the current primary group-by (a dimension can't
+  // sub-group by itself); "None" turns sub-grouping off.
+  const subGroupOptions = GROUP_OPTIONS.filter(
+    (opt) => opt.value === 'none' || opt.value !== display.groupBy,
+  );
 
   const toggleSection = (id: SectionId) => {
     setSections((s) => ({ ...s, [id]: !s[id] }));
@@ -195,11 +211,40 @@ export function ProjectIssuesDisplayPanel({ display, setDisplay }: ProjectIssues
                 value={opt.value}
                 label={opt.label}
                 selected={display.groupBy === opt.value}
-                onSelect={(v) => setDisplay((p) => ({ ...p, groupBy: v }))}
+                onSelect={(v) =>
+                  setDisplay((p) => ({
+                    ...p,
+                    groupBy: v,
+                    subGroupBy: normalizeSubGroupBy(v, p.subGroupBy),
+                  }))
+                }
               />
             ))}
           </div>
         </CollapsibleSection>
+
+        {enableSubGroup && display.groupBy !== 'none' && (
+          <CollapsibleSection
+            id="subgroup"
+            title="Sub-group by"
+            expanded={sections.subgroup}
+            onToggle={toggleSection}
+          >
+            <div className="flex flex-col gap-0.5">
+              {subGroupOptions.map((opt) => (
+                <RadioRow
+                  key={opt.value}
+                  value={opt.value}
+                  label={opt.label}
+                  selected={display.subGroupBy === opt.value}
+                  onSelect={(v) =>
+                    setDisplay((p) => ({ ...p, subGroupBy: normalizeSubGroupBy(p.groupBy, v) }))
+                  }
+                />
+              ))}
+            </div>
+          </CollapsibleSection>
+        )}
 
         <CollapsibleSection
           id="order"

--- a/apps/web/src/components/work-item/layouts/IssueLayoutBoard.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutBoard.tsx
@@ -17,7 +17,10 @@ import {
 } from '../EditableCells';
 import { DatePickerTrigger } from '../DatePickerTrigger';
 import { isOverdue, membersFromAssigneeIds } from '../../../lib/issueRowHelpers';
-import type { GroupedIssuesResult } from '../../../lib/issueListGroupAndSort';
+import type {
+  GroupedIssuesResult,
+  SubGroupedIssuesResult,
+} from '../../../lib/issueListGroupAndSort';
 import type {
   SavedViewDisplayPropertyId,
   SavedViewGroupBy,
@@ -38,6 +41,8 @@ import {
 
 interface IssueLayoutBoardProps extends IssueLayoutProps {
   groupedIssues?: GroupedIssuesResult;
+  /** Optional second-level grouping; when present the board renders swimlanes. */
+  subGroupedIssues?: SubGroupedIssuesResult | null;
   hasCol?: (key: SavedViewDisplayPropertyId) => boolean;
   groupBy?: SavedViewGroupBy;
   showEmptyGroups?: boolean;
@@ -59,6 +64,7 @@ export function IssueLayoutBoard({
   now,
   projectsById,
   groupedIssues,
+  subGroupedIssues,
   hasCol: hasColProp,
   groupBy,
   showEmptyGroups = false,
@@ -168,8 +174,12 @@ export function IssueLayoutBoard({
     return { columns, orphans };
   }, [groupedIssues, groupByStateGroup, states, issues, stateById, labelById, showEmptyGroups]);
 
+  // Drag-and-drop is disabled in swimlane mode to keep the cross-dimension
+  // interaction unambiguous (a drop would otherwise be both a column and a lane).
   const dndEnabled =
-    Boolean(onCardMove) && (groupByStateGroup || !groupedIssues || groupBy === 'states');
+    Boolean(onCardMove) &&
+    !subGroupedIssues &&
+    (groupByStateGroup || !groupedIssues || groupBy === 'states');
 
   const renderCard = (issue: IssueApiResponse) => (
     <BoardCard
@@ -213,6 +223,52 @@ export function IssueLayoutBoard({
     const target = resolveTargetStateId(columnKey, issue);
     return Boolean(target) && target !== issue.state_id;
   };
+
+  // Swimlanes: one horizontal band of columns (primary groups) per sub-group.
+  if (subGroupedIssues) {
+    const sg = subGroupedIssues;
+    return (
+      <div className="space-y-6 px-4 py-4">
+        {sg.subOrder.map((subKey) => {
+          const laneCount = sg.primaryOrder.reduce(
+            (n, pk) => n + (sg.cells.get(pk)?.get(subKey)?.length ?? 0),
+            0,
+          );
+          if (laneCount === 0 && !showEmptyGroups) return null;
+          return (
+            <section key={subKey} className="space-y-2">
+              <h3 className="flex items-center gap-2 text-sm font-semibold text-(--txt-primary)">
+                {sg.subTitle(subKey)}
+                <span className="font-normal text-(--txt-tertiary)">{laneCount}</span>
+              </h3>
+              <div className="flex gap-3 overflow-x-auto">
+                {sg.primaryOrder.map((pk) => {
+                  const items = sg.cells.get(pk)?.get(subKey) ?? [];
+                  if (items.length === 0 && !showEmptyGroups) return null;
+                  const color = stateById.get(pk)?.color ?? labelById.get(pk)?.color ?? undefined;
+                  return (
+                    <BoardColumn
+                      key={pk}
+                      title={sg.primaryTitle(pk)}
+                      color={color}
+                      count={items.length}
+                    >
+                      {items.map(renderCard)}
+                      {items.length === 0 && (
+                        <p className="px-2 py-6 text-center text-xs text-(--txt-tertiary)">
+                          No work items
+                        </p>
+                      )}
+                    </BoardColumn>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="flex gap-3 overflow-x-auto px-4 py-4">

--- a/apps/web/src/components/work-item/layouts/IssueLayoutList.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutList.tsx
@@ -20,12 +20,17 @@ import { isOverdue, membersFromAssigneeIds } from '../../../lib/issueRowHelpers'
 import { cn } from '../../../lib/utils';
 import type { IssueApiResponse, LabelApiResponse } from '../../../api/types';
 import type { Priority } from '../../../types';
-import type { GroupedIssuesResult } from '../../../lib/issueListGroupAndSort';
+import type {
+  GroupedIssuesResult,
+  SubGroupedIssuesResult,
+} from '../../../lib/issueListGroupAndSort';
 import type { IssueLayoutProps } from './IssueLayoutTypes';
 
 interface IssueLayoutListProps extends IssueLayoutProps {
   /** Pre-built grouping result from the parent (state/priority/cycle/etc. groupings). */
   groupedIssues: GroupedIssuesResult;
+  /** Optional second-level grouping; when present, sections are nested. */
+  subGroupedIssues?: SubGroupedIssuesResult | null;
   /**
    * Filter columns (display properties) — true means render. Accepts the same
    * narrow `SavedViewDisplayPropertyId` keys the parent's `hasCol` checks; we
@@ -63,6 +68,7 @@ export function IssueLayoutList({
   issueHref,
   now,
   groupedIssues,
+  subGroupedIssues,
   hasCol,
   showEmptyGroups,
   subWorkCountByParentId,
@@ -332,6 +338,50 @@ export function IssueLayoutList({
       <ul className="w-full divide-y divide-(--border-subtle)">
         {flatList.map((issue, idx) => renderRow(issue, idx, flatList))}
       </ul>
+    );
+  }
+
+  // Nested (sub-grouped) rendering: each primary group holds sub-group sections.
+  if (subGroupedIssues) {
+    const sg = subGroupedIssues;
+    return (
+      <div className="space-y-8 px-4 py-4">
+        {sg.primaryOrder.map((primaryKey) => {
+          const bySub = sg.cells.get(primaryKey);
+          const primaryCount = sg.subOrder.reduce(
+            (n, subKey) => n + (bySub?.get(subKey)?.length ?? 0),
+            0,
+          );
+          if (primaryCount === 0 && !showEmptyGroups) return null;
+          return (
+            <section key={primaryKey} className="space-y-3">
+              <h3 className="flex items-center gap-2 text-sm font-semibold text-(--txt-primary)">
+                {sg.primaryTitle(primaryKey)}
+                <span className="font-normal text-(--txt-tertiary)">{primaryCount}</span>
+              </h3>
+              <div className="space-y-3 border-l-2 border-(--border-subtle) pl-3">
+                {sg.subOrder.map((subKey) => {
+                  const cellIssues = bySub?.get(subKey) ?? [];
+                  if (cellIssues.length === 0 && !showEmptyGroups) return null;
+                  return (
+                    <section key={subKey} className="space-y-1.5">
+                      <h4 className="flex items-center gap-2 text-xs font-medium text-(--txt-secondary)">
+                        {sg.subTitle(subKey)}
+                        <span className="font-normal text-(--txt-tertiary)">
+                          {cellIssues.length}
+                        </span>
+                      </h4>
+                      <ul className="w-full divide-y divide-(--border-subtle) rounded-md border border-(--border-subtle) bg-(--bg-surface-1)">
+                        {cellIssues.map((issue) => renderRow(issue))}
+                      </ul>
+                    </section>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
     );
   }
 

--- a/apps/web/src/lib/issueListGroupAndSort.ts
+++ b/apps/web/src/lib/issueListGroupAndSort.ts
@@ -403,3 +403,95 @@ export function buildGroupedIssues(params: {
     isFlat: true,
   };
 }
+
+// subGroupKey returns the bucket key an issue falls into for a given dimension,
+// mirroring the key derivation in buildGroupedIssues exactly (including the
+// sentinel "none" keys) so a sub-grouping lines up with the same dimension's
+// primary grouping.
+export function subGroupKey(
+  dimension: SavedViewGroupBy,
+  issue: IssueApiResponse,
+  labels: LabelApiResponse[],
+): string {
+  switch (dimension) {
+    case 'states':
+      return issue.state_id?.trim() ? issue.state_id : NONE_STATE_KEY;
+    case 'priority':
+      return issue.priority?.trim() || 'none';
+    case 'cycle':
+      return issue.cycle_ids?.[0]?.trim() ?? NONE_CYCLE_KEY;
+    case 'module':
+      return issue.module_ids?.[0]?.trim() ?? NONE_MODULE_KEY;
+    case 'labels': {
+      const ids = [...(issue.label_ids ?? [])].sort((a, b) => {
+        const na = labels.find((l) => l.id === a)?.name ?? a;
+        const nb = labels.find((l) => l.id === b)?.name ?? b;
+        return na.localeCompare(nb);
+      });
+      return ids[0] ?? NONE_LABEL_KEY;
+    }
+    case 'assignees':
+      return issue.assignee_ids?.[0]?.trim() ?? NONE_ASSIGNEE_KEY;
+    case 'created_by':
+      return issue.created_by_id?.trim() ?? NONE_CREATOR_KEY;
+    default:
+      return ALL_GROUP_KEY;
+  }
+}
+
+// A two-level grouping: a primary group-by nested under (or crossed with) a
+// secondary sub-group-by. Cells are keyed cells[primaryKey][subKey].
+export interface SubGroupedIssuesResult {
+  primaryOrder: string[];
+  primaryTitle: (key: string) => string;
+  subOrder: string[];
+  subTitle: (key: string) => string;
+  cells: Map<string, Map<string, IssueApiResponse[]>>;
+}
+
+// buildSubGroupedIssues layers a secondary dimension on top of the primary
+// grouping. Returns null when sub-grouping doesn't apply (no primary group, no
+// sub-group, or the two dimensions are equal), so callers fall back to the
+// normal single-level grouping. It reuses buildGroupedIssues for both
+// dimensions' order + titles so behavior stays consistent.
+export function buildSubGroupedIssues(params: {
+  baseForGrouping: IssueApiResponse[];
+  groupBy: SavedViewGroupBy;
+  subGroupBy: SavedViewGroupBy;
+  orderBy: SavedViewOrderBy;
+  orderDirection?: SavedViewOrderDirection;
+  showEmptyGroups: boolean;
+  states: StateApiResponse[];
+  cycles: CycleApiResponse[];
+  modules: ModuleApiResponse[];
+  labels: LabelApiResponse[];
+  members: WorkspaceMemberApiResponse[];
+}): SubGroupedIssuesResult | null {
+  const { groupBy, subGroupBy, labels } = params;
+  if (groupBy === 'none' || subGroupBy === 'none' || subGroupBy === groupBy) {
+    return null;
+  }
+  const primary = buildGroupedIssues({ ...params, groupBy });
+  const sub = buildGroupedIssues({ ...params, groupBy: subGroupBy });
+  if (primary.isFlat || sub.isFlat) return null;
+
+  const cells = new Map<string, Map<string, IssueApiResponse[]>>();
+  for (const primaryKey of primary.order) {
+    const issues = primary.groups.get(primaryKey) ?? [];
+    const bySub = new Map<string, IssueApiResponse[]>();
+    for (const issue of issues) {
+      const sk = subGroupKey(subGroupBy, issue, labels);
+      const arr = bySub.get(sk) ?? [];
+      arr.push(issue);
+      bySub.set(sk, arr);
+    }
+    cells.set(primaryKey, bySub);
+  }
+  return {
+    primaryOrder: primary.order,
+    primaryTitle: primary.title,
+    subOrder: sub.order,
+    subTitle: sub.title,
+    cells,
+  };
+}

--- a/apps/web/src/lib/projectIssuesDisplay.ts
+++ b/apps/web/src/lib/projectIssuesDisplay.ts
@@ -37,6 +37,7 @@ const ORDER_BY_OPTIONS: SavedViewOrderBy[] = [
 export interface ProjectIssuesDisplayState {
   displayProperties: Set<SavedViewDisplayPropertyId>;
   groupBy: SavedViewGroupBy;
+  subGroupBy: SavedViewGroupBy;
   orderBy: SavedViewOrderBy;
   showSubWorkItems: boolean;
   showEmptyGroups: boolean;
@@ -45,6 +46,7 @@ export interface ProjectIssuesDisplayState {
 export const DEFAULT_PROJECT_ISSUES_DISPLAY: ProjectIssuesDisplayState = {
   displayProperties: new Set(ALL_SAVED_VIEW_DISPLAY_PROPERTIES),
   groupBy: 'none',
+  subGroupBy: 'none',
   orderBy: 'last_created',
   showSubWorkItems: true,
   showEmptyGroups: true,
@@ -54,10 +56,21 @@ export function cloneDefaultProjectIssuesDisplay(): ProjectIssuesDisplayState {
   return {
     displayProperties: new Set(DEFAULT_PROJECT_ISSUES_DISPLAY.displayProperties),
     groupBy: DEFAULT_PROJECT_ISSUES_DISPLAY.groupBy,
+    subGroupBy: DEFAULT_PROJECT_ISSUES_DISPLAY.subGroupBy,
     orderBy: DEFAULT_PROJECT_ISSUES_DISPLAY.orderBy,
     showSubWorkItems: DEFAULT_PROJECT_ISSUES_DISPLAY.showSubWorkItems,
     showEmptyGroups: DEFAULT_PROJECT_ISSUES_DISPLAY.showEmptyGroups,
   };
+}
+
+// A sub-group-by is only meaningful when it's a real dimension different from
+// the primary group-by. Otherwise it collapses to a single sub-group.
+export function normalizeSubGroupBy(
+  groupBy: SavedViewGroupBy,
+  subGroupBy: SavedViewGroupBy,
+): SavedViewGroupBy {
+  if (groupBy === 'none' || subGroupBy === groupBy) return 'none';
+  return subGroupBy;
 }
 
 function isValidPropertyId(x: string): x is SavedViewDisplayPropertyId {
@@ -67,6 +80,7 @@ function isValidPropertyId(x: string): x is SavedViewDisplayPropertyId {
 export interface PersistedProjectIssuesDisplay {
   displayProperties: string[];
   groupBy: string;
+  subGroupBy?: string;
   orderBy: string;
   showSubWorkItems: boolean;
   showEmptyGroups?: boolean;
@@ -85,12 +99,16 @@ export function parseProjectIssuesDisplay(raw: string | null): ProjectIssuesDisp
     const groupBy = GROUP_BY_OPTIONS.includes(p.groupBy as SavedViewGroupBy)
       ? (p.groupBy as SavedViewGroupBy)
       : DEFAULT_PROJECT_ISSUES_DISPLAY.groupBy;
+    const rawSubGroupBy = GROUP_BY_OPTIONS.includes(p.subGroupBy as SavedViewGroupBy)
+      ? (p.subGroupBy as SavedViewGroupBy)
+      : DEFAULT_PROJECT_ISSUES_DISPLAY.subGroupBy;
     const orderBy = ORDER_BY_OPTIONS.includes(p.orderBy as SavedViewOrderBy)
       ? (p.orderBy as SavedViewOrderBy)
       : DEFAULT_PROJECT_ISSUES_DISPLAY.orderBy;
     return {
       displayProperties: props.size > 0 ? props : new Set(ALL_SAVED_VIEW_DISPLAY_PROPERTIES),
       groupBy,
+      subGroupBy: normalizeSubGroupBy(groupBy, rawSubGroupBy),
       orderBy,
       showSubWorkItems: p.showSubWorkItems !== undefined ? Boolean(p.showSubWorkItems) : true,
       showEmptyGroups: p.showEmptyGroups !== undefined ? Boolean(p.showEmptyGroups) : true,
@@ -104,6 +122,7 @@ export function serializeProjectIssuesDisplay(s: ProjectIssuesDisplayState): str
   return JSON.stringify({
     displayProperties: [...s.displayProperties],
     groupBy: s.groupBy,
+    subGroupBy: s.subGroupBy,
     orderBy: s.orderBy,
     showSubWorkItems: s.showSubWorkItems,
     showEmptyGroups: s.showEmptyGroups,
@@ -118,6 +137,7 @@ export function toDisplayPayload(s: ProjectIssuesDisplayState): ProjectIssuesDis
   return {
     displayProperties: [...s.displayProperties],
     groupBy: s.groupBy,
+    subGroupBy: s.subGroupBy,
     orderBy: s.orderBy,
     showSubWorkItems: s.showSubWorkItems,
     showEmptyGroups: s.showEmptyGroups,
@@ -129,11 +149,17 @@ export function fromDisplayPayload(p: ProjectIssuesDisplayPayload): ProjectIssue
   for (const id of p.displayProperties) {
     if (isValidPropertyId(id)) props.add(id);
   }
+  const groupBy = GROUP_BY_OPTIONS.includes(p.groupBy)
+    ? p.groupBy
+    : DEFAULT_PROJECT_ISSUES_DISPLAY.groupBy;
+  const rawSubGroupBy =
+    p.subGroupBy && GROUP_BY_OPTIONS.includes(p.subGroupBy)
+      ? p.subGroupBy
+      : DEFAULT_PROJECT_ISSUES_DISPLAY.subGroupBy;
   return {
     displayProperties: props.size > 0 ? props : new Set(ALL_SAVED_VIEW_DISPLAY_PROPERTIES),
-    groupBy: GROUP_BY_OPTIONS.includes(p.groupBy)
-      ? p.groupBy
-      : DEFAULT_PROJECT_ISSUES_DISPLAY.groupBy,
+    groupBy,
+    subGroupBy: normalizeSubGroupBy(groupBy, rawSubGroupBy),
     orderBy: ORDER_BY_OPTIONS.includes(p.orderBy)
       ? p.orderBy
       : DEFAULT_PROJECT_ISSUES_DISPLAY.orderBy,

--- a/apps/web/src/lib/projectIssuesEvents.ts
+++ b/apps/web/src/lib/projectIssuesEvents.ts
@@ -13,6 +13,7 @@ export const PROJECT_ISSUES_DISPLAY_EVENT = 'project-issues-display-change';
 export interface ProjectIssuesDisplayPayload {
   displayProperties: SavedViewDisplayPropertyId[];
   groupBy: SavedViewGroupBy;
+  subGroupBy?: SavedViewGroupBy;
   orderBy: SavedViewOrderBy;
   showSubWorkItems: boolean;
   showEmptyGroups: boolean;

--- a/apps/web/src/pages/IssueListPage.tsx
+++ b/apps/web/src/pages/IssueListPage.tsx
@@ -31,7 +31,7 @@ import type {
 import type { Priority } from '../types';
 import type { StateGroup } from '../types/workspaceViewFilters';
 import type { SavedViewDisplayPropertyId } from '../lib/projectSavedViewDisplay';
-import { buildGroupedIssues } from '../lib/issueListGroupAndSort';
+import { buildGroupedIssues, buildSubGroupedIssues } from '../lib/issueListGroupAndSort';
 import {
   cloneDefaultProjectIssuesDisplay,
   fromDisplayPayload,
@@ -464,6 +464,37 @@ export function IssueListPage() {
     ],
   );
 
+  // Optional second-level grouping (swimlanes). Null unless both a primary and
+  // a distinct secondary dimension are selected; layouts fall back to the flat
+  // groupedIssues when it's null.
+  const subGroupedIssues = useMemo(
+    () =>
+      buildSubGroupedIssues({
+        baseForGrouping,
+        groupBy: listDisplay.groupBy,
+        subGroupBy: listDisplay.subGroupBy,
+        orderBy: listDisplay.orderBy,
+        showEmptyGroups: listDisplay.showEmptyGroups,
+        states,
+        cycles,
+        modules,
+        labels,
+        members,
+      }),
+    [
+      baseForGrouping,
+      listDisplay.groupBy,
+      listDisplay.subGroupBy,
+      listDisplay.orderBy,
+      listDisplay.showEmptyGroups,
+      states,
+      cycles,
+      modules,
+      labels,
+      members,
+    ],
+  );
+
   // Stable "now" timestamp used by overdue/relative-date cells. Sampled once
   // at mount via useState's lazy initializer (allowed to be impure) so each
   // row stays pure for the rest of the render-tree's lifetime.
@@ -777,6 +808,7 @@ export function IssueListPage() {
             <IssueLayoutList
               {...layoutProps}
               groupedIssues={groupedIssues}
+              subGroupedIssues={subGroupedIssues}
               hasCol={hasCol}
               showEmptyGroups={listDisplay.showEmptyGroups}
               subWorkCountByParentId={subWorkCountByParentId}
@@ -791,6 +823,7 @@ export function IssueListPage() {
             <IssueLayoutBoard
               {...layoutProps}
               {...groupedLayoutProps}
+              subGroupedIssues={subGroupedIssues}
               groupBy={listDisplay.groupBy}
               onCardMove={handleCardMove}
               onUpdateIssue={handleInlineUpdate}


### PR DESCRIPTION
## Feature summary

Work-item layouts now support an optional second grouping dimension: the List nests sub-group sections inside each group, and the Board renders swimlanes.

## Linked issues / discussion

Closes #177

## User-facing behavior

In a project's work items, open **Display**. After picking a primary **Group by**, a new **Sub-group by** control appears offering every other dimension (states, priority, cycle, module, labels, assignees, created by) — it can't equal the primary group-by, and "None" turns it off.

- **List:** each primary group is a section; inside it, one nested sub-section per sub-group, each with its own header + count.
- **Board:** each sub-group is a horizontal swimlane; within a lane, one column per primary group. (e.g. Group by State + Sub-group by Priority → a swimlane per priority, columns per state.)

The choice persists per project (localStorage) alongside the other display options.

## What changed

### UI (`apps/web/`)
- `lib/issueListGroupAndSort.ts`: new `buildSubGroupedIssues` + `subGroupKey`, layered on top of the existing `buildGroupedIssues` (reusing each dimension's ordering and titles). Returns `null` when sub-grouping doesn't apply, so callers fall back to the flat grouping.
- `lib/projectIssuesDisplay.ts` + `projectIssuesEvents.ts`: added `subGroupBy` to the display state, persistence, and event payload, with a `normalizeSubGroupBy` guard (sub-group is cleared when it equals the primary or the primary is "None").
- `ProjectIssuesDisplayPanel.tsx`: new "Sub-group by" section (hidden until a primary group is chosen; excludes the primary; gated by an `enableSubGroup` prop).
- `IssueLayoutList.tsx` / `IssueLayoutBoard.tsx`: nested-section and swimlane rendering when a sub-grouping is present.
- `IssueListPage.tsx`: builds and threads the sub-grouped result to both layouts.
- `ModuleDetailHeader.tsx`: passes `enableSubGroup={false}` (the module view doesn't render swimlanes).

### API / Database
- None.

## Why this design

The flat `GroupedIssuesResult` is consumed by several layouts (spreadsheet, gantt, calendar, …). Rather than change its shape, sub-grouping is a **parallel** structure that only List and Board opt into, so the other layouts are untouched. Both dimensions' key/order/title logic is reused from `buildGroupedIssues` (via a shared `subGroupKey`) so a sub-grouping is always consistent with that dimension's normal grouping. Drag-and-drop is disabled in swimlane mode so a drop isn't ambiguously both a column and a lane change.

## Test plan

- [x] `npm run validate` (typecheck + lint + prettier) green
- [x] Manual end-to-end (Playwright) on a project: Group by **States** + Sub-group by **Priority**
  - List: State sections each nest Priority sub-sections with correct counts (Backlog → High 1, Medium 1; No state → High 1, None 5)
  - Board: swimlanes per Priority, columns per State, items placed in the correct cells
  - Verified "Sub-group by" is hidden until a primary group is set and excludes the current primary
- [ ] Tested at narrow viewport

## Out of scope (follow-ups)

- Swimlanes in the module work-items view
- Drag-and-drop across swimlanes
- Persisting sub-group to saved views (`display_filters`)

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code (Claude Opus 4.8)` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title follows Conventional Commits and is ≤ 100 chars
- [x] Acceptance criteria from the linked issue are met (sub-group nested in list + swimlanes on board; can't equal primary)
