### PR TITLE
fix(ui): keep comment text when a post or edit fails

### DIFF
--- a/apps/web/src/components/work-item/CommentEditor.tsx
+++ b/apps/web/src/components/work-item/CommentEditor.tsx
@@ -125,6 +125,9 @@ export function CommentEditor({
     } catch {
       return;
     }
+    // The await above may outlive the editor (parent unmounts / cancels the
+    // edit); clearing a destroyed editor throws.
+    if (editor.isDestroyed) return;
     editor.commands.clearContent();
     setIsEmpty(true);
   };

--- a/apps/web/src/components/work-item/CommentEditor.tsx
+++ b/apps/web/src/components/work-item/CommentEditor.tsx
@@ -23,7 +23,15 @@ import {
 import { createMentionExtension, type MentionMember } from './editorMention';
 
 export interface CommentEditorProps {
-  onSubmit: (contentHtml: string, access: 'INTERNAL' | 'EXTERNAL') => void | Promise<void>;
+  /**
+   * Called when the user submits. Return (or resolve to) `false` — or throw —
+   * to signal the submit failed; the editor then keeps the typed text instead
+   * of clearing it, so nothing is lost on a network/permission error.
+   */
+  onSubmit: (
+    contentHtml: string,
+    access: 'INTERNAL' | 'EXTERNAL',
+  ) => void | boolean | Promise<void | boolean>;
   isSubmitting?: boolean;
   initialHtml?: string;
   placeholder?: string;
@@ -105,11 +113,18 @@ export function CommentEditor({
 
   if (!editor) return null;
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (isSubmitting) return;
     const html = editor.getHTML().trim();
     if (html === '<p></p>' || html === '') return;
-    void onSubmit(html, access);
+    try {
+      // Only clear once the submit has actually succeeded — otherwise a failed
+      // post/edit would silently discard the user's text.
+      const result = await onSubmit(html, access);
+      if (result === false) return;
+    } catch {
+      return;
+    }
     editor.commands.clearContent();
     setIsEmpty(true);
   };

--- a/apps/web/src/pages/IssueDetailPage.tsx
+++ b/apps/web/src/pages/IssueDetailPage.tsx
@@ -427,8 +427,11 @@ export function IssueDetailPage() {
     return t('common.time.justNow', 'just now');
   };
 
-  const postComment = async (contentHtml: string, access: 'INTERNAL' | 'EXTERNAL' = 'INTERNAL') => {
-    if (!workspaceSlug || !contentHtml.trim()) return;
+  const postComment = async (
+    contentHtml: string,
+    access: 'INTERNAL' | 'EXTERNAL' = 'INTERNAL',
+  ): Promise<boolean> => {
+    if (!workspaceSlug || !contentHtml.trim()) return false;
     setErrorMessage(null);
     setPostingComment(true);
     try {
@@ -440,19 +443,21 @@ export function IssueDetailPage() {
         access,
       );
       setComments((prev) => [...prev, created]);
+      return true;
     } catch (err) {
       setErrorMessage(
         err instanceof Error
           ? err.message
           : t('workItem.detail.postCommentFailed', 'Failed to post comment.'),
       );
+      return false;
     } finally {
       setPostingComment(false);
     }
   };
 
-  const updateComment = async (commentId: string, contentHtml: string) => {
-    if (!workspaceSlug || !contentHtml.trim()) return;
+  const updateComment = async (commentId: string, contentHtml: string): Promise<boolean> => {
+    if (!workspaceSlug || !contentHtml.trim()) return false;
     setErrorMessage(null);
     setUpdatingCommentId(commentId);
     try {
@@ -465,12 +470,14 @@ export function IssueDetailPage() {
       );
       setComments((prev) => prev.map((c) => (c.id === commentId ? updated : c)));
       setEditingCommentId(null);
+      return true;
     } catch (err) {
       setErrorMessage(
         err instanceof Error
           ? err.message
           : t('workItem.detail.updateCommentFailed', 'Failed to update comment.'),
       );
+      return false;
     } finally {
       setUpdatingCommentId(null);
     }
@@ -745,7 +752,7 @@ export function IssueDetailPage() {
                             <div className="mt-2">
                               <CommentEditor
                                 initialHtml={c.comment}
-                                onSubmit={(html) => void updateComment(c.id, html)}
+                                onSubmit={(html) => updateComment(c.id, html)}
                                 isSubmitting={updatingCommentId === c.id}
                                 onCancel={() => setEditingCommentId(null)}
                                 showShortcutHint


### PR DESCRIPTION
## Summary

`CommentEditor` cleared the editor synchronously right after firing `onSubmit`, so a failed comment (offline, 5xx, or the EXTERNAL-comment permission error) was silently lost — the parent showed an error toast but the typed text was already gone.

## Linked issues

Closes #315

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

- `onSubmit` now reports success: it may return/resolve to `false` (or throw) to signal failure. `CommentEditor.handleSubmit` awaits it and only calls `clearContent()` when the submit actually succeeded.
- `postComment` / `updateComment` on the work-item page return `true`/`false` accordingly (they already caught their own errors and showed a message — they just didn't tell the editor).

## Why this approach

The parent deliberately swallows the error to render its own message, so the promise resolved even on failure and the editor couldn't tell success from failure. Rather than make the parent rethrow (which would double-handle the error), the handler now returns a success flag — the least surprising contract for a controlled editor.

## Test plan

- [x] `npm run typecheck` + `npm run lint` (with the i18n gate) pass
- [x] Manual: post a comment with the API stopped → error shows **and the text stays** in the composer; retry after the API is back → posts and clears. Same for inline edit.

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code (Opus 4.8)` — commits carry a `Co-Authored-By:` trailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comment drafts are no longer cleared when posting or editing fails.
  * Failed comment submissions now display an error while preserving entered content for retry.
  * Comment posting and editing states reset reliably after completion, including failed requests.
  * Empty comments and unavailable workspace details are handled without losing the draft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->