### PR TITLE
fix(ui): don't wipe the current project when a stale fetch rejects

### DIFF
--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -71,7 +71,8 @@ export function PageHeader() {
         if (!cancelled && list) setProjects(list);
       })
       .catch(() => {
-        if (!cancelled) setWorkspace(null);
+        if (cancelled) return;
+        setWorkspace(null);
         setProjects([]);
       });
     return () => {
@@ -98,7 +99,8 @@ export function PageHeader() {
         if (!cancelled && Array.isArray(issues)) setProjectIssueCount(issues.length);
       })
       .catch(() => {
-        if (!cancelled) setProject(null);
+        if (cancelled) return;
+        setProject(null);
         setProjectIssueCount(0);
       });
     return () => {

--- a/apps/web/src/pages/IssueListPage.tsx
+++ b/apps/web/src/pages/IssueListPage.tsx
@@ -205,7 +205,10 @@ export function IssueListPage() {
         setMembers(mem ?? []);
       })
       .catch(() => {
-        if (!cancelled) setWorkspace(null);
+        // Guard the whole reset: a stale request rejecting after the user
+        // switched projects must not wipe the newly-loaded project's data.
+        if (cancelled) return;
+        setWorkspace(null);
         setProject(null);
         setProjects([]);
         setIssues([]);

--- a/apps/web/src/pages/ProjectsListPage.tsx
+++ b/apps/web/src/pages/ProjectsListPage.tsx
@@ -113,7 +113,8 @@ export function ProjectsListPage() {
         if (!cancelled && list) setAllProjects(list);
       })
       .catch(() => {
-        if (!cancelled) setWorkspace(null);
+        if (cancelled) return;
+        setWorkspace(null);
         setAllProjects([]);
       })
       .finally(() => {


### PR DESCRIPTION
## Summary

The issue-list aggregate load guarded only the **first** setter in its `.catch`; the rest ran unconditionally. Opening project A then quickly switching to B — if A's request rejected after B had loaded — cleared B's issues/states/labels/cycles/modules and left an empty page for a perfectly valid project.

## Linked issues

Closes #316

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

- `IssueListPage`: replaced `if (!cancelled) setWorkspace(null)` (with 8 unguarded setters after it) with an early `if (cancelled) return;` so the whole reset is skipped for a stale request.
- Applied the same one-line guard to `ProjectsListPage` and both loaders in `PageHeader`, which had the identical partial-guard pattern.

## Why this approach

The `cancelled` flag already exists (flipped in each effect's cleanup); it was just applied to one line instead of the block. Early-returning the entire catch is the smallest correct fix and matches how the `.then`/`.finally` handlers in the same effects already guard.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Manual: throttle the network, open project A, immediately switch to B; A's load loses the race and rejects → B stays intact (before this change B blanked out).

## AI assistance

- [x] AI tools were used — tool(s): `Claude Code (Opus 4.8)` — commits carry a `Co-Authored-By:` trailer