### PR TITLE
fix(api): seed default Cancelled state in the "cancelled" group

### DIFF
--- a/apps/api/internal/service/state.go
+++ b/apps/api/internal/service/state.go
@@ -80,7 +80,7 @@ var defaultProjectStates = []struct {
 	{name: "Todo", color: "#60646C", sequence: 25000, group: "unstarted"},
 	{name: "In Progress", color: "#F59E0B", sequence: 35000, group: "started"},
 	{name: "Done", color: "#46A758", sequence: 45000, group: "completed"},
-	{name: "Cancelled", color: "#9AA4BC", sequence: 55000, group: "canceled"},
+	{name: "Cancelled", color: "#9AA4BC", sequence: 55000, group: "cancelled"},
 }
 
 func (s *StateService) ensureDefaultStates(ctx context.Context, projectID, workspaceID uuid.UUID) error {

--- a/apps/api/internal/service/state_default_test.go
+++ b/apps/api/internal/service/state_default_test.go
@@ -1,0 +1,29 @@
+package service
+
+import "testing"
+
+// Every seeded default state must use a group the app actually recognises.
+// This guards against typos like "canceled" vs "cancelled", which silently
+// broke auto-close, auto-archive and progress bucketing for every new project.
+func TestDefaultProjectStatesUseValidGroups(t *testing.T) {
+	for _, st := range defaultProjectStates {
+		if !validStateGroups[st.group] {
+			t.Errorf("default state %q has group %q which is not in validStateGroups", st.name, st.group)
+		}
+	}
+
+	// The Cancelled state specifically must be in the "cancelled" group so
+	// auto-close/archive and progress charts pick it up.
+	var found bool
+	for _, st := range defaultProjectStates {
+		if st.name == "Cancelled" {
+			found = true
+			if st.group != "cancelled" {
+				t.Errorf("Cancelled state group = %q; want \"cancelled\"", st.group)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no default Cancelled state found")
+	}
+}

--- a/apps/api/migrations/000013_fix_cancelled_state_group.down.sql
+++ b/apps/api/migrations/000013_fix_cancelled_state_group.down.sql
@@ -1,0 +1,5 @@
+-- This migration fixes a typo in existing data. There is no safe way to
+-- reverse it: we can't tell which "cancelled" rows were the mistyped default
+-- versus states that were always spelled correctly, and reintroducing the typo
+-- would just bring the bug back. Intentionally a no-op.
+SELECT 1;

--- a/apps/api/migrations/000013_fix_cancelled_state_group.up.sql
+++ b/apps/api/migrations/000013_fix_cancelled_state_group.up.sql
@@ -1,0 +1,6 @@
+-- Every project's default "Cancelled" state was seeded with the group
+-- "canceled" (one L) while the rest of the app matches on "cancelled" (two L).
+-- That mismatch made auto-close a no-op, kept cancelled issues out of
+-- auto-archive, and mis-bucketed them as "backlog" in every progress chart.
+-- Correct the existing rows so they line up with the seed fix.
+UPDATE states SET "group" = 'cancelled' WHERE "group" = 'canceled';


### PR DESCRIPTION
## Summary

The default "Cancelled" state was seeded with the group `"canceled"` (one L) while the rest of the backend matches on `"cancelled"` (two L). Since it's the default for every new project, several things quietly broke.

## Linked issues

Closes #333

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)
- [x] Database migration (`apps/api/migrations/`)

## What changed

- `state.go`: seed the default Cancelled state with group `"cancelled"`.
- Migration `000013`: `UPDATE states SET "group" = 'cancelled' WHERE "group" = 'canceled'` to fix existing projects. The down migration is a documented no-op (reversing a typo fix isn't safe, we can't tell which rows were originally mistyped).
- Test `TestDefaultProjectStatesUseValidGroups`: asserts every default state's group is in `validStateGroups`, so this kind of typo fails the build next time.

## What this fixes

With the wrong group, for every new project: auto-close silently did nothing (`CloseInactiveBefore` matches `group = 'cancelled'`), auto-archive skipped cancelled issues, progress charts counted cancelled work as backlog, and open/closed filters treated cancelled issues as open.

## Test plan

- [x] `go test ./...` green (new test included)
- [x] `go vet ./...` clean
- [x] Migration filename follows the `NNNNNN_name.{up,down}.sql` convention and applies as a plain UPDATE

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, and AI-assisted commits carry a `Co-Authored-By:` trailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default “Cancelled” workflow state grouping to use the accepted `cancelled` value.
  * Updated existing records to ensure cancellation-related automation and progress reporting work consistently.
* **Tests**
  * Added validation to ensure default workflow states use supported group values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->