### PR TITLE
fix(ui): sanitize external quicklink URLs

### DIFF
--- a/apps/web/src/pages/WorkspaceHomePage.tsx
+++ b/apps/web/src/pages/WorkspaceHomePage.tsx
@@ -10,6 +10,7 @@ import { stickiesService } from '../services/stickiesService';
 import { StickyNoteCard } from '../components/stickies/StickyNoteCard';
 import { pickRandomStickyBackground } from '../components/stickies/stickyPalette';
 import { OPEN_HOME_WIDGETS } from '../lib/homeWidgetsEvents';
+import { safeUrl } from '../lib/sanitize';
 import { recentsService } from '../services/recentsService';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
@@ -425,7 +426,9 @@ function QuicklinkCardRow({
   const menuRootRef = useRef<HTMLDivElement>(null);
   const label = ql.title?.trim() || ql.url;
   const isInternal = !!ql.project_id;
-  const href = isInternal ? `${baseUrl}/projects/${ql.project_id}` : ql.url;
+  // External quicklink URLs are user-supplied, so run them through safeUrl to
+  // block javascript:/data: and other non http(s) schemes.
+  const href = isInternal ? `${baseUrl}/projects/${ql.project_id}` : safeUrl(ql.url);
 
   useEffect(() => {
     if (!menuOpen) return;


### PR DESCRIPTION
## Summary

The home page rendered a quicklink's stored URL straight into the anchor `href`, so a `javascript:` URL would run when someone clicked the link.

## Linked issues

Closes #327

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

`WorkspaceHomePage.tsx`: the external quicklink `href` now goes through `safeUrl` (the same helper every other link surface uses), which only allows http/https/mailto. The favicon, copy and open-in-new-tab paths already used a helper that forced an `https://` prefix, so only the clickable anchor was exposed.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Manual: a quicklink saved with `javascript:...` now resolves to a dead `#` instead of running

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer