### PR TITLE
fix(api): cap the GitHub webhook request body size

### DIFF
--- a/apps/api/internal/handler/integration.go
+++ b/apps/api/internal/handler/integration.go
@@ -501,8 +501,18 @@ func (h *IntegrationHandler) GitHubIssueSummary(c *gin.Context) {
 // auth — authentication is the HMAC signature in X-Hub-Signature-256.
 // POST /webhooks/github
 func (h *IntegrationHandler) GitHubWebhook(c *gin.Context) {
+	// This route is public (auth is the HMAC signature). Cap the body before
+	// reading it so an unauthenticated client can't exhaust memory with a huge
+	// payload. GitHub caps webhook deliveries at 25 MiB.
+	const maxWebhookBody = 25 << 20
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxWebhookBody)
 	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "Payload too large"})
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read body"})
 		return
 	}


### PR DESCRIPTION
## Summary

The GitHub webhook receiver read the whole request body with `io.ReadAll` and no size limit, before checking the signature, on a public unauthenticated route. A single large POST, or a few concurrent ones, could exhaust process memory.

## Linked issues

Closes #329

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)

## What changed

Wrap `c.Request.Body` in `http.MaxBytesReader` at GitHub's 25 MiB payload cap before reading, and return 413 when it's exceeded.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green
- [x] Reasoning: a body over 25 MiB now fails the read with a `MaxBytesError` and returns 413 instead of being buffered in full

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer