### PR TITLE
fix(api): neutralize formula injection in the issue export

### DIFF
--- a/apps/api/internal/service/export.go
+++ b/apps/api/internal/service/export.go
@@ -106,6 +106,23 @@ func (s *ExportService) ListHistory(ctx context.Context, slug string, userID uui
 
 const exportPageSize = 500
 
+// neutralizeFormula guards a spreadsheet cell against formula injection. Excel,
+// LibreOffice and Sheets execute a cell whose text begins with =, +, -, @, tab
+// or carriage return as a formula, so user-controlled text (issue/project/state
+// names) that starts with one of those is prefixed with a single quote, which
+// forces it to be treated as literal text. Non-string values pass through.
+func neutralizeFormula(v interface{}) interface{} {
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return v
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + s
+	}
+	return v
+}
+
 func (s *ExportService) buildWorkbook(ctx context.Context, projectIDs []uuid.UUID) ([]byte, error) {
 	f := excelize.NewFile()
 	defer func() { _ = f.Close() }()
@@ -158,7 +175,7 @@ func (s *ExportService) buildWorkbook(ctx context.Context, projectIDs []uuid.UUI
 				}
 				for c, v := range values {
 					cell, _ := excelize.CoordinatesToCellName(c+1, row)
-					_ = f.SetCellValue(sheet, cell, v)
+					_ = f.SetCellValue(sheet, cell, neutralizeFormula(v))
 				}
 				row++
 			}

--- a/apps/api/internal/service/export_formula_test.go
+++ b/apps/api/internal/service/export_formula_test.go
@@ -1,0 +1,25 @@
+package service
+
+import "testing"
+
+func TestNeutralizeFormula(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want interface{}
+	}{
+		{"=HYPERLINK(\"http://evil\")", "'=HYPERLINK(\"http://evil\")"},
+		{"+1+2", "'+1+2"},
+		{"-2+3", "'-2+3"},
+		{"@SUM(A1)", "'@SUM(A1)"},
+		{"\tstartsWithTab", "'\tstartsWithTab"},
+		{"\rstartsWithCR", "'\rstartsWithCR"},
+		{"Normal title", "Normal title"},
+		{"", ""},
+		{42, 42}, // non-string values pass through untouched
+	}
+	for _, tc := range cases {
+		if got := neutralizeFormula(tc.in); got != tc.want {
+			t.Errorf("neutralizeFormula(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Issue, project and state names were written straight into spreadsheet cells, so a work item title like `=HYPERLINK(...)`, `+cmd`, `-2+3` or `@SUM(...)` became a live formula when the exported `.xlsx` was opened in Excel, LibreOffice or Sheets. Titles are user-controlled, so anyone who can create an issue could plant one and whoever exported and opened the file would trigger it.

## Linked issues

Closes #331

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)

## What changed

Added `neutralizeFormula`, which prefixes any cell text starting with `=`, `+`, `-`, `@`, tab or CR with a single quote so the spreadsheet treats it as literal text. Applied it to every cell value in the workbook builder. Non-string values pass through untouched.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green, including the new `TestNeutralizeFormula`

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer