### PR TITLE
fix(api): don't double-run webhook side effects on a concurrent duplicate

### DIFF
--- a/apps/api/internal/service/github_events.go
+++ b/apps/api/internal/service/github_events.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Devlaner/devlane/api/internal/model"
 	"github.com/Devlaner/devlane/api/internal/store"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // GithubEventService processes inbound webhook events: it owns the side-effects
@@ -101,6 +102,13 @@ func (s *GithubEventService) HandleWebhook(ctx context.Context, event, deliveryI
 		Status:             "received",
 	}
 	if err := s.events.Create(ctx, logRow); err != nil {
+		// A concurrent duplicate delivery loses the race on the unique
+		// delivery_id constraint. The winning delivery is already running the
+		// side effects, so stop here instead of dispatching them again.
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			s.logger().Debug("github webhook delivery already processed (concurrent)", "delivery_id", deliveryID, "event", event)
+			return nil
+		}
 		s.logger().Error("failed to record github webhook event", "delivery_id", deliveryID, "error", err)
 	}
 


### PR DESCRIPTION
## Summary

Webhook deduplication was a check-then-act: `ExistsByDeliveryID` then `Create`. Two concurrent deliveries of the same GitHub event both pass the exists check; one `Create` wins and the other fails the unique `delivery_id` constraint. That error was only logged, so the losing racer fell through to `dispatch` and ran the side effects a second time, giving duplicate bot comments and duplicate or oscillating state changes.

## Linked issues

Closes #332

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)

## What changed

Treat a duplicate-key error from `Create` (`gorm.ErrDuplicatedKey`, already used elsewhere with `TranslateError` on) as "already processed" and return before dispatching. Sequential redeliveries were already short-circuited by the exists check; this closes the concurrent window.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer