### PR TITLE
fix(api): reject a placeholder or too-short encryption key in production

### DIFF
--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -109,15 +109,36 @@ func Load() (*Config, error) {
 		if cfg.MagicCodeSecret == "" {
 			missing = append(missing, "MAGIC_CODE_SECRET")
 		}
-		if os.Getenv("INSTANCE_ENCRYPTION_KEY") == "" {
+		encKey := os.Getenv("INSTANCE_ENCRYPTION_KEY")
+		if encKey == "" {
 			missing = append(missing, "INSTANCE_ENCRYPTION_KEY")
 		}
 		if len(missing) > 0 {
 			return nil, fmt.Errorf("missing required production secrets %v (set ENV=development only for local dev)", missing)
 		}
+		// A set-but-weak encryption key is as dangerous as a missing one: it
+		// feeds the AES key that protects instance secrets (SMTP password, OAuth
+		// client secrets, GitHub App private key). Reject the shipped placeholder
+		// and anything too short to be meaningfully random.
+		if isWeakSecret(encKey) {
+			return nil, fmt.Errorf("INSTANCE_ENCRYPTION_KEY is a placeholder or too short; set a random value of at least 16 characters for production")
+		}
 	}
 
 	return cfg, nil
+}
+
+// isWeakSecret reports whether a production secret is unusable: a known
+// .env.example placeholder, or too short to carry meaningful entropy.
+func isWeakSecret(v string) bool {
+	if len(v) < 16 {
+		return true
+	}
+	switch v {
+	case "change-me-generate-a-random-key", "change-me", "changeme":
+		return true
+	}
+	return false
 }
 
 func getEnv(key, defaultVal string) string {

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -1,0 +1,29 @@
+package config
+
+import "testing"
+
+func TestIsWeakSecret(t *testing.T) {
+	weak := []string{
+		"",
+		"short",
+		"change-me-generate-a-random-key",
+		"change-me",
+		"changeme",
+		"0123456789abcde", // 15 chars
+	}
+	for _, v := range weak {
+		if !isWeakSecret(v) {
+			t.Errorf("isWeakSecret(%q) = false; want true", v)
+		}
+	}
+
+	strong := []string{
+		"0123456789abcdef",                  // 16 chars
+		"a-perfectly-fine-random-key-value", // long, non-placeholder
+	}
+	for _, v := range strong {
+		if isWeakSecret(v) {
+			t.Errorf("isWeakSecret(%q) = true; want false", v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The production guard only checked that `INSTANCE_ENCRYPTION_KEY` was set, and `.env.example` ships it as `change-me-generate-a-random-key`. Copying the example to a real host and setting `ENV=production` passed the guard while encrypting all instance secrets (SMTP password, OAuth client secrets, GitHub App private key) under a publicly known key.

## Linked issues

Closes #330

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)

## What changed

Added `isWeakSecret`, and the production startup guard now rejects a set-but-weak `INSTANCE_ENCRYPTION_KEY`: the shipped placeholder values and anything shorter than 16 characters fail startup outside development, alongside the existing empty check.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green, including the new `TestIsWeakSecret`

## Notes

The issue also mentions `ENV` defaulting to `development` and the key being read via `os.Getenv` instead of the `Config` struct. I kept this PR to the concrete "placeholder passes the guard" hole. Happy to follow up on the default and the config threading if you want them in scope.

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer