### PR TITLE
fix(ui): let the command palette search terms starting with c or p

### DIFF
--- a/apps/web/src/components/layout/GlobalCommandPalette.tsx
+++ b/apps/web/src/components/layout/GlobalCommandPalette.tsx
@@ -147,7 +147,6 @@ export function GlobalCommandPalette({
         id: 'create-issue',
         category: t('commandPalette.category.workItem', 'Work item'),
         label: t('commandPalette.createIssue', 'Create new work item'),
-        shortcut: 'C',
         matchText: t('commandPalette.createIssue.match', 'new issue task'),
         icon: <CirclePlus className="size-[15px] shrink-0" strokeWidth={2} />,
         run: () => runAndClose(onRequestCreateWorkItem),
@@ -172,7 +171,6 @@ export function GlobalCommandPalette({
         id: 'create-project',
         category: t('commandPalette.category.project', 'Project'),
         label: t('commandPalette.createProject', 'Go to projects'),
-        shortcut: 'P',
         matchText: t('commandPalette.createProject.match', 'create new project list'),
         icon: <FolderKanban className="size-[15px] shrink-0 opacity-90" strokeWidth={2} />,
         run: () => runAndClose(() => navigate(`${baseUrl}/projects`)),
@@ -541,16 +539,6 @@ export function GlobalCommandPalette({
 
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing) return;
-
-    if (!e.ctrlKey && !e.metaKey && !e.altKey && e.key.length === 1 && query.trim() === '') {
-      const letter = e.key.toUpperCase();
-      const hit = filtered.find((c) => c.shortcut?.toUpperCase() === letter);
-      if (hit) {
-        e.preventDefault();
-        hit.run();
-        return;
-      }
-    }
 
     if (e.key === 'ArrowDown') {
       e.preventDefault();


### PR DESCRIPTION
## Summary

With an empty query, a single keystroke that matched a command's shortcut ran the command and consumed the key. `create-issue` used `C` and `create-project` used `P`, so you couldn't type a search that started with either letter.

## Linked issues

Closes #338

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

Removed the type-to-run shortcut handling in the palette input, so every printable character goes into the search box. The commands are still reachable by typing and pressing Enter (or clicking). Nothing else bound these single-key shortcuts, so no global accelerator is lost.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Manual: open the palette and type "cy" or "pr" and it filters instead of firing a command

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer