### PR TITLE
fix(ui): stop Gantt dates shifting a day for clients behind UTC

### DIFF
--- a/apps/web/src/components/work-item/layouts/IssueLayoutGantt.tsx
+++ b/apps/web/src/components/work-item/layouts/IssueLayoutGantt.tsx
@@ -420,9 +420,14 @@ function startOfDay(d: Date): Date {
 }
 
 function parseDay(input: string): number | null {
-  const t = Date.parse(input);
-  if (Number.isNaN(t)) return null;
-  return startOfDay(new Date(t)).getTime();
+  // Dates arrive as "YYYY-MM-DD" or a UTC-midnight ISO timestamp. Take the
+  // leading date parts and build a local-midnight date, so the day doesn't
+  // shift for clients behind UTC. Routing the value through Date.parse +
+  // new Date reads local components off a UTC instant and lands on the previous
+  // day in the Americas (the calendar layout avoids this the same way).
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(input);
+  if (!m) return null;
+  return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])).getTime();
 }
 
 function pad2(n: number): string {


### PR DESCRIPTION
## Summary

On the Gantt layout, dates were off by one day for anyone in a timezone behind UTC, and dragging a bar by a day saved the date it already had.

## Linked issues

Closes #337

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

`parseDay` used `Date.parse(input)` then read local components off the resulting UTC instant, so `2026-07-16` became the 15th in the Americas. `fmtDay` then re-serialized from those shifted components, so a one-day drag computed 15th + 1 = 16th and saved the original date. Now `parseDay` takes the leading `YYYY-MM-DD` and builds a local-midnight date, matching how the calendar layout handles it.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Manual (UTC-5 browser): a target date of 2026-07-16 now renders on the 16th, and dragging by a day saves 2026-07-17

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer