### PR TITLE
fix(ui): apply the saved theme before paint to avoid a light flash

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,6 +1,29 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en">
   <head>
+    <script>
+      // Apply the saved theme before the bundle paints so dark/pink users don't
+      // flash light first. Mirrors ThemeContext (key, values, system fallback).
+      (function () {
+        try {
+          var pref = localStorage.getItem('devlane-theme');
+          if (pref !== 'light' && pref !== 'dark' && pref !== 'system' && pref !== 'pink') {
+            pref = 'system';
+          }
+          var effective = pref;
+          if (pref === 'system') {
+            effective = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          if (effective === 'dark' || effective === 'pink') {
+            document.documentElement.setAttribute('data-theme', effective);
+          } else {
+            document.documentElement.removeAttribute('data-theme');
+          }
+        } catch (e) {
+          /* localStorage blocked; fall back to the default light theme */
+        }
+      })();
+    </script>
     <link rel="icon" href="/devlane-2-dark-no-bg.png" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary

Users with a dark or pink theme saw a flash of the light theme on every page load.

## Linked issues

Closes #348

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

`index.html` hardcoded `data-theme="light"` and the real theme was only reconciled once React ran (a `useLayoutEffect` in `ThemeContext`). Added a small blocking script in the `<head>` that reads `devlane-theme` from localStorage, mirrors `ThemeContext`'s values and system fallback, and sets `data-theme` before the bundle paints. Dropped the hardcoded `data-theme="light"` since the script now owns it (and light is the attribute-less default).

## Test plan

- [x] `npm run build` succeeds
- [x] Manual: with `devlane-theme` set to dark, a reload paints dark immediately instead of flashing light

## Notes

The issue also mentions cross-tab sync via the `storage` event. Left that out to keep this focused on the flash, happy to add it if you want it here.

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer