### PR TITLE
fix(api): exclude removed issues from module progress

### DIFF
--- a/apps/api/internal/store/module.go
+++ b/apps/api/internal/store/module.go
@@ -184,7 +184,7 @@ func (s *ModuleStore) StateDistributionByProject(ctx context.Context, projectID 
 		FROM module_issues mi
 		JOIN issues i ON i.id = mi.issue_id AND i.deleted_at IS NULL
 		LEFT JOIN states st ON st.id = i.state_id
-		WHERE mi.project_id = ?
+		WHERE mi.project_id = ? AND mi.deleted_at IS NULL
 		GROUP BY mi.module_id, COALESCE(st."group", 'backlog')
 	`, projectID).Scan(&rows).Error
 	if err != nil {


### PR DESCRIPTION
## Summary

Module progress counted issues that had been removed from the module.

## Linked issues

Closes #343

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)

## What changed

`ModuleStore.StateDistributionByProject` is a raw SQL query, so GORM doesn't add the soft-delete scope automatically, and it was missing `AND mi.deleted_at IS NULL`. `RemoveModuleIssue` soft-deletes the link, so removed issues stayed in the progress totals. Added the filter, matching the cycle version which already has it.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green
- [x] One-line WHERE change mirroring `CycleStore.StateDistributionByProject`

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded soft-deleted module issues from per-module issue counts.
  * Updated project state distributions to reflect only active module issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->