### PR TITLE
fix(ui): reset module and workspace-view filters when the scope changes

### DIFF
--- a/apps/web/src/contexts/ModulesFilterContext.tsx
+++ b/apps/web/src/contexts/ModulesFilterContext.tsx
@@ -36,6 +36,8 @@ export interface ModulesFilterContextValue extends ModulesFilterState {
   setDueAfter: (v: string | null) => void;
   setDueBefore: (v: string | null) => void;
   updateFilter: (updater: (prev: ModulesFilterState) => Partial<ModulesFilterState>) => void;
+  /** Reset every filter back to defaults (e.g. when switching projects). */
+  reset: () => void;
 }
 
 const defaultState: ModulesFilterState = {
@@ -66,6 +68,8 @@ export function ModulesFilterProvider({ children }: { children: ReactNode }) {
     },
     [],
   );
+
+  const reset = useCallback(() => setState(defaultState), []);
 
   const setSearch = useCallback((v: string) => {
     setState((prev) => ({ ...prev, search: v }));
@@ -143,6 +147,7 @@ export function ModulesFilterProvider({ children }: { children: ReactNode }) {
       setDueAfter,
       setDueBefore,
       updateFilter,
+      reset,
     }),
     [
       state,
@@ -161,6 +166,7 @@ export function ModulesFilterProvider({ children }: { children: ReactNode }) {
       setDueAfter,
       setDueBefore,
       updateFilter,
+      reset,
     ],
   );
 

--- a/apps/web/src/pages/ModulesPage.tsx
+++ b/apps/web/src/pages/ModulesPage.tsx
@@ -157,6 +157,12 @@ function ModuleProgressCircle({ progress }: { progress: number }) {
   );
 }
 
+// The modules filter provider lives at the app-shell root and outlives this
+// page, so its status/lead/member ids (which are project-specific) would carry
+// over into another project. Track the project the filter was last set for at
+// module scope so it survives remounts, and reset when the project changes.
+let lastFilteredProjectId: string | undefined;
+
 export function ModulesPage() {
   const { t } = useTranslation();
   const { workspaceSlug, projectId } = useParams<{
@@ -164,6 +170,13 @@ export function ModulesPage() {
     projectId: string;
   }>();
   const filter = useModulesFilter();
+  const resetFilter = filter.reset;
+  useEffect(() => {
+    if (projectId && projectId !== lastFilteredProjectId) {
+      lastFilteredProjectId = projectId;
+      resetFilter();
+    }
+  }, [projectId, resetFilter]);
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [project, setProject] = useState<ProjectApiResponse | null>(null);
   const [modules, setModules] = useState<ModuleApiResponse[]>([]);

--- a/apps/web/src/pages/WorkspaceViewsPage.tsx
+++ b/apps/web/src/pages/WorkspaceViewsPage.tsx
@@ -183,6 +183,11 @@ export function WorkspaceViewsPage() {
     if (prevViewIdRef.current !== viewId) {
       prevViewIdRef.current = viewId;
       viewAppliedRef.current = false;
+      // Static views (all-issues, assigned, etc.) carry no saved filters, so
+      // clear any left over from a custom view instead of keeping them applied.
+      if (!isCustomViewId(viewId)) {
+        setFilters(parseWorkspaceViewFiltersFromSearchParams(new URLSearchParams()));
+      }
     }
     if (!workspaceSlug || !viewId || !isCustomViewId(viewId) || viewAppliedRef.current) return;
     viewAppliedRef.current = true;


### PR DESCRIPTION
## Summary

Module and workspace-view filters carried over across navigation, so you could end up filtering one project by another project's member/lead/status ids (usually showing nothing).

## Linked issues

Closes #339

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

- The modules filter provider lives at the app-shell root and outlives the page. `ModulesFilterContext` now exposes a `reset`, and `ModulesPage` calls it when the project id changes. The last-filtered project is tracked at module scope so the reset still fires when you leave the modules page and come back under a different project (the provider keeps the stale state across that remount, a page-local ref wouldn't catch it).
- Workspace views had the mirror bug: switching from a custom view (with saved filters) to a static view left the custom view's filters applied because the apply effect early-returned for static views. It now clears filters back to defaults when the target view is static.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Manual: filter modules in project A by a member, open project B's modules, filters are cleared; apply filters in a custom view, switch to All issues, filters are cleared

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Module filters are now cleared when switching between projects, preventing filters from carrying over unexpectedly.
  - Custom view filters are reset when navigating to built-in workspace views.
  - Filter state now resets consistently when changing contexts, showing results relevant to the selected project or view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->