### PR TITLE
perf(api): index the module join tables

### DIFF
--- a/apps/api/migrations/000014_module_join_indexes.down.sql
+++ b/apps/api/migrations/000014_module_join_indexes.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_module_issues_module;
+DROP INDEX IF EXISTS idx_module_issues_issue;
+DROP INDEX IF EXISTS idx_module_members_module;
+DROP INDEX IF EXISTS idx_module_links_module;

--- a/apps/api/migrations/000014_module_join_indexes.up.sql
+++ b/apps/api/migrations/000014_module_join_indexes.up.sql
@@ -1,0 +1,8 @@
+-- The module join tables had no indexes, so every lookup by module_id or
+-- issue_id did a sequential scan (ListModuleIssueIDs, RemoveModuleIssue,
+-- CountIssuesByModuleIDs, ListMemberIDsByModuleIDs, the progress join, etc.).
+-- The cycle join tables already have the equivalent indexes; add them here.
+CREATE INDEX IF NOT EXISTS idx_module_issues_module ON module_issues (module_id);
+CREATE INDEX IF NOT EXISTS idx_module_issues_issue ON module_issues (issue_id);
+CREATE INDEX IF NOT EXISTS idx_module_members_module ON module_members (module_id);
+CREATE INDEX IF NOT EXISTS idx_module_links_module ON module_links (module_id);


### PR DESCRIPTION
## Summary

The module join tables (`module_issues`, `module_members`, `module_links`) had no indexes, so every lookup by `module_id` or `issue_id` was a sequential scan. The cycle join tables already have the equivalent indexes.

## Linked issues

Refs #346 (the index half)

## Type of change

- [x] Performance (`perf:`)

## Surface

- [x] API (`apps/api/`)
- [x] Database migration (`apps/api/migrations/`)

## What changed

Migration `000014` adds `idx_module_issues_module`, `idx_module_issues_issue`, `idx_module_members_module` and `idx_module_links_module`, using `CREATE INDEX IF NOT EXISTS` so it's safe to re-run.

## Scope note

Issue #346 also flags N+1 association loading in the issue list/detail paths. That's a larger refactor (batching assignees/labels/cycles/modules), so I've left it for a separate PR and kept this one to the indexes.

## Migration ordering

I have another open PR (#350) that adds `000013`. This one is `000014`, so it should merge after #350 to keep the sequence clean. Happy to renumber if you'd prefer.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green; migration applies as plain `CREATE INDEX IF NOT EXISTS`

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer