### PR TITLE
fix(api): download attachments instead of rendering them inline

### DIFF
--- a/apps/api/internal/handler/upload.go
+++ b/apps/api/internal/handler/upload.go
@@ -187,6 +187,14 @@ func (h *UploadHandler) ServeFile(c *gin.Context) {
 
 	c.Header("Content-Type", info.ContentType)
 	c.Header("X-Content-Type-Options", "nosniff")
-	c.Header("Content-Disposition", "inline")
+	// Attachments are arbitrary user files with an unvalidated content-type, so
+	// force a download instead of rendering them inline: an uploaded .html or
+	// SVG would otherwise execute on the API origin when opened. The uploads/
+	// prefix (avatars, covers, logos) is validated as images and stays inline.
+	disposition := "inline"
+	if strings.HasPrefix(path, "attachments/") {
+		disposition = "attachment"
+	}
+	c.Header("Content-Disposition", disposition)
 	c.DataFromReader(http.StatusOK, info.Size, info.ContentType, obj, nil)
 }


### PR DESCRIPTION
## Summary

Attachment uploads don't validate content-type, and `ServeFile` streamed every object back with `Content-Disposition: inline`. A member could upload an HTML file (or an SVG with script) and have it execute on the API origin when another member opened the attachment URL.

## Linked issues

Closes #328

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] API (`apps/api/`)

## What changed

`ServeFile` now forces `Content-Disposition: attachment` for the `attachments/` prefix, so the browser downloads the file rather than rendering it. The `uploads/` prefix (avatars, covers, logos) is validated as images and stays `inline`.

## Test plan

- [x] `go build`, `go vet`, `go test ./...` green
- [x] Reasoning: with `Content-Disposition: attachment` the browser won't render the response in-page regardless of its declared type, which neutralizes the stored-XSS vector

## Note

This is the low-risk mitigation. Validating/allow-listing content-type on upload (like the image path does) would be a good follow-up, but forcing download closes the XSS on its own.

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer