### PR TITLE
fix(ui): add focus management to the shared Modal

### DIFF
--- a/apps/web/src/components/ui/Modal.tsx
+++ b/apps/web/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useId, useRef, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '../../lib/utils';
 
@@ -11,17 +11,58 @@ export interface ModalProps {
   className?: string;
 }
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export function Modal({ open, onClose, title, children, footer, className }: ModalProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (!open) return;
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    // Remember what had focus so we can restore it when the dialog closes.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      // Trap focus inside the dialog so Tab can't reach the page behind it.
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => el.offsetParent !== null,
+      );
+      if (focusable.length === 0) {
+        e.preventDefault();
+        root.focus();
+        return;
+      }
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      const active = document.activeElement;
+      if (e.shiftKey && (active === first || !root.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
-    document.addEventListener('keydown', handleEscape);
+
+    document.addEventListener('keydown', handleKeyDown);
     document.body.style.overflow = 'hidden';
+
+    // Move focus into the dialog (first field, or the dialog itself).
+    const root = dialogRef.current;
+    (root?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? root)?.focus();
+
     return () => {
-      document.removeEventListener('keydown', handleEscape);
+      document.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = '';
+      previouslyFocused?.focus?.();
     };
   }, [open, onClose]);
 
@@ -32,18 +73,20 @@ export function Modal({ open, onClose, title, children, footer, className }: Mod
       className="fixed inset-0 z-10050 flex items-center justify-center p-4"
       role="dialog"
       aria-modal="true"
-      aria-labelledby="modal-title"
+      aria-labelledby={titleId}
     >
       <div className="absolute inset-0 bg-(--bg-backdrop)" onClick={onClose} aria-hidden />
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className={cn(
-          'relative z-10 w-full max-w-md rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay)',
+          'relative z-10 w-full max-w-md rounded-(--radius-lg) border border-(--border-subtle) bg-(--bg-surface-1) shadow-(--shadow-overlay) outline-none',
           className,
         )}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="border-b border-(--border-subtle) px-5 py-4">
-          <h2 id="modal-title" className="text-lg font-semibold text-(--txt-primary)">
+          <h2 id={titleId} className="text-lg font-semibold text-(--txt-primary)">
             {title}
           </h2>
         </div>


### PR DESCRIPTION
## Summary

The shared `Modal` had `role="dialog"`, `aria-modal` and Escape handling, but it never moved focus into the dialog, didn't trap Tab (keyboard focus could land on the page behind it), and didn't return focus to the trigger on close. Most modals reuse this primitive, so the gap repeated everywhere.

## Linked issues

Closes #347

## Type of change

- [x] Bug fix (`fix:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

- Move focus to the first focusable field (or the dialog) when it opens.
- Trap `Tab`/`Shift+Tab` within the dialog.
- Restore focus to the previously focused element on close.
- Give the title a unique `useId()` for `aria-labelledby` instead of a shared static `modal-title` id (which would collide if two modals ever mounted).

## Scope note

Issue #347 also lists the bespoke page-editor dropdowns and the inline confirm dialog in `IssueDetailPage`. This PR fixes the shared `Modal`, which is the widest-reaching piece; the dropdowns/inline dialog are worth a follow-up (they don't share this primitive).

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Manual: open a modal, focus starts inside it, Tab cycles within it, Escape closes it, and focus returns to the element that opened it

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer