### PR TITLE
perf(ui): look up cycle/module names via maps on the issue list

### DIFF
--- a/apps/web/src/pages/IssueListPage.tsx
+++ b/apps/web/src/pages/IssueListPage.tsx
@@ -590,14 +590,20 @@ export function IssueListPage() {
   const dp = listDisplay.displayProperties;
   const hasCol = (id: SavedViewDisplayPropertyId) => dp.has(id);
 
+  // Build id -> name maps once per render instead of doing an O(cycles) /
+  // O(modules) find for every row. (Plain consts, not useMemo, because this
+  // sits after the component's early returns.)
+  const cycleNameById = new Map(cycles.map((c) => [c.id, c.name]));
+  const moduleNameById = new Map(modules.map((m) => [m.id, m.name]));
+
   const cycleName = (issue: IssueApiResponse) => {
     const id = issue.cycle_ids?.[0];
-    return id ? (cycles.find((c) => c.id === id)?.name ?? '—') : '—';
+    return id ? (cycleNameById.get(id) ?? '—') : '—';
   };
 
   const moduleName = (issue: IssueApiResponse) => {
     const id = issue.module_ids?.[0];
-    return id ? (modules.find((m) => m.id === id)?.name ?? '—') : '—';
+    return id ? (moduleNameById.get(id) ?? '—') : '—';
   };
 
   const layout = parseIssueLayout(searchParams.get('layout'));


### PR DESCRIPTION
## Summary

`cycleName`/`moduleName` on the work-item list did a linear `cycles.find` / `modules.find` for every row, and they're called a few times per row, so a large list was O(rows x cycles) per render.

## Linked issues

Refs #345 (a focused slice)

## Type of change

- [x] Performance (`perf:`)

## Surface

- [x] UI (`apps/web/`)

## What changed

Build `id -> name` maps once per render and look up in O(1), the same pattern the file already uses for `stateById`/`labelById`. Plain `const` rather than `useMemo` because this sits after the component's early returns.

## Scope note

Issue #345 is broader (memoizing the Row/Card components and lifting drag/resize state out of the row subtree so the whole list doesn't re-render on hover/resize). That's a larger, riskier change I've left for a separate PR; this one is the safe, self-contained slice.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass

## AI assistance

- [x] AI tools were used, tool(s): `Claude Code (Opus 4.8)`, commits carry a `Co-Authored-By:` trailer