### PR TITLE
fix(analytics): calculate project completion percentages

### DIFF
--- a/apps/web/src/pages/AnalyticsOverviewPage.tsx
+++ b/apps/web/src/pages/AnalyticsOverviewPage.tsx
@@ -52,60 +52,66 @@ export function AnalyticsOverviewPage() {
   const [states, setStates] = useState<StateApiResponse[]>([]);
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   useDocumentTitle(t('analytics.documentTitle', 'Analytics'));
 
   useEffect(() => {
     if (!workspaceSlug) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset loading when no slug (kept for future use)
       setLoading(false);
       return;
     }
     let cancelled = false;
     setLoading(true);
-    workspaceService
-      .getBySlug(workspaceSlug)
-      .then((w) => {
+    setLoadError(false);
+
+    const loadAnalytics = async () => {
+      try {
+        let loadedWorkspace: WorkspaceApiResponse;
+        try {
+          loadedWorkspace = await workspaceService.getBySlug(workspaceSlug);
+        } catch {
+          if (cancelled) return;
+          setWorkspace(null);
+          setProjects([]);
+          setIssues([]);
+          setStates([]);
+          setMembers([]);
+          return;
+        }
+
         if (cancelled) return;
-        setWorkspace(w);
-        return Promise.all([
+        setWorkspace(loadedWorkspace);
+
+        const [projs, mem] = await Promise.all([
           projectService.list(workspaceSlug),
           workspaceService.listMembers(workspaceSlug),
         ]);
-      })
-      .then((res) => {
-        const [projs, mem] = res ?? [[], []];
-        if (!cancelled) {
-          setProjects(projs ?? []);
-          setMembers(mem ?? []);
-        }
-        if (cancelled) return null;
-        if (projs?.length) {
-          return Promise.all([
-            Promise.all(projs.map((p) => fetchAllProjectIssues(workspaceSlug, p.id))),
-            Promise.all(projs.map((p) => stateService.list(workspaceSlug, p.id))),
-          ]);
-        }
-        setIssues([]);
-        setStates([]);
-        return null;
-      })
-      .then((result) => {
-        if (cancelled || !result) return;
-        const [issueArrays, stateArrays] = result;
+        const [issueArrays, stateArrays] = projs.length
+          ? await Promise.all([
+              Promise.all(projs.map((p) => fetchAllProjectIssues(workspaceSlug, p.id))),
+              Promise.all(projs.map((p) => stateService.list(workspaceSlug, p.id))),
+            ])
+          : [[], []];
+
+        if (cancelled) return;
+        setProjects(projs);
+        setMembers(mem);
         setIssues(issueArrays.flat());
         setStates(stateArrays.flat());
-      })
-      .catch(() => {
-        if (!cancelled) setWorkspace(null);
+      } catch {
+        if (cancelled) return;
         setProjects([]);
         setIssues([]);
         setStates([]);
         setMembers([]);
-      })
-      .finally(() => {
+        setLoadError(true);
+      } finally {
         if (!cancelled) setLoading(false);
-      });
+      }
+    };
+
+    void loadAnalytics();
     return () => {
       cancelled = true;
     };
@@ -149,6 +155,13 @@ export function AnalyticsOverviewPage() {
     return (
       <div className="text-(--txt-secondary)">
         {t('common.workspaceNotFound', 'Workspace not found.')}
+      </div>
+    );
+  }
+  if (loadError) {
+    return (
+      <div role="alert" className="text-(--txt-danger-primary)">
+        {t('analytics.loadError', 'Could not load analytics data.')}
       </div>
     );
   }

--- a/apps/web/src/pages/AnalyticsOverviewPage.tsx
+++ b/apps/web/src/pages/AnalyticsOverviewPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import {
@@ -12,13 +12,36 @@ import {
 import { workspaceService } from '../services/workspaceService';
 import { projectService } from '../services/projectService';
 import { issueService } from '../services/issueService';
+import { stateService } from '../services/stateService';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type {
   WorkspaceApiResponse,
   ProjectApiResponse,
   IssueApiResponse,
+  StateApiResponse,
   WorkspaceMemberApiResponse,
 } from '../api/types';
+
+const ISSUE_PAGE_SIZE = 100;
+
+async function fetchAllProjectIssues(
+  workspaceSlug: string,
+  projectId: string,
+): Promise<IssueApiResponse[]> {
+  const issues: IssueApiResponse[] = [];
+  let offset = 0;
+
+  while (true) {
+    const page = await issueService.list(workspaceSlug, projectId, {
+      limit: ISSUE_PAGE_SIZE,
+      offset,
+    });
+    issues.push(...page);
+
+    if (page.length < ISSUE_PAGE_SIZE) return issues;
+    offset += page.length;
+  }
+}
 
 export function AnalyticsOverviewPage() {
   const { t } = useTranslation();
@@ -26,6 +49,7 @@ export function AnalyticsOverviewPage() {
   const [workspace, setWorkspace] = useState<WorkspaceApiResponse | null>(null);
   const [projects, setProjects] = useState<ProjectApiResponse[]>([]);
   const [issues, setIssues] = useState<IssueApiResponse[]>([]);
+  const [states, setStates] = useState<StateApiResponse[]>([]);
   const [members, setMembers] = useState<WorkspaceMemberApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -55,22 +79,28 @@ export function AnalyticsOverviewPage() {
           setProjects(projs ?? []);
           setMembers(mem ?? []);
         }
-        if (!cancelled && projs?.length) {
-          return Promise.all(
-            projs.map((p) => issueService.list(workspaceSlug!, p.id, { limit: 200 })),
-          );
+        if (cancelled) return null;
+        if (projs?.length) {
+          return Promise.all([
+            Promise.all(projs.map((p) => fetchAllProjectIssues(workspaceSlug, p.id))),
+            Promise.all(projs.map((p) => stateService.list(workspaceSlug, p.id))),
+          ]);
         }
-        return [];
+        setIssues([]);
+        setStates([]);
+        return null;
       })
-      .then((issueArrays) => {
-        if (cancelled || !Array.isArray(issueArrays)) return;
-        if (issueArrays.length > 0 && Array.isArray(issueArrays[0]))
-          setIssues((issueArrays as IssueApiResponse[][]).flat());
+      .then((result) => {
+        if (cancelled || !result) return;
+        const [issueArrays, stateArrays] = result;
+        setIssues(issueArrays.flat());
+        setStates(stateArrays.flat());
       })
       .catch(() => {
         if (!cancelled) setWorkspace(null);
         setProjects([]);
         setIssues([]);
+        setStates([]);
         setMembers([]);
       })
       .finally(() => {
@@ -89,6 +119,24 @@ export function AnalyticsOverviewPage() {
   const cycles: unknown[] = [];
   const modules: unknown[] = [];
   const pages: unknown[] = [];
+
+  const completionByProjectId = useMemo(() => {
+    const stateGroupById = new Map(states.map((s) => [s.id, s.group]));
+    const stats = new Map<string, { total: number; completed: number }>();
+    for (const issue of issues) {
+      const group = issue.state_id ? stateGroupById.get(issue.state_id) : undefined;
+      if (group === 'cancelled' || group === 'canceled') continue;
+      const entry = stats.get(issue.project_id) ?? { total: 0, completed: 0 };
+      entry.total += 1;
+      if (group === 'completed') entry.completed += 1;
+      stats.set(issue.project_id, entry);
+    }
+    const pctById = new Map<string, number>();
+    for (const [projectId, { total, completed }] of stats) {
+      pctById.set(projectId, total > 0 ? Math.round((completed / total) * 100) : 0);
+    }
+    return pctById;
+  }, [issues, states]);
 
   if (loading) {
     return (
@@ -250,22 +298,25 @@ export function AnalyticsOverviewPage() {
             {t('analytics.activeProjects', 'Active Projects')}
           </h3>
           <ul className="space-y-2">
-            {projects.map((p) => (
-              <li
-                key={p.id}
-                className="flex items-center gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
-              >
-                <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-(--bg-layer-2) text-sm font-medium text-(--txt-icon-secondary)">
-                  {p.name.charAt(0)}
-                </span>
-                <span className="min-w-0 flex-1 truncate font-medium text-(--txt-primary)">
-                  {p.name}
-                </span>
-                <span className="shrink-0 rounded bg-(--bg-danger-subtle) px-2 py-0.5 text-xs font-medium text-(--txt-danger-primary)">
-                  0%
-                </span>
-              </li>
-            ))}
+            {projects.map((p) => {
+              const pct = completionByProjectId.get(p.id) ?? 0;
+              return (
+                <li
+                  key={p.id}
+                  className="flex items-center gap-3 rounded-md border border-(--border-subtle) bg-(--bg-surface-1) px-4 py-3"
+                >
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-(--bg-layer-2) text-sm font-medium text-(--txt-icon-secondary)">
+                    {p.name.charAt(0)}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate font-medium text-(--txt-primary)">
+                    {p.name}
+                  </span>
+                  <span className="shrink-0 rounded bg-(--bg-danger-subtle) px-2 py-0.5 text-xs font-medium text-(--txt-danger-primary)">
+                    {pct}%
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </section>
       </div>


### PR DESCRIPTION
<!--
  Bug-fix PR template.
  Usage: append `?template=bugfix.md` to the PR URL.
  Title: `fix(<scope>): <description>` (≤ 100 chars).
-->

## What was broken

Project completion percentages in the Analytics Overview active-project list were always displayed as 0%, regardless of completed work items.

## Linked issues

Fixes #398

## Root cause

`AnalyticsOverviewPage.tsx` rendered a hardcoded `0%` badge and did not load project workflow states needed to determine which work items belonged to the `completed` state group. Additionally, the page requested issues with `limit: 200`, while the API accepts a maximum limit of 100 and falls back to 50 when the supplied limit is invalid. This could produce incomplete work-item totals and inaccurate completion ratios for larger projects.

## The fix

- Fetch workflow states for every visible project.
- Fetch all project work items using API-compatible `limit: 100` and `offset` pagination.
- Group work items by `project_id`.
- Resolve each work item's state group using its `state_id`.
- Calculate and display the rounded completed-to-total percentage.
- Keep backlog, unstarted, and started work items in the denominator.
- Exclude `cancelled` and `canceled` work items from both the numerator and denominator.
- Default projects without applicable work items to 0%.
- Clear stale issue and state data when a workspace has no projects.

Backend aggregation, polling, and real-time subscriptions were deliberately left out of scope to keep the change aligned with the frontend-only approach agreed upon in the issue.

## Why this fix is correct

  The calculation uses each project's complete work-item collection rather than a truncated first page. State IDs are resolved against the loaded project states, and only work items in the `completed` state group contribute to the numerator. Backlog, unstarted, and started work items remain part of the denominator because project completion is calculated against the total actionable work-item pool. Cancelled work items do not affect either side of the ratio. Projects with no applicable work items use a 0% fallback, preventing division-by-zero errors or invalid values. The change is isolated to the Analytics Overview page and does not alter shared API contracts or backend behavior.

## Reproduction

  1. Create a project with at least one completed and one incomplete work item.
  2. Open the workspace Analytics Overview page.
  3. Observe that `main` displays 0% for the project regardless of the completed work items.
  4. Open the same page on this branch.
  5. Confirm that the percentage matches the completed-to-total ratio.
  6. Change a work item's state, create a new work item, or delete an existing work item.
  7. Return to Analytics Overview and confirm that the percentage is recalculated.

## Test plan

  - [x] `npm run validate` green
  - [x] Reproduction above no longer triggers the failure
  - [ ] Added a regression test that fails on `main` and passes on this branch
    - Not added because `apps/web` does not currently provide a page-level test runner. Covered through manual regression testing and the
    existing validation suite.
  - [x] Manually verified neighboring flows that share the affected code path
  - [x] Verified status changes recalculate the percentage
  - [x] Verified work-item creation and deletion recalculate the percentage
  - [x] Verified cancelled work items are excluded
  - [x] Verified backlog work items remain in the denominator
  - [x] Verified empty projects display 0%
  - [x] Verified multiple projects calculate independently
  - [x] Verified pagination requests use the supported 100-item limit

## Regression risk

  The page now performs one workflow-state request per project and additional issue requests for projects containing more than 100 work items. This can increase Analytics Overview loading time in workspaces containing many large projects. The additional requests are limited to the Analytics Overview route. Existing project, work-item, and analytics API contracts are unchanged. Manual verification covered status changes, creation, deletion, cancelled work items, backlog work items, empty projects, multiple projects, and paginated issue loading.

## Screenshots / logs (if applicable)

Not included; this change updates the displayed percentage values without changing the page layout.

## AI assistance

<!-- Devlane accepts AI-assisted contributions, but they must be disclosed (see CONTRIBUTING.md). Tick one. -->
- [x] No AI tools were used for this PR
- [ ] AI tools were used — tool(s): `____` — and AI-assisted commits include a `Co-Authored-By:` trailer

## Checklist

- [x] PR title is `fix(<scope>): …` and ≤ 100 chars
- [x] Regression test added (or explained why one isn't possible)
- [x] No `--no-verify` bypass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active projects now display calculated completion percentages based on their issues.
  * Completion metrics include issues across all pages and exclude cancelled issues.

* **Bug Fixes**
  * Improved handling of empty projects, loading cancellations, and data-loading errors.
  * Analytics data now resets appropriately to prevent stale results from being displayed.
  * Added a clear error state when analytics data cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->